### PR TITLE
116: remove unused deps and update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +687,12 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "binascii"
@@ -719,13 +735,36 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
  "hex_lit",
  "secp256k1 0.27.0",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-io"
@@ -738,6 +777,15 @@ name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -770,17 +818,14 @@ name = "bitcredit"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.32.3",
  "borsh",
+ "borsh-derive",
  "chrono",
  "clap",
- "dotenv",
  "env_logger",
- "envy",
  "futures",
- "futures-timer",
  "hex",
  "libp2p",
  "log",
@@ -789,17 +834,15 @@ dependencies = [
  "moksha-wallet",
  "open",
  "openssl",
- "reqwest 0.11.27",
+ "reqwest 0.12.8",
  "rocket",
  "rocket_dyn_templates",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "url",
- "utoipa",
- "void",
 ]
 
 [[package]]
@@ -850,47 +893,25 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
- "borsh-derive",
- "hashbrown 0.13.2",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
-dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
+ "syn_derive",
 ]
 
 [[package]]
@@ -948,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1009,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1044,7 +1071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d528ade112e169cbb79ceae2f235b4502fee6e939326bbaa36aafcdfd54cd91c"
 dependencies = [
  "anyhow",
- "bitcoin",
+ "bitcoin 0.30.2",
  "futures-core",
  "hex",
  "log",
@@ -1432,12 +1459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,25 +1557,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
-name = "envy"
-version = "0.4.2"
+name = "env_logger"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
- "serde",
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1767,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1782,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1792,15 +1814,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1821,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1855,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1877,15 +1899,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -1895,9 +1917,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2078,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
 dependencies = [
  "log",
  "pest",
@@ -2393,15 +2415,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2498,7 +2523,7 @@ dependencies = [
  "log",
  "rtnetlink",
  "smol",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "windows 0.51.1",
 ]
@@ -3184,7 +3209,7 @@ version = "0.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "hex-conservative 0.1.2",
 ]
 
@@ -3194,8 +3219,8 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106fdb897e69df697480f45bf0a564b425af488fb0f7407e770a770c39b19a21"
 dependencies = [
- "bech32",
- "bitcoin",
+ "bech32 0.9.1",
+ "bitcoin 0.30.2",
  "lightning",
  "num-traits",
  "secp256k1 0.27.0",
@@ -3410,7 +3435,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
@@ -3443,7 +3468,7 @@ dependencies = [
  "lightning-invoice",
  "moksha-core",
  "rand",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "rexie",
  "secp256k1 0.29.1",
  "serde",
@@ -3810,9 +3835,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "4.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a083c0c7e5e4a8ec4176346cf61f67ac674e8bfb059d9226e1c54a96b377c12"
+checksum = "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3821,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3853,9 +3878,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -4312,21 +4337,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml 0.5.11",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4767,23 +4792,19 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4794,24 +4815,28 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.3",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4823,7 +4848,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-socks",
  "tower-service",
@@ -4966,9 +4993,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_dyn_templates"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bfc006e547e4f72b760ab861f5943b688aed8a82c4977b5500c98f5d17dbfa"
+checksum = "5bbab919c9e67df3f7ac6624a32ef897df4cd61c0969f4d66f3ced0534660d7a"
 dependencies = [
  "handlebars",
  "normpath",
@@ -5304,7 +5331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
- "rand",
  "secp256k1-sys 0.8.1",
  "serde",
 ]
@@ -5315,6 +5341,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
+ "bitcoin_hashes 0.14.0",
  "rand",
  "secp256k1-sys 0.10.1",
  "serde",
@@ -5400,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
 dependencies = [
  "itoa",
  "memchr",
@@ -5902,6 +5929,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,7 +5975,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5944,6 +5994,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5960,15 +6020,6 @@ dependencies = [
  "once_cell",
  "rustix 0.38.37",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-openssl = "0.10.40"
-borsh = "0.10.2"
-env_logger = "0.10.0"
-chrono = "0.4.23"
-async-trait = "0.1.64"
+openssl = "0.10.68"
+borsh = "1.5.1"
+borsh-derive = "1.0.0"
+env_logger = "0.11.5"
+chrono = "0.4.38"
 libp2p = { version = "0.51.3", features = [
   "tcp",
   "dns",
@@ -25,29 +25,24 @@ libp2p = { version = "0.51.3", features = [
   "relay",
   "dcutr",
 ] }
-tokio = { version = "1.26.0", features = ["full"] }
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
-rocket_dyn_templates = { version = "0.1.0-rc.2", features = ["handlebars"] }
-open = "4.0.0"
-serde_json = "1.0.94"
-serde = "1.0.154"
-serde_derive = "1.0.154"
+tokio = { version = "1.40.0", features = ["rt", "rt-multi-thread", "macros", "io-util", "time", "io-std"] }
+tokio-stream = { version = "0.1.16", features = ["io-util"] }
+async-trait = "0.1.83"
+rocket = { version = "0.5.1", features = ["json"] }
+rocket_dyn_templates = { version = "0.2.0", features = ["handlebars"] }
+open = "5.3.0"
+serde_json = "1.0.129"
+serde = { version = "1.0.210", features = ["derive"] }
 hex = "0.4.3"
-log = "0.4.17"
-futures = "0.3.28"
-futures-timer = "3.0.0"
-async-std = "1.12.0"
-void = "1.0.2"
-bitcoin = { version = "0.30.0", features = ["rand", "rand-std"] }
-reqwest = { version = "0.11.17", features = ["json", "serde_json"] }
+log = "0.4.22"
+futures = "0.3.31"
+bitcoin = { version = "0.32.3", features = ["rand", "rand-std"] }
+reqwest = { version = "0.12.8", features = ["json"] }
+anyhow = "1.0.89"
+clap = { version = "4.5.20", features = ["derive", "env"] }
+url = "2.5.2"
+thiserror = "1.0.64"
 moksha-core = { git = "https://github.com/mtbitcr/moksha" }
 moksha-mint = { git = "https://github.com/mtbitcr/moksha" }
 moksha-wallet = { git = "https://github.com/mtbitcr/moksha" }
-anyhow = "1.0.79"
-utoipa = "4.2.0"
-clap = { version = "4.4.18", features = ["derive", "env"] }
-url = "2.5.0"
-envy = "0.4.2"
-dotenv = "0.15.0"
-thiserror = "1.0.64"
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct ChainStats {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,17 @@
-extern crate core;
-#[macro_use]
-extern crate rocket;
-
 use std::collections::HashMap;
 use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
-use std::{env, fs, mem, path, thread};
+use std::{env, fs, mem, thread};
 
 use bitcoin::PublicKey;
-use borsh::{self, BorshDeserialize, BorshSerialize};
+use borsh::{to_vec, BorshDeserialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use chrono::Utc;
 use clap::Parser;
 use config::Config;
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
+use log::info;
 use moksha_core::primitives::CheckBitcreditQuoteResponse;
 use moksha_wallet::localstore::sqlite::SqliteLocalStore;
 use openssl::pkey::{Private, Public};
@@ -23,7 +21,7 @@ use openssl::sha::sha256;
 use rocket::fs::FileServer;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::yansi::Paint;
-use rocket::{Build, Rocket};
+use rocket::{catchers, routes, Build, FromForm, Rocket};
 
 use crate::blockchain::{
     start_blockchain_for_new_bill, Block, Chain, ChainToReturn, OperationCode,
@@ -198,7 +196,7 @@ pub fn create_quotes_map() {
 }
 
 pub fn write_quotes_map(map: HashMap<String, BitcreditEbillQuote>) {
-    let quotes_byte = map.try_to_vec().unwrap();
+    let quotes_byte = to_vec(&map).unwrap();
     fs::write(QUOTE_MAP_FILE_PATH, quotes_byte).expect("Unable to write quote in file.");
 }
 
@@ -344,7 +342,7 @@ fn create_contacts_map() {
 }
 
 fn write_contacts_map(map: HashMap<String, IdentityPublicData>) {
-    let contacts_byte = map.try_to_vec().unwrap();
+    let contacts_byte = to_vec(&map).unwrap();
     fs::write(CONTACT_MAP_FILE_PATH, contacts_byte).expect("Unable to write peer id in file.");
 }
 
@@ -875,7 +873,7 @@ fn read_peer_id_from_file() -> PeerId {
 }
 
 fn identity_to_byte_array(identity: &Identity) -> Vec<u8> {
-    identity.try_to_vec().unwrap()
+    to_vec(identity).unwrap()
 }
 
 fn identity_from_byte_array(identity: &[u8]) -> Identity {
@@ -1875,7 +1873,7 @@ fn read_bill_from_file(bill_name: &String) -> BitcreditBill {
 }
 
 fn bill_to_byte_array(bill: &BitcreditBill) -> Vec<u8> {
-    bill.try_to_vec().unwrap()
+    to_vec(bill).unwrap()
 }
 
 fn bill_from_byte_array(bill: &[u8]) -> BitcreditBill {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,28 +1,23 @@
 #[cfg(test)]
 mod test {
-    use std::io::Read;
     use std::path::{Path, PathBuf};
-    use std::{fs, mem, thread};
+    use std::{fs, mem};
 
     use bitcoin::secp256k1::Scalar;
-    use futures::executor::block_on;
     use libp2p::identity::Keypair;
     use libp2p::PeerId;
-    use moksha_core::amount::Amount;
     use moksha_core::primitives::{CurrencyUnit, PaymentMethod};
     use moksha_wallet::http::CrossPlatformHttpClient;
     use moksha_wallet::localstore::sqlite::SqliteLocalStore;
-    use moksha_wallet::wallet::{Wallet, WalletBuilder};
+    use moksha_wallet::wallet::Wallet;
     use openssl::rsa::{Padding, Rsa};
-    use serde_derive::Deserialize;
-    use tokio::runtime::Builder;
+    use serde::Deserialize;
     use url::Url;
 
     use crate::numbers_to_words::encode;
     use crate::{
         byte_array_to_size_array_keypair, byte_array_to_size_array_peer_id, create_new_identity,
-        generation_rsa_key, read_bill_with_chain_from_file, read_identity_from_file,
-        structure_as_u8_slice, Identity,
+        generation_rsa_key, read_identity_from_file, structure_as_u8_slice, Identity,
     };
 
     //TODO: Change. Because we create new bill every time we run tests
@@ -246,7 +241,11 @@ mod test {
             .expect("Could not create wallet");
 
         let wallet_keysets = wallet
-            .add_mint_keysets_by_id(&Url::parse("http://127.0.0.1:3338").unwrap(), "cr-sat".to_string(), "5ee3478d7e11534d332dffe67dfad8c6def74d2130d8af3e9035cd180d0f70f6".to_string())
+            .add_mint_keysets_by_id(
+                &Url::parse("http://127.0.0.1:3338").unwrap(),
+                "cr-sat".to_string(),
+                "5ee3478d7e11534d332dffe67dfad8c6def74d2130d8af3e9035cd180d0f70f6".to_string(),
+            )
             .await
             .unwrap();
         let wallet_keyset = wallet_keysets.first().unwrap();
@@ -264,7 +263,10 @@ mod test {
             )
             .await;
 
-        let token = result.unwrap().serialize(Option::from(CurrencyUnit::CrSat)).unwrap();
+        let token = result
+            .unwrap()
+            .serialize(Option::from(CurrencyUnit::CrSat))
+            .unwrap();
         println!("Token: {token:?}");
 
         let balance2 = wallet.get_balance().await.unwrap();
@@ -420,12 +422,12 @@ mod test {
     fn test_schnorr() {
         let secp1 = bitcoin::secp256k1::Secp256k1::new();
         let key_pair1 =
-            bitcoin::secp256k1::KeyPair::new(&secp1, &mut bitcoin::secp256k1::rand::thread_rng());
+            bitcoin::secp256k1::Keypair::new(&secp1, &mut bitcoin::secp256k1::rand::thread_rng());
         let xonly1 = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&key_pair1);
 
         let secp2 = bitcoin::secp256k1::Secp256k1::new();
         let key_pair2 =
-            bitcoin::secp256k1::KeyPair::new(&secp2, &mut bitcoin::secp256k1::rand::thread_rng());
+            bitcoin::secp256k1::Keypair::new(&secp2, &mut bitcoin::secp256k1::rand::thread_rng());
         let xonly2 = bitcoin::secp256k1::XOnlyPublicKey::from_keypair(&key_pair2);
 
         let msg = bitcoin::secp256k1::Message::from_slice(&[0xab; 32]).unwrap();

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,32 +1,29 @@
-#![feature(proc_macro_hygiene, decl_macro)]
-
 use std::path::Path;
 use std::str::FromStr;
 use std::{fs, thread};
 
 use bitcoin::secp256k1::Scalar;
-use chrono::{Days, Utc};
 use libp2p::PeerId;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::form::Form;
 use rocket::http::{Header, Status};
 use rocket::serde::json::Json;
-use rocket::{Request, Response, State};
-use rocket_dyn_templates::{context, handlebars, Template};
+use rocket::{catch, delete, get, post, put, Request, Response, State};
+use rocket_dyn_templates::handlebars;
 
 use crate::blockchain::{Chain, ChainToReturn, GossipsubEvent, GossipsubEventId, OperationCode};
-use crate::constants::{BILLS_FOLDER_PATH, BILL_VALIDITY_PERIOD, IDENTITY_FILE_PATH, USEDNET};
+use crate::constants::{BILLS_FOLDER_PATH, IDENTITY_FILE_PATH, USEDNET};
 use crate::dht::network::Client;
 use crate::work_with_mint::{
     accept_mint_bitcredit, check_bitcredit_quote, client_accept_bitcredit_quote,
     request_to_mint_bitcredit,
 };
 use crate::{
-    accept_bill, add_in_contacts_map, api, blockchain, change_contact_data_from_dht,
+    accept_bill, add_in_contacts_map, api, change_contact_data_from_dht,
     change_contact_name_from_contacts_map, create_whole_identity, delete_from_contacts_map,
     endorse_bitcredit_bill, get_bills, get_bills_for_list, get_contact_from_map, get_contacts_vec,
     get_quote_from_map, get_whole_identity, issue_new_bill, issue_new_bill_drawer_is_drawee,
-    issue_new_bill_drawer_is_payee, mint_bitcredit_bill, read_bill_from_file, read_contacts_map,
+    issue_new_bill_drawer_is_payee, mint_bitcredit_bill, read_bill_from_file,
     read_identity_from_file, read_peer_id_from_file, request_acceptance, request_pay,
     sell_bitcredit_bill, write_identity_to_file, AcceptBitcreditBillForm,
     AcceptMintBitcreditBillForm, BitcreditBill, BitcreditBillForm, BitcreditBillToReturn,
@@ -916,7 +913,7 @@ pub fn customize(hbs: &mut Handlebars) {
 }
 
 fn wow_helper(
-    h: &handlebars::Helper<'_, '_>,
+    h: &handlebars::Helper<'_>,
     _: &Handlebars,
     _: &handlebars::Context,
     _: &mut handlebars::RenderContext<'_, '_>,

--- a/src/work_with_mint.rs
+++ b/src/work_with_mint.rs
@@ -1,4 +1,7 @@
-use moksha_core::primitives::{BillKeys, CurrencyUnit, PaymentMethod, PostMintQuoteBitcreditResponse, PostRequestToMintBitcreditResponse};
+use moksha_core::primitives::{
+    BillKeys, CurrencyUnit, PaymentMethod, PostMintQuoteBitcreditResponse,
+    PostRequestToMintBitcreditResponse,
+};
 use moksha_wallet::http::CrossPlatformHttpClient;
 use moksha_wallet::localstore::sqlite::SqliteLocalStore;
 use moksha_wallet::wallet::Wallet;
@@ -89,7 +92,10 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
         .expect("Could not create wallet");
 
     let clone_bill_id = bill_id.clone();
-    let wallet_keysets = wallet.add_mint_keysets_by_id(&mint_url, "cr-sat".to_string(), clone_bill_id).await.unwrap();
+    let wallet_keysets = wallet
+        .add_mint_keysets_by_id(&mint_url, "cr-sat".to_string(), clone_bill_id)
+        .await
+        .unwrap();
     let wallet_keyset = wallet_keysets.first().unwrap();
 
     let quote = get_quote_from_map(bill_id);
@@ -109,7 +115,10 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
             )
             .await;
 
-        token = result.unwrap().serialize(Option::from(CurrencyUnit::CrSat)).unwrap();
+        token = result
+            .unwrap()
+            .serialize(Option::from(CurrencyUnit::CrSat))
+            .unwrap();
 
         add_bitcredit_token_in_quotes_map(token.clone(), bill_id.clone());
     }


### PR DESCRIPTION
This fixes https://github.com/BitcreditProtocol/E-Bill/issues/116, except for libp2p, for which I created https://github.com/BitcreditProtocol/E-Bill/issues/167, because there are a lot of breaking changes, which are subtle to get right and it warrants it's own ticket.

Besides that, I was able to get rid of `async-std` and `futures-timer`, by implementing the respective things using `tokio`. I also removed some unused deps (`envy`, `dotenv`, `void` and `utoipa`), but left `thiserror` and `anyhow` in, despite being unused, since we're going to be using those anyway, when we implement proper error-handling (or, if not, we can remove them then).

Most of the code changes are due to `borsh` having breaking changes and I was able to remove the `Either/Void`-type of death with the help of https://github.com/libp2p/rust-libp2p/discussions/2812. :v: 