### PR TITLE
small improvements for the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN cargo build --release
 ##############################
 FROM ubuntu:22.04
 
+RUN apt-get update && \
+  apt-get install -y ca-certificates && \
+  apt-get clean
+
 # Import user and group files from builder.
 COPY --from=rust-builder /etc/passwd /etc/passwd
 COPY --from=rust-builder /etc/group /etc/group

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export P2P_ADDRESS=0.0.0.0
 
 ### Configuration
 
-You can use the following environment variables:
+You can use the following environment variables to configure the application:
 
 * `P2P_PORT` - the P2P port (default: 1908)
 * `P2P_ADDRESS` - the P2P address (default: 0.0.0.0)
@@ -86,12 +86,16 @@ You should be able to open the app at [http://127.0.0.1:8000/bitcredit/]([http:/
 Build and launch the app with docker-compose running on a different port than the default 8000:
 
 ```bash
-# run in foreground
+# run in foreground, can be stopped using CTRL+C
 docker-compose up
 
-# run in background
+# run in background, can be stopped using docker-compose stop
 docker-compose up -d
 
 # rebuild the image
 docker-compose build
 ```
+
+If you use the above commands, the application state (identity, bills, contacts) will persist between sessions. However, if you use `docker-compose down`, or `docker-compose rm`, the existing container gets removed, along with it's state.
+Of course, rebuilding the image also removes the application state.
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ export P2P_PORT=1909
 export P2P_ADDRESS=0.0.0.0
 ```
 
+### Configuration
+
+You can use the following environment variables:
+
+* `P2P_PORT` - the P2P port (default: 1908)
+* `P2P_ADDRESS` - the P2P address (default: 0.0.0.0)
+* `HTTP_PORT` - the HTTP address (default: 8000)
+* `HTTP_ADDRESS` - the HTTP address (default: 127.0.0.1, or 0.0.0.0 in Docker)
+* `RUST_LOG` - the log level, e.g.: info, trace, debug, error (default: error)
+
 ### Frontend
 
 Make sure to have a recent version of Node.js installed.
@@ -66,12 +76,14 @@ docker build -t <image-name> .
 Launch the image:
 
 ```bash
-docker run -p 8000:8000 <image-name>
+docker run -p 8000:8000 -p 1908:1908 <image-name>
 ```
+
+You should be able to open the app at [http://127.0.0.1:8000/bitcredit/]([http://127.0.0.1:8000/bitcredit/])
 
 #### Run with docker-compose
 
-Build and launch the app with docker-compose running on a different port that the default 8000:
+Build and launch the app with docker-compose running on a different port than the default 8000:
 
 ```bash
 # run in foreground

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - P2P_PORT=1909
       - HTTP_ADDRESS=0.0.0.0
       - HTTP_PORT=8001
+      - RUST_LOG=info
     ports:
       - "8001:8001"
       - "1909:1909"

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,8 @@ fn rocket_main(dht: Client, conf: &Config) -> Rocket<Build> {
         .mount("/quote", routes![web::return_quote, web::accept_quote])
         .attach(web::CORS);
 
+    info!("HTTP Server Listening on {}", conf.http_listen_url());
+
     match open::that(format!("{}/bitcredit/", conf.http_listen_url()).as_str()) {
         Ok(_) => {}
         Err(_) => {


### PR DESCRIPTION
This adds

* ca-certificates (so HTTPs requests inside docker don't fail)
* an `info` log to show when the web server is ready to serve requests
* info-logging for the docker-compose build
* some more documentation on how to use `docker` and `docker-compose` to run multiple instances locally

With this setup, I was able to run multiple instances locally, which were able to communicate with each other.

I documented additional improvements, which take a bit more time, for the docker build in this follow-up task: https://github.com/BitcreditProtocol/E-Bill/issues/180