### PR TITLE
85: fix logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Start the backend server in development mode:
 
 ```bash
 # Run with defaults
-cargo run
+RUST_LOG=info cargo run
 
 # configure listening ports and addresses
-cargo run -- --http-port 8001 --http-address 0.0.0.0
+RUST_LOG=info cargo run -- --http-port 8001 --http-address 0.0.0.0
 
 # Configuration can also be set via environment variables
 export P2P_PORT=1909
@@ -44,11 +44,23 @@ Start the app in development mode with frontend and backend hot reloading (requi
 
 ```bash
 # Terminal 1
-cargo watch -x run  # watch can be installed with cargo install cargo-watch
+RUST_LOG=info cargo watch -x run  # watch can be installed with cargo install cargo-watch
 
 # Terminal 2
 cd frontend
 npm run start
+```
+
+### Tests
+
+You can run the existing tests using the following commands:
+
+```bash
+// without logs
+cargo test
+
+// with logs - (env_logger needs to be activated in the test to show logs)
+RUST_LOG=info cargo test -- --nocapture
 ```
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker build -t <image-name> .
 Launch the image:
 
 ```bash
-docker run -p 8000:8000 -p 1908:1908 <image-name>
+docker run -p 8000:8000 -p 1908:1908 -e RUST_LOG=info <image-name>
 ```
 
 You should be able to open the app at [http://127.0.0.1:8000/bitcredit/]([http://127.0.0.1:8000/bitcredit/])

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The following options are available:
 ## Example
 
 ```bash
-cargo run -- --http-port 8001
+RUST_LOG=info cargo run -- --http-port 8001
 
 RUST_LOG=info HTTP_PORT=8001 cargo run
 ```

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,6 +3,8 @@ use std::net::Ipv4Addr;
 
 // General
 pub const BILLS_PREFIX: &str = "BILLS";
+pub const BILL_PREFIX: &str = "BILL_";
+pub const KEY_PREFIX: &str = "KEY_";
 
 // Paths
 pub const IDENTITY_FOLDER_PATH: &str = "identity";

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -20,6 +20,7 @@ use futures::prelude::*;
 use libp2p::kad::record::Record;
 use libp2p::request_response::ResponseChannel;
 use libp2p::PeerId;
+use log::error;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fs;
@@ -268,7 +269,7 @@ impl Client {
     pub async fn get_bill(&mut self, name: String) -> Vec<u8> {
         let providers = self.get_providers(name.clone()).await;
         if providers.is_empty() {
-            eprintln!("No providers was found.");
+            error!("No providers was found.");
             Vec::new()
         } else {
             //TODO: If it's me - don't continue.
@@ -286,7 +287,7 @@ impl Client {
             let file_content_await = file_content.await;
 
             if file_content_await.is_err() {
-                println!("None of the providers returned file.");
+                error!("None of the providers returned file.");
                 Vec::new()
             } else {
                 file_content_await
@@ -300,7 +301,7 @@ impl Client {
     pub async fn get_key(&mut self, name: String) -> Vec<u8> {
         let providers = self.get_providers(name.clone()).await;
         if providers.is_empty() {
-            eprintln!("No providers was found.");
+            error!("No providers was found.");
             Vec::new()
         } else {
             //TODO: If it's me - don't continue.
@@ -318,7 +319,7 @@ impl Client {
             let file_content_await = file_content.await;
 
             if file_content_await.is_err() {
-                println!("None of the providers returned file.");
+                error!("None of the providers returned file.");
                 Vec::new()
             } else {
                 file_content_await
@@ -486,7 +487,7 @@ impl Client {
                     match args.next() {
                         Some(name) => String::from(name),
                         None => {
-                            eprintln!("Expected name.");
+                            error!("Expected name.");
                             return;
                         }
                     }
@@ -499,7 +500,7 @@ impl Client {
                     match args.next() {
                         Some(name) => String::from(name),
                         None => {
-                            eprintln!("Expected name.");
+                            error!("Expected name.");
                             return;
                         }
                     }
@@ -512,7 +513,7 @@ impl Client {
                     match args.next() {
                         Some(name) => String::from(name),
                         None => {
-                            eprintln!("Expected name.");
+                            error!("Expected name.");
                             return;
                         }
                     }
@@ -525,7 +526,7 @@ impl Client {
                     match args.next() {
                         Some(key) => String::from(key),
                         None => {
-                            eprintln!("Expected key");
+                            error!("Expected key");
                             return;
                         }
                     }
@@ -534,7 +535,7 @@ impl Client {
                     match args.next() {
                         Some(value) => String::from(value),
                         None => {
-                            eprintln!("Expected value");
+                            error!("Expected value");
                             return;
                         }
                     }
@@ -548,7 +549,7 @@ impl Client {
                     match args.next() {
                         Some(key) => String::from(key),
                         None => {
-                            eprintln!("Expected topic");
+                            error!("Expected topic");
                             return;
                         }
                     }
@@ -557,7 +558,7 @@ impl Client {
                     match args.next() {
                         Some(value) => String::from(value),
                         None => {
-                            eprintln!("Expected msg");
+                            error!("Expected msg");
                             return;
                         }
                     }
@@ -571,7 +572,7 @@ impl Client {
                     match args.next() {
                         Some(key) => String::from(key),
                         None => {
-                            eprintln!("Expected topic");
+                            error!("Expected topic");
                             return;
                         }
                     }
@@ -585,7 +586,7 @@ impl Client {
                     match args.next() {
                         Some(key) => String::from(key),
                         None => {
-                            eprintln!("Expected key");
+                            error!("Expected key");
                             return;
                         }
                     }
@@ -598,7 +599,7 @@ impl Client {
                     match args.next() {
                         Some(key) => String::from(key),
                         None => {
-                            eprintln!("Expected key");
+                            error!("Expected key");
                             return;
                         }
                     }
@@ -607,7 +608,7 @@ impl Client {
             }
 
             _ => {
-                eprintln!(
+                error!(
                         "expected GET, PUT, SEND_MESSAGE, SUBSCRIBE, GET_RECORD, PUT_RECORD or GET_PROVIDERS."
                     );
             }

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -18,6 +18,7 @@ use libp2p::multihash::Multihash;
 use libp2p::request_response::{self, RequestId};
 use libp2p::swarm::{Swarm, SwarmEvent};
 use libp2p::{gossipsub, relay, PeerId};
+use log::{error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::iter;
@@ -85,11 +86,7 @@ impl EventLoop {
                     record, ..
                 }))) => {
                     if let Some(sender) = self.pending_get_records.remove(&id) {
-                        println!(
-                            "Got record {:?} {:?}",
-                            std::str::from_utf8(record.key.as_ref()).unwrap(),
-                            std::str::from_utf8(&record.value).unwrap(),
-                        );
+                        info!("Got record {:?} {:?}", record.key.as_ref(), &record.value,);
 
                         sender.send(record).expect("Receiver not to be dropped.");
 
@@ -108,7 +105,7 @@ impl EventLoop {
                     ..
                 })) => {
                     self.pending_get_records.remove(&id);
-                    println!("No records.");
+                    info!("No records.");
                 }
 
                 QueryResult::GetRecord(Err(GetRecordError::NotFound { key, .. })) => {
@@ -161,7 +158,7 @@ impl EventLoop {
                 })) => {
                     if let Some(sender) = self.pending_get_providers.remove(&id) {
                         for peer in &providers {
-                            println!("PEER {peer:?}");
+                            info!("Get Providers: PEER {peer:?}");
                         }
 
                         sender.send(providers).expect("Receiver not to be dropped.");
@@ -223,29 +220,29 @@ impl EventLoop {
             SwarmEvent::Behaviour(ComposedEvent::RequestResponse(
                 request_response::Event::ResponseSent { .. },
             )) => {
-                println!("{event:?}")
+                info!("ResponseSent event: {event:?}")
             }
 
             //--------------IDENTIFY EVENTS--------------
             SwarmEvent::Behaviour(ComposedEvent::Identify(event)) => {
-                println!("{:?}", event)
+                info!("Identify event: {:?}", event)
             }
 
             //--------------DCUTR EVENTS--------------
             SwarmEvent::Behaviour(ComposedEvent::Dcutr(event)) => {
-                println!("{:?}", event)
+                info!("Dcutr event: {:?}", event)
             }
 
             //--------------RELAY EVENTS--------------
             SwarmEvent::Behaviour(ComposedEvent::Relay(
                 relay::client::Event::ReservationReqAccepted { .. },
             )) => {
-                println!("{event:?}");
-                println!("Relay accepted our reservation request.");
+                info!("ReservationReqAccepted event: {event:?}");
+                info!("Relay accepted our reservation request.");
             }
 
             SwarmEvent::Behaviour(ComposedEvent::Relay(event)) => {
-                println!("{:?}", event)
+                info!("{:?}", event)
             }
 
             //--------------GOSSIPSUB EVENTS--------------
@@ -255,7 +252,7 @@ impl EventLoop {
                 message,
             })) => {
                 let bill_name = message.topic.clone().into_string();
-                println!("Got message with id: {id} from peer: {peer_id} in topic: {bill_name}",);
+                info!("Got message with id: {id} from peer: {peer_id} in topic: {bill_name}",);
                 let event = GossipsubEvent::from_byte_array(&message.data);
 
                 if event.id.eq(&GossipsubEventId::Block) {
@@ -282,21 +279,21 @@ impl EventLoop {
                         .publish(gossipsub::IdentTopic::new(bill_name.clone()), message)
                         .expect("Can not publish message.");
                 } else {
-                    println!("Unknown event id: {id} from peer: {peer_id} in topic: {bill_name}");
+                    warn!("Unknown event id: {id} from peer: {peer_id} in topic: {bill_name}");
                 }
             }
             //--------------OTHERS BEHAVIOURS EVENTS--------------
             SwarmEvent::Behaviour(event) => {
-                println!("{event:?}")
+                info!("Behaviour event: {event:?}")
             }
 
             //--------------COMMON EVENTS--------------
             SwarmEvent::NewListenAddr { address, .. } => {
-                println!("Listening on {:?}", address);
+                info!("Listening on {:?}", address);
             }
 
             SwarmEvent::IncomingConnection { .. } => {
-                println!("{event:?}")
+                info!("IncomingConnection event: {event:?}")
             }
 
             SwarmEvent::ConnectionEstablished {
@@ -310,11 +307,11 @@ impl EventLoop {
             }
 
             SwarmEvent::ConnectionClosed { .. } => {
-                println!("{event:?}")
+                info!("ConnectionClosed event: {event:?}")
             }
 
             SwarmEvent::OutgoingConnectionError { .. } => {
-                // println!("Outgoing connection error to {:?}: {:?}", peer_id, error);
+                error!("OutgoingConnectionError event {event:?}");
                 // if let Some(peer_id) = peer_id {
                 //     if let Some(sender) = self.pending_dial.remove(&peer_id) {
                 //         let _ = sender.send(Err(Box::new(error)));
@@ -323,7 +320,7 @@ impl EventLoop {
             }
 
             SwarmEvent::IncomingConnectionError { .. } => {
-                println!("{event:?}")
+                error!("IncomingConnectionError event: {event:?}")
             }
 
             _ => {}
@@ -333,7 +330,7 @@ impl EventLoop {
     async fn handle_command(&mut self, command: Command) {
         match command {
             Command::StartProviding { file_name, sender } => {
-                println!("Start providing {file_name:?}");
+                info!("Start providing {file_name:?}");
                 let query_id = self
                     .swarm
                     .behaviour_mut()
@@ -344,7 +341,7 @@ impl EventLoop {
             }
 
             Command::PutRecord { key, value } => {
-                println!("Put record {key:?}");
+                info!("Put record {key:?}");
                 let key_record = Key::new(&key);
                 let value_bytes = value.as_bytes().to_vec();
                 let record = Record {
@@ -368,7 +365,7 @@ impl EventLoop {
             }
 
             Command::SendMessage { msg, topic } => {
-                println!("Send message to topic {topic:?}");
+                info!("Send message to topic {topic:?}");
                 let swarm = self.swarm.behaviour_mut();
                 //TODO: check if topic not empty.
                 swarm
@@ -378,7 +375,7 @@ impl EventLoop {
             }
 
             Command::SubscribeToTopic { topic } => {
-                println!("Subscribe to topic {topic:?}");
+                info!("Subscribe to topic {topic:?}");
                 self.swarm
                     .behaviour_mut()
                     .gossipsub
@@ -387,14 +384,14 @@ impl EventLoop {
             }
 
             Command::GetRecord { key, sender } => {
-                println!("Get record {key:?}");
+                info!("Get record {key:?}");
                 let key_record = Key::new(&key);
                 let query_id = self.swarm.behaviour_mut().kademlia.get_record(key_record);
                 self.pending_get_records.insert(query_id, sender);
             }
 
             Command::GetProviders { file_name, sender } => {
-                println!("Get providers {file_name:?}");
+                info!("Get providers {file_name:?}");
                 let query_id = self
                     .swarm
                     .behaviour_mut()
@@ -408,7 +405,7 @@ impl EventLoop {
                 peer,
                 sender,
             } => {
-                println!("Request file {file_name:?}");
+                info!("Request file {file_name:?}");
 
                 let relay_peer_id: PeerId = RELAY_BOOTSTRAP_NODE_ONE_PEER_ID
                     .to_string()
@@ -430,7 +427,7 @@ impl EventLoop {
             }
 
             Command::RespondFile { file, channel } => {
-                println!("Respond file");
+                info!("Respond file");
                 self.swarm
                     .behaviour_mut()
                     .request_response

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -86,7 +86,11 @@ impl EventLoop {
                     record, ..
                 }))) => {
                     if let Some(sender) = self.pending_get_records.remove(&id) {
-                        info!("Got record {:?} {:?}", record.key.as_ref(), &record.value,);
+                        info!(
+                            "Got record {:?} {:?}",
+                            std::str::from_utf8(record.key.as_ref()).unwrap(),
+                            std::str::from_utf8(&record.value).unwrap(),
+                        );
 
                         sender.send(record).expect("Receiver not to be dropped.");
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod test {
     use bitcoin::secp256k1::Scalar;
     use libp2p::identity::Keypair;
     use libp2p::PeerId;
+    use log::info;
     use openssl::rsa::{Padding, Rsa};
     use std::path::Path;
     use std::{fs, mem};
@@ -187,6 +188,7 @@ mod test {
 
     #[test]
     fn test_bitcoin() {
+        let _ = env_logger::try_init();
         let s1 = bitcoin::secp256k1::Secp256k1::new();
         let private_key1 = bitcoin::PrivateKey::new(
             s1.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
@@ -214,14 +216,15 @@ mod test {
         let pub_key3 = bitcoin::PublicKey::new(public_key3);
         let address3 = bitcoin::Address::p2pkh(pub_key3, bitcoin::Network::Testnet);
 
-        println!("private key: {}", pr_key3);
-        println!("public key: {}", pub_key3);
-        println!("address: {}", address3);
-        println!("{}", address3.is_spend_standard());
+        info!("private key: {}", pr_key3);
+        info!("public key: {}", pub_key3);
+        info!("address: {}", address3);
+        info!("{}", address3.is_spend_standard());
     }
 
     // #[tokio::test]
     // async fn test_mint() {
+    //     let _ = env_logger::try_init();
     //     let dir = PathBuf::from("./data/wallet".to_string());
     //     fs::create_dir_all(dir.clone()).unwrap();
     //     let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
@@ -249,7 +252,7 @@ mod test {
     //     let wallet_keyset = wallet_keysets.first().unwrap();
 
     //     let balance = wallet.get_balance().await.unwrap();
-    //     println!("Balance: {balance:?} sats");
+    //     info!("Balance: {balance:?} sats");
 
     //     let result = wallet
     //         .mint_tokens(
@@ -265,16 +268,17 @@ mod test {
     //         .unwrap()
     //         .serialize(Option::from(CurrencyUnit::CrSat))
     //         .unwrap();
-    //     println!("Token: {token:?}");
+    //     info!("Token: {token:?}");
 
     //     let balance2 = wallet.get_balance().await.unwrap();
-    //     println!("Balance2: {balance2:?} sats");
+    //     info!("Balance2: {balance2:?} sats");
 
     //     assert_eq!(1, 2);
     // }
 
     //#[tokio::test]
     //async fn test_check_quote() {
+    //    let _ = env_logger::try_init();
     //    let dir = PathBuf::from("./data/wallet".to_string());
     //    fs::create_dir_all(dir.clone()).unwrap();
     //    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
@@ -304,13 +308,14 @@ mod test {
     //    //     .check_bitcredit_quote(&mint_url, "19d676f0425295dacb5724fb3f0488934f97aff8d044c7a2eb051275671f1a5de".to_string(), "112D3KooWRzpBaZnydS4eMA74yaKEoGZFP7WFRvC8yQR7HyGoWfAk".to_string())
     //    //     .await;
 
-    //    println!("Quote: {result:?}");
+    //    info!("Quote: {result:?}");
 
     //    assert_eq!(1, 2);
     //}
 
     // #[tokio::test]
     // async fn test_send() {
+    //     let _ = env_logger::try_init();
     //     let dir = PathBuf::from("./data/wallet".to_string());
     //     fs::create_dir_all(dir.clone()).unwrap();
     //     let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
@@ -330,8 +335,8 @@ mod test {
     //     let result = wallet.send_tokens(10).await.expect("Cannot send tokens");
     //     let payment_invoice: String = result.try_into().unwrap();
     //
-    //     println!("Result:\n{payment_invoice}");
-    //     println!(
+    //     info!("Result:\n{payment_invoice}");
+    //     info!(
     //         "\nNew balance: {:?} sats",
     //         wallet.get_balance().await.unwrap()
     //     );
@@ -362,7 +367,7 @@ mod test {
     //         .expect("Could not create wallet");
 
     //     let balance = wallet.get_balance().await.unwrap();
-    //     println!("Balance: {balance:?} sats");
+    //     info!("Balance: {balance:?} sats");
 
     //     assert_eq!(1, balance);
     //     assert_ne!(1, balance);
@@ -370,25 +375,26 @@ mod test {
 
     #[tokio::test]
     async fn test_api() {
+        let _ = env_logger::try_init();
         let request_url = format!(
             "https://blockstream.info/testnet/api/address/{address}",
             address = "mzYHxNxTTGrrxnwSc1RvqTusK4EM88o6yj"
         );
-        println!("{}", request_url);
+        info!("{}", request_url);
         let response1 = reqwest::get(&request_url)
             .await
             .expect("Failed to send request")
             .text()
             .await
             .expect("Failed to read response");
-        println!("{:?}", response1);
+        info!("{:?}", response1);
         let response: AddressInfo = reqwest::get(&request_url)
             .await
             .expect("Failed to send request")
             .json()
             .await
             .expect("Failed to read response");
-        println!("{:?}", response);
+        info!("{:?}", response);
     }
 
     #[test]

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -17,6 +17,7 @@ use crate::constants::{BILLS_FOLDER_PATH, IDENTITY_FILE_PATH};
 use crate::dht::Client;
 use crate::external;
 use crate::external::mint::{accept_mint_bitcredit, request_to_mint_bitcredit};
+use log::{info, warn};
 use rocket::form::Form;
 use rocket::http::Status;
 use rocket::serde::json::Json;
@@ -289,7 +290,7 @@ pub async fn issue_bill(state: &State<Client>, bill_form: Form<BitcreditBillForm
 
             for node in nodes {
                 if !node.is_empty() {
-                    println!("Add {} for node {}", &bill.name, &node);
+                    info!("issue bill: add {} for node {}", &bill.name, &node);
                     client.add_bill_to_dht_for_node(&bill.name, &node).await;
                 }
             }
@@ -633,7 +634,7 @@ pub async fn mint_bill(
                     )
                     .await;
             } else {
-                println!("Can't mint");
+                warn!("Can't mint");
             }
 
             Status::Ok

--- a/src/web/handlers/identity.rs
+++ b/src/web/handlers/identity.rs
@@ -32,7 +32,6 @@ pub async fn return_peer_id() -> Json<NodeId> {
 
 #[post("/create", data = "<identity_form>")]
 pub async fn create_identity(identity_form: Form<IdentityForm>, state: &State<Client>) -> Status {
-    println!("Create identity");
     let identity: IdentityForm = identity_form.into_inner();
     create_whole_identity(
         identity.name,
@@ -52,8 +51,6 @@ pub async fn create_identity(identity_form: Form<IdentityForm>, state: &State<Cl
 
 #[put("/change", data = "<identity_form>")]
 pub async fn change_identity(identity_form: Form<IdentityForm>, state: &State<Client>) -> Status {
-    println!("Change identity");
-
     let identity_form: IdentityForm = identity_form.into_inner();
     let mut identity_changes: Identity = Identity::new_empty();
     identity_changes.name = identity_form.name.trim().to_string();


### PR DESCRIPTION
Draft until #188 is merged

This fixes #85.

All instances of `println` were replaced with variants of log::info!/warn!/error! and I updated the docs, so the app is ran with `RUST_LOG` set to the desired log level.

I removed the logs from the web handlers, since their being called is logged anyway using rocket, if RUST_LOG is set to `info`.

I didn't add any additional logging for now, since dht is well instrumented and the web handlers are as well via rocket. Once we fully implement Result-based error handling, we'll add logs for error-cases anyway.

For critical parts, we can also add trace, or debug logs, as soon as we run into issues.