### PR TITLE
split up data between web and the rest

### DIFF
--- a/src/blockchain/bill/chain.rs
+++ b/src/blockchain/bill/chain.rs
@@ -7,7 +7,7 @@ use super::{BillOpCode, RecourseWaitingForPayment};
 use super::{OfferToSellWaitingForPayment, RecoursePaymentInfo};
 use crate::blockchain::{Block, Blockchain, Error};
 use crate::constants::{PAYMENT_DEADLINE_SECONDS, RECOURSE_DEADLINE_SECONDS};
-use crate::service::bill_service::BillKeys;
+use crate::data::bill::BillKeys;
 use crate::util::{self, BcrKeys};
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -251,7 +251,7 @@ mod tests {
     use super::*;
     use crate::{
         blockchain::bill::{block::BillOfferToSellBlockData, tests::get_baseline_identity},
-        service::{bill_service::BitcreditBill, contact_service::IdentityPublicData},
+        data::{bill::BitcreditBill, contact::IdentityPublicData},
         tests::tests::{get_bill_keys, TEST_PRIVATE_KEY_SECP},
     };
 

--- a/src/blockchain/bill/mod.rs
+++ b/src/blockchain/bill/mod.rs
@@ -1,9 +1,5 @@
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
-
-use super::{Blockchain, Result};
-use crate::service::bill_service::BillKeys;
 
 pub mod block;
 pub mod chain;
@@ -13,16 +9,7 @@ use block::BillIdentityBlockData;
 pub use chain::BillBlockchain;
 
 #[derive(
-    BorshSerialize,
-    BorshDeserialize,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    ToSchema,
-    Hash,
+    BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
 )]
 pub enum BillOpCode {
     Issue,
@@ -70,69 +57,14 @@ pub struct RecoursePaymentInfo {
     pub currency: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
-pub struct BillBlockchainToReturn {
-    pub blocks: Vec<BillBlockToReturn>,
-}
-
-impl BillBlockchainToReturn {
-    /// Creates a new blockchain to return by transforming a given blockchain into its corresponding representation.
-    ///
-    /// # Parameters
-    /// * `chain` - The blockchain to be transformed. It contains the list of blocks and the initial bill version
-    ///   necessary for processing.
-    /// * `bill_keys` - The keys for the bill
-    ///
-    /// # Returns
-    /// A new instance containing the transformed `BillBlockToReturn` objects.
-    ///
-    pub fn new(chain: BillBlockchain, bill_keys: &BillKeys) -> Result<Self> {
-        let mut blocks: Vec<BillBlockToReturn> = Vec::new();
-        for block in chain.blocks() {
-            blocks.push(BillBlockToReturn::new(block.clone(), bill_keys)?);
-        }
-        Ok(Self { blocks })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ToSchema)]
-pub struct BillBlockToReturn {
-    pub id: u64,
-    pub hash: String,
-    pub timestamp: u64,
-    pub data: String,
-    pub previous_hash: String,
-    pub signature: String,
-    pub op_code: BillOpCode,
-    pub label: String,
-}
-
-impl BillBlockToReturn {
-    /// Creates a new block to return for the given bill, with an attached history label,
-    /// describing what happened in this block
-    pub fn new(block: BillBlock, bill_keys: &BillKeys) -> Result<Self> {
-        let label = block.get_history_label(bill_keys)?;
-
-        Ok(Self {
-            id: block.id,
-            hash: block.hash,
-            timestamp: block.timestamp,
-            data: block.data,
-            previous_hash: block.previous_hash,
-            signature: block.signature,
-            op_code: block.op_code,
-            label,
-        })
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{
-        service::{
-            bill_service::BitcreditBill,
-            identity_service::{Identity, IdentityWithAll},
+        blockchain::Blockchain,
+        data::{
+            bill::BitcreditBill,
+            identity::{Identity, IdentityWithAll},
         },
         tests::tests::TEST_PRIVATE_KEY_SECP,
         util::BcrKeys,

--- a/src/blockchain/identity/mod.rs
+++ b/src/blockchain/identity/mod.rs
@@ -1,9 +1,8 @@
 use super::bill::BillOpCode;
 use super::Result;
 use super::{Block, Blockchain, FIRST_BLOCK_ID};
-use crate::service::identity_service::Identity;
+use crate::data::{identity::Identity, File, OptionalPostalAddress};
 use crate::util::{self, crypto, BcrKeys};
-use crate::web::data::{File, OptionalPostalAddress};
 use borsh::to_vec;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};

--- a/src/data/bill.rs
+++ b/src/data/bill.rs
@@ -1,0 +1,261 @@
+use super::{
+    contact::{IdentityPublicData, LightIdentityPublicData, LightIdentityPublicDataWithAddress},
+    notification::Notification,
+    File, PostalAddress,
+};
+use crate::util::date::date_string_to_i64_timestamp;
+use borsh_derive::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
+pub struct BitcreditBill {
+    pub id: String,
+    pub country_of_issuing: String,
+    pub city_of_issuing: String,
+    // The party obliged to pay a Bill
+    pub drawee: IdentityPublicData,
+    // The party issuing a Bill
+    pub drawer: IdentityPublicData,
+    pub payee: IdentityPublicData,
+    // The person to whom the Payee or an Endorsee endorses a bill
+    pub endorsee: Option<IdentityPublicData>,
+    pub currency: String,
+    pub sum: u64,
+    pub maturity_date: String,
+    pub issue_date: String,
+    pub country_of_payment: String,
+    pub city_of_payment: String,
+    pub language: String,
+    pub files: Vec<File>,
+}
+
+#[cfg(test)]
+impl BitcreditBill {
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            id: "".to_string(),
+            country_of_issuing: "".to_string(),
+            city_of_issuing: "".to_string(),
+            drawee: IdentityPublicData::new_empty(),
+            drawer: IdentityPublicData::new_empty(),
+            payee: IdentityPublicData::new_empty(),
+            endorsee: None,
+            currency: "".to_string(),
+            sum: 0,
+            maturity_date: "".to_string(),
+            issue_date: "".to_string(),
+            city_of_payment: "".to_string(),
+            country_of_payment: "".to_string(),
+            language: "".to_string(),
+            files: vec![],
+        }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone)]
+pub struct BillKeys {
+    pub private_key: String,
+    pub public_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum RecourseReason {
+    Accept,
+    Pay(u64, String), // sum and currency
+}
+
+#[derive(Debug, Clone)]
+pub struct BitcreditBillResult {
+    pub id: String,
+    pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
+    pub country_of_issuing: String,
+    pub city_of_issuing: String,
+    /// The party obliged to pay a Bill
+    pub drawee: IdentityPublicData,
+    /// The party issuing a Bill
+    pub drawer: IdentityPublicData,
+    pub payee: IdentityPublicData,
+    /// The person to whom the Payee or an Endorsee endorses a bill
+    pub endorsee: Option<IdentityPublicData>,
+    pub currency: String,
+    pub sum: String,
+    pub maturity_date: String,
+    pub issue_date: String,
+    pub country_of_payment: String,
+    pub city_of_payment: String,
+    pub language: String,
+    pub accepted: bool,
+    pub endorsed: bool,
+    pub requested_to_pay: bool,
+    pub requested_to_accept: bool,
+    pub paid: bool,
+    pub waiting_for_payment: bool,
+    pub buyer: Option<IdentityPublicData>,
+    pub seller: Option<IdentityPublicData>,
+    pub in_recourse: bool,
+    pub recourser: Option<IdentityPublicData>,
+    pub recoursee: Option<IdentityPublicData>,
+    pub link_for_buy: String,
+    pub link_to_pay: String,
+    pub link_to_pay_recourse: String,
+    pub address_to_pay: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub files: Vec<File>,
+    /// The currently active notification for this bill if any
+    pub active_notification: Option<Notification>,
+    pub bill_participants: Vec<String>,
+    pub endorsements_count: u64,
+}
+
+impl BitcreditBillResult {
+    /// Returns the role of the given node_id in the bill, or None if the node_id is not a
+    /// participant in the bill
+    pub fn get_bill_role_for_node_id(&self, node_id: &str) -> Option<BillRole> {
+        // Node id is not part of the bill
+        if !self.bill_participants.iter().any(|bp| bp == node_id) {
+            return None;
+        }
+
+        // Node id is the payer
+        if self.drawee.node_id == *node_id {
+            return Some(BillRole::Payer);
+        }
+
+        // Node id is payee / endorsee
+        if self.payee.node_id == *node_id
+            || self.endorsee.as_ref().map(|e| e.node_id.as_str()) == Some(node_id)
+        {
+            return Some(BillRole::Payee);
+        }
+
+        // Node id is part of the bill, but neither payer, nor payee - they are part of the risk
+        // chain
+        Some(BillRole::Contingent)
+    }
+
+    // Search in the participants for the search term
+    pub fn search_bill_for_search_term(&self, search_term: &str) -> bool {
+        let search_term_lc = search_term.to_lowercase();
+        if self.payee.name.to_lowercase().contains(&search_term_lc) {
+            return true;
+        }
+
+        if self.drawer.name.to_lowercase().contains(&search_term_lc) {
+            return true;
+        }
+
+        if self.drawee.name.to_lowercase().contains(&search_term_lc) {
+            return true;
+        }
+
+        if let Some(ref endorsee) = self.endorsee {
+            if endorsee.name.to_lowercase().contains(&search_term_lc) {
+                return true;
+            }
+        }
+
+        if let Some(ref buyer) = self.buyer {
+            if buyer.name.to_lowercase().contains(&search_term_lc) {
+                return true;
+            }
+        }
+
+        if let Some(ref seller) = self.seller {
+            if seller.name.to_lowercase().contains(&search_term_lc) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LightBitcreditBillResult {
+    pub id: String,
+    pub drawee: LightIdentityPublicData,
+    pub drawer: LightIdentityPublicData,
+    pub payee: LightIdentityPublicData,
+    pub endorsee: Option<LightIdentityPublicData>,
+    pub active_notification: Option<Notification>,
+    pub sum: String,
+    pub currency: String,
+    pub issue_date: String,
+    pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
+}
+
+impl From<BitcreditBillResult> for LightBitcreditBillResult {
+    fn from(value: BitcreditBillResult) -> Self {
+        Self {
+            id: value.id,
+            drawee: value.drawee.into(),
+            drawer: value.drawer.into(),
+            payee: value.payee.into(),
+            endorsee: value.endorsee.map(|v| v.into()),
+            active_notification: value.active_notification,
+            sum: value.sum,
+            currency: value.currency,
+            issue_date: value.issue_date,
+            time_of_drawing: value.time_of_drawing,
+            time_of_maturity: date_string_to_i64_timestamp(&value.maturity_date, None).unwrap_or(0)
+                as u64,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BillsBalanceOverview {
+    pub payee: BillsBalance,
+    pub payer: BillsBalance,
+    pub contingent: BillsBalance,
+}
+
+#[derive(Debug, Clone)]
+pub struct BillsBalance {
+    pub sum: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BillRole {
+    Payee,
+    Payer,
+    Contingent,
+}
+
+#[derive(Debug)]
+pub struct BillCombinedBitcoinKey {
+    pub private_key: String,
+}
+
+#[derive(Debug)]
+pub enum BillsFilterRole {
+    All,
+    Payer,
+    Payee,
+    Contingent,
+}
+
+#[derive(Debug)]
+pub struct PastEndorsee {
+    pub pay_to_the_order_of: LightIdentityPublicData,
+    pub signed: LightSignedBy,
+    pub signing_timestamp: u64,
+    pub signing_address: PostalAddress,
+}
+
+#[derive(Debug)]
+pub struct Endorsement {
+    pub pay_to_the_order_of: LightIdentityPublicDataWithAddress,
+    pub signed: LightSignedBy,
+    pub signing_timestamp: u64,
+    pub signing_address: PostalAddress,
+}
+
+#[derive(Debug)]
+pub struct LightSignedBy {
+    pub data: LightIdentityPublicData,
+    pub signatory: Option<LightIdentityPublicData>,
+}

--- a/src/data/company.rs
+++ b/src/data/company.rs
@@ -1,0 +1,24 @@
+use super::{File, PostalAddress};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
+pub struct Company {
+    pub id: String,
+    pub name: String,
+    pub country_of_registration: Option<String>,
+    pub city_of_registration: Option<String>,
+    pub postal_address: PostalAddress,
+    pub email: String,
+    pub registration_number: Option<String>,
+    pub registration_date: Option<String>,
+    pub proof_of_registration_file: Option<File>,
+    pub logo_file: Option<File>,
+    pub signatories: Vec<String>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone)]
+pub struct CompanyKeys {
+    pub private_key: String,
+    pub public_key: String,
+}

--- a/src/data/contact.rs
+++ b/src/data/contact.rs
@@ -1,0 +1,183 @@
+use super::{company::Company, identity::Identity, File, PostalAddress};
+use crate::blockchain::bill::block::BillIdentityBlockData;
+use borsh_derive::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+#[repr(u8)]
+#[derive(
+    Debug,
+    Clone,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[borsh(use_discriminant = true)]
+pub enum ContactType {
+    Person = 0,
+    Company = 1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Contact {
+    #[serde(rename = "type")]
+    pub t: ContactType,
+    pub node_id: String,
+    pub name: String,
+    pub email: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddress,
+    pub date_of_birth_or_registration: Option<String>,
+    pub country_of_birth_or_registration: Option<String>,
+    pub city_of_birth_or_registration: Option<String>,
+    pub identification_number: Option<String>,
+    pub avatar_file: Option<File>,
+    pub proof_document_file: Option<File>,
+    pub nostr_relays: Vec<String>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct IdentityPublicData {
+    /// The type of identity (0 = person, 1 = company)
+    #[serde(rename = "type")]
+    pub t: ContactType,
+    /// The P2P node id of the identity
+    pub node_id: String,
+    /// The name of the identity
+    pub name: String,
+    /// Full postal address of the identity
+    #[serde(flatten)]
+    pub postal_address: PostalAddress,
+    /// email address of the identity
+    pub email: Option<String>,
+    /// The preferred Nostr relay to deliver Nostr messages to
+    pub nostr_relay: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightIdentityPublicData {
+    #[serde(rename = "type")]
+    pub t: ContactType,
+    pub name: String,
+    pub node_id: String,
+}
+
+impl From<IdentityPublicData> for LightIdentityPublicData {
+    fn from(value: IdentityPublicData) -> Self {
+        Self {
+            t: value.t,
+            name: value.name,
+            node_id: value.node_id,
+        }
+    }
+}
+
+impl From<BillIdentityBlockData> for LightIdentityPublicData {
+    fn from(value: BillIdentityBlockData) -> Self {
+        Self {
+            t: value.t,
+            name: value.name,
+            node_id: value.node_id,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightIdentityPublicDataWithAddress {
+    #[serde(rename = "type")]
+    pub t: ContactType,
+    pub name: String,
+    pub node_id: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddress,
+}
+
+impl From<IdentityPublicData> for LightIdentityPublicDataWithAddress {
+    fn from(value: IdentityPublicData) -> Self {
+        Self {
+            t: value.t,
+            name: value.name,
+            node_id: value.node_id,
+            postal_address: value.postal_address,
+        }
+    }
+}
+
+impl From<BillIdentityBlockData> for LightIdentityPublicDataWithAddress {
+    fn from(value: BillIdentityBlockData) -> Self {
+        Self {
+            t: value.t,
+            name: value.name,
+            node_id: value.node_id,
+            postal_address: value.postal_address,
+        }
+    }
+}
+
+impl From<Contact> for IdentityPublicData {
+    fn from(value: Contact) -> Self {
+        Self {
+            t: value.t,
+            node_id: value.node_id.clone(),
+            name: value.name,
+            postal_address: value.postal_address,
+            email: Some(value.email),
+            nostr_relay: value.nostr_relays.first().cloned(),
+        }
+    }
+}
+
+impl From<Company> for IdentityPublicData {
+    fn from(value: Company) -> Self {
+        Self {
+            t: ContactType::Company,
+            node_id: value.id.clone(),
+            name: value.name,
+            postal_address: value.postal_address,
+            email: Some(value.email),
+            nostr_relay: None,
+        }
+    }
+}
+
+impl IdentityPublicData {
+    pub fn new(identity: Identity) -> Option<Self> {
+        match identity.postal_address.to_full_postal_address() {
+            Some(postal_address) => Some(Self {
+                t: ContactType::Person,
+                node_id: identity.node_id,
+                name: identity.name,
+                postal_address,
+                email: Some(identity.email),
+                nostr_relay: identity.nostr_relay,
+            }),
+            None => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            t: ContactType::Person,
+            node_id: "".to_string(),
+            name: "".to_string(),
+            postal_address: PostalAddress::new_empty(),
+            email: None,
+            nostr_relay: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_only_node_id(node_id: String) -> Self {
+        Self {
+            t: ContactType::Person,
+            node_id,
+            name: "".to_string(),
+            postal_address: PostalAddress::new_empty(),
+            email: None,
+            nostr_relay: None,
+        }
+    }
+}

--- a/src/data/identity.rs
+++ b/src/data/identity.rs
@@ -1,0 +1,74 @@
+use super::{File, OptionalPostalAddress};
+use crate::{blockchain::bill::block::BillSignatoryBlockData, util::BcrKeys};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+#[repr(u8)]
+#[derive(
+    Debug,
+    Clone,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[borsh(use_discriminant = true)]
+pub enum IdentityType {
+    Person = 0,
+    Company = 1,
+}
+
+#[derive(Clone, Debug)]
+pub struct IdentityWithAll {
+    pub identity: Identity,
+    pub key_pair: BcrKeys,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct Identity {
+    pub node_id: String,
+    pub name: String,
+    pub email: String,
+    pub postal_address: OptionalPostalAddress,
+    pub date_of_birth: Option<String>,
+    pub country_of_birth: Option<String>,
+    pub city_of_birth: Option<String>,
+    pub identification_number: Option<String>,
+    pub nostr_relay: Option<String>,
+    pub profile_picture_file: Option<File>,
+    pub identity_document_file: Option<File>,
+}
+
+impl Identity {
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            node_id: "".to_string(),
+            name: "".to_string(),
+            email: "".to_string(),
+            postal_address: OptionalPostalAddress::new_empty(),
+            date_of_birth: None,
+            country_of_birth: None,
+            city_of_birth: None,
+            identification_number: None,
+            nostr_relay: None,
+            profile_picture_file: None,
+            identity_document_file: None,
+        }
+    }
+
+    pub fn get_nostr_name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+impl From<Identity> for BillSignatoryBlockData {
+    fn from(value: Identity) -> Self {
+        Self {
+            name: value.name,
+            node_id: value.node_id,
+        }
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,0 +1,110 @@
+use bill::LightBitcreditBillResult;
+use borsh_derive::{BorshDeserialize, BorshSerialize};
+use company::Company;
+use contact::Contact;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+pub mod bill;
+pub mod company;
+pub mod contact;
+pub mod identity;
+pub mod notification;
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PostalAddress {
+    pub country: String,
+    pub city: String,
+    pub zip: Option<String>,
+    pub address: String,
+}
+
+impl fmt::Display for PostalAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.zip {
+            Some(ref zip) => {
+                write!(
+                    f,
+                    "{}, {} {}, {}",
+                    self.address, zip, self.city, self.country
+                )
+            }
+            None => {
+                write!(f, "{}, {}, {}", self.address, self.city, self.country)
+            }
+        }
+    }
+}
+
+impl PostalAddress {
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            country: "".to_string(),
+            city: "".to_string(),
+            zip: None,
+            address: "".to_string(),
+        }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct OptionalPostalAddress {
+    pub country: Option<String>,
+    pub city: Option<String>,
+    pub zip: Option<String>,
+    pub address: Option<String>,
+}
+
+impl OptionalPostalAddress {
+    pub fn is_fully_set(&self) -> bool {
+        self.country.is_some() && self.city.is_some() && self.address.is_some()
+    }
+
+    pub fn to_full_postal_address(&self) -> Option<PostalAddress> {
+        if self.is_fully_set() {
+            return Some(PostalAddress {
+                country: self.country.clone().expect("checked above"),
+                city: self.city.clone().expect("checked above"),
+                zip: self.zip.clone(),
+                address: self.address.clone().expect("checked above"),
+            });
+        }
+        None
+    }
+
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            country: None,
+            city: None,
+            zip: None,
+            address: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GeneralSearchResult {
+    pub bills: Vec<LightBitcreditBillResult>,
+    pub contacts: Vec<Contact>,
+    pub companies: Vec<Company>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum GeneralSearchFilterItemType {
+    Company,
+    Bill,
+    Contact,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct File {
+    pub name: String,
+    pub hash: String,
+}
+
+#[derive(Debug)]
+pub struct UploadFilesResult {
+    pub file_upload_id: String,
+}

--- a/src/data/notification.rs
+++ b/src/data/notification.rs
@@ -1,0 +1,65 @@
+use crate::util::date::{now, DateTimeUtc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt::Display;
+use uuid::Uuid;
+
+/// A notification as it will be delivered to the UI.
+///
+/// A generic notification. Payload is unstructured json. The timestamp refers to the
+/// time when the client received the notification. The type determines the payload
+/// type and the reference_id is used to identify and optional other entity like a
+/// Bill or Company.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notification {
+    /// The unique id of the notification
+    pub id: String,
+    /// Id of the identity that the notification is for
+    pub node_id: Option<String>,
+    /// The type/topic of the notification
+    pub notification_type: NotificationType,
+    /// An optional reference to some other entity
+    pub reference_id: Option<String>,
+    /// A description to quickly show to a user in the ui (probably a translation key)
+    pub description: String,
+    /// The datetime when the notification was created
+    pub datetime: DateTimeUtc,
+    /// Whether the notification is active or not. If active the user shold still perform
+    /// some action to dismiss the notification.
+    pub active: bool,
+    /// Additional data to be used for notification specific logic
+    pub payload: Option<Value>,
+}
+
+impl Notification {
+    pub fn new_bill_notification(
+        bill_id: &str,
+        node_id: &str,
+        description: &str,
+        payload: Option<Value>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            node_id: Some(node_id.to_string()),
+            notification_type: NotificationType::Bill,
+            reference_id: Some(bill_id.to_string()),
+            description: description.to_string(),
+            datetime: now(),
+            active: true,
+            payload,
+        }
+    }
+}
+
+/// The type/topic of a notification we show to the user
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NotificationType {
+    General,
+    Bill,
+}
+
+impl Display for NotificationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(format!("{:?}", self).as_str())
+    }
+}

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -11,6 +11,10 @@ use crate::blockchain::bill::BillBlockchain;
 use crate::blockchain::company::CompanyBlockchain;
 use crate::blockchain::Blockchain;
 use crate::constants::{BILLS_PREFIX, BILL_PREFIX, COMPANIES_PREFIX, COMPANY_PREFIX};
+use crate::data::{
+    bill::BillKeys,
+    company::{Company, CompanyKeys},
+};
 use crate::persistence::bill::{
     bill_chain_from_bytes, bill_chain_to_bytes, bill_keys_from_bytes, bill_keys_to_bytes,
     BillChainStoreApi, BillStoreApi,
@@ -21,8 +25,6 @@ use crate::persistence::company::{
 };
 use crate::persistence::file_upload::FileUploadStoreApi;
 use crate::persistence::identity::IdentityStoreApi;
-use crate::service::bill_service::BillKeys;
-use crate::service::company_service::{Company, CompanyKeys};
 use crate::{blockchain, util};
 use borsh::{from_slice, to_vec};
 use future::{try_join_all, BoxFuture};
@@ -1490,19 +1492,15 @@ mod tests {
             BILL_ATTACHMENT_PREFIX, COMPANY_CHAIN_PREFIX, COMPANY_KEY_PREFIX, COMPANY_LOGO_PREFIX,
             COMPANY_PROOF_PREFIX, KEY_PREFIX,
         },
+        data::{identity::Identity, File, PostalAddress},
         persistence::{
             bill::{MockBillChainStoreApi, MockBillStoreApi},
             company::{MockCompanyChainStoreApi, MockCompanyStoreApi},
             file_upload::MockFileUploadStoreApi,
             identity::MockIdentityStoreApi,
         },
-        service::{
-            bill_service::tests::{get_baseline_bill, get_genesis_chain},
-            company_service::CompanyToReturn,
-            identity_service::Identity,
-        },
+        service::bill_service::tests::{get_baseline_bill, get_genesis_chain},
         tests::tests::{TEST_NODE_ID_SECP, TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP},
-        web::data::{File, PostalAddress},
     };
     use blockchain::company::CompanyCreateBlockData;
     use futures::channel::mpsc::{self, Sender};
@@ -1599,11 +1597,10 @@ mod tests {
     }
 
     fn get_valid_company_chain(company_id: &str) -> CompanyBlockchain {
-        let (id, (company, company_keys)) = get_baseline_company_data(company_id);
-        let to_return = CompanyToReturn::from(id, company);
+        let (_id, (company, company_keys)) = get_baseline_company_data(company_id);
 
         CompanyBlockchain::new(
-            &CompanyCreateBlockData::from(to_return),
+            &CompanyCreateBlockData::from(company),
             &BcrKeys::new(),
             &company_keys,
             1731593928,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use tokio::spawn;
 mod blockchain;
 mod config;
 mod constants;
+mod data;
 mod dht;
 mod error;
 mod external;

--- a/src/persistence/bill.rs
+++ b/src/persistence/bill.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use super::Result;
 use crate::{
     blockchain::bill::{BillBlock, BillBlockchain, BillOpCode},
-    service::bill_service::BillKeys,
+    data::bill::BillKeys,
 };
 use async_trait::async_trait;
 

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -1,5 +1,5 @@
 use crate::blockchain::company::{CompanyBlock, CompanyBlockchain};
-use crate::service::company_service::{Company, CompanyKeys};
+use crate::data::company::{Company, CompanyKeys};
 use std::collections::HashMap;
 
 use super::Result;

--- a/src/persistence/contact.rs
+++ b/src/persistence/contact.rs
@@ -1,4 +1,4 @@
-use crate::service::contact_service::Contact;
+use crate::data::contact::Contact;
 use std::collections::HashMap;
 
 use super::Result;

--- a/src/persistence/db/bill.rs
+++ b/src/persistence/db/bill.rs
@@ -7,8 +7,8 @@ use crate::{
         DB_BILL_ID, DB_OP_CODE, DB_TABLE, DB_TIMESTAMP, PAYMENT_DEADLINE_SECONDS,
         RECOURSE_DEADLINE_SECONDS,
     },
+    data::bill::BillKeys,
     persistence::{bill::BillStoreApi, Error},
-    service::bill_service::BillKeys,
     util,
 };
 use async_trait::async_trait;
@@ -235,17 +235,17 @@ pub mod tests {
             tests::get_baseline_identity,
             BillBlock, BillOpCode,
         },
+        data::{
+            bill::{BillKeys, BitcreditBill},
+            contact::IdentityPublicData,
+            PostalAddress,
+        },
         persistence::{
             bill::{BillChainStoreApi, BillStoreApi},
             db::{bill_chain::SurrealBillChainStore, get_memory_db},
         },
-        service::{
-            bill_service::{BillKeys, BitcreditBill},
-            contact_service::IdentityPublicData,
-        },
         tests::tests::{get_bill_keys, TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP},
         util::{self, BcrKeys},
-        web::data::PostalAddress,
     };
     use chrono::Months;
     use surrealdb::{engine::any::Any, Surreal};

--- a/src/persistence/db/bill_chain.rs
+++ b/src/persistence/db/bill_chain.rs
@@ -204,11 +204,10 @@ mod tests {
             bill::block::{BillAcceptBlockData, BillIdentityBlockData},
             Blockchain,
         },
+        data::{contact::ContactType, PostalAddress},
         persistence::db::{bill::tests::get_first_block, get_memory_db},
-        service::contact_service::ContactType,
         tests::tests::get_bill_keys,
         util::BcrKeys,
-        web::data::PostalAddress,
     };
 
     async fn get_store() -> SurrealBillChainStore {

--- a/src/persistence/db/company.rs
+++ b/src/persistence/db/company.rs
@@ -1,8 +1,8 @@
 use super::{FileDb, PostalAddressDb, Result};
 use crate::{
     constants::{DB_SEARCH_TERM, DB_TABLE},
+    data::company::{Company, CompanyKeys},
     persistence::{company::CompanyStoreApi, Error},
-    service::company_service::{Company, CompanyKeys},
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -200,10 +200,10 @@ impl From<&CompanyKeys> for CompanyKeysDb {
 mod tests {
     use super::*;
     use crate::{
+        data::PostalAddress,
         persistence::db::get_memory_db,
         tests::tests::{TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP},
         util::BcrKeys,
-        web::data::PostalAddress,
     };
 
     async fn get_store() -> SurrealCompanyStore {

--- a/src/persistence/db/company_chain.rs
+++ b/src/persistence/db/company_chain.rs
@@ -213,11 +213,13 @@ mod tests {
     use super::*;
     use crate::{
         blockchain::company::CompanyUpdateBlockData,
+        data::{
+            company::{Company, CompanyKeys},
+            OptionalPostalAddress, PostalAddress,
+        },
         persistence::db::get_memory_db,
-        service::company_service::{CompanyKeys, CompanyToReturn},
         tests::tests::{TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP},
         util::BcrKeys,
-        web::data::{OptionalPostalAddress, PostalAddress},
     };
 
     async fn get_store() -> SurrealCompanyChainStore {
@@ -240,7 +242,7 @@ mod tests {
         let block = CompanyBlock::create_block_for_create(
             "some_id".to_string(),
             "genesis hash".to_string(),
-            &CompanyToReturn {
+            &Company {
                 id: "some_id".to_string(),
                 name: "Hayek Ltd".to_string(),
                 country_of_registration: Some("AT".to_string()),
@@ -295,7 +297,7 @@ mod tests {
         let block = CompanyBlock::create_block_for_create(
             "some_id".to_string(),
             "genesis hash".to_string(),
-            &CompanyToReturn {
+            &Company {
                 id: "some_id".to_string(),
                 name: "Hayek Ltd".to_string(),
                 country_of_registration: Some("AT".to_string()),

--- a/src/persistence/db/contact.rs
+++ b/src/persistence/db/contact.rs
@@ -7,8 +7,8 @@ use surrealdb::{engine::any::Any, Surreal};
 
 use crate::{
     constants::{DB_SEARCH_TERM, DB_TABLE},
+    data::contact::{Contact, ContactType},
     persistence::ContactStoreApi,
-    service::contact_service::{Contact, ContactType},
 };
 
 #[derive(Clone)]
@@ -134,7 +134,7 @@ impl From<Contact> for ContactDb {
 pub mod tests {
     use super::*;
     use crate::{
-        persistence::db::get_memory_db, tests::tests::TEST_NODE_ID_SECP, web::data::PostalAddress,
+        data::PostalAddress, persistence::db::get_memory_db, tests::tests::TEST_NODE_ID_SECP,
     };
 
     pub fn get_baseline_contact() -> Contact {

--- a/src/persistence/db/identity.rs
+++ b/src/persistence/db/identity.rs
@@ -1,7 +1,7 @@
 use super::{FileDb, OptionalPostalAddressDb, Result};
 use crate::{
+    data::identity::{Identity, IdentityWithAll},
     persistence::{identity::IdentityStoreApi, Error},
-    service::identity_service::{Identity, IdentityWithAll},
     util::BcrKeys,
 };
 use async_trait::async_trait;

--- a/src/persistence/db/identity_chain.rs
+++ b/src/persistence/db/identity_chain.rs
@@ -177,8 +177,10 @@ impl From<&IdentityBlock> for IdentityBlockDb {
 mod tests {
     use super::*;
     use crate::{
-        blockchain::identity::IdentityUpdateBlockData, persistence::db::get_memory_db,
-        service::identity_service::Identity, util::BcrKeys, web::data::OptionalPostalAddress,
+        blockchain::identity::IdentityUpdateBlockData,
+        data::{identity::Identity, OptionalPostalAddress},
+        persistence::db::get_memory_db,
+        util::BcrKeys,
     };
 
     async fn get_store() -> SurrealIdentityChainStore {

--- a/src/persistence/db/mod.rs
+++ b/src/persistence/db/mod.rs
@@ -1,5 +1,5 @@
 use super::Result;
-use crate::web::data::{File, OptionalPostalAddress, PostalAddress};
+use crate::data::{File, OptionalPostalAddress, PostalAddress};
 use log::error;
 use serde::{Deserialize, Serialize};
 use surrealdb::{

--- a/src/persistence/db/notification.rs
+++ b/src/persistence/db/notification.rs
@@ -5,8 +5,9 @@ use serde_json::Value;
 use surrealdb::{engine::any::Any, sql::Thing, Surreal};
 
 use crate::{
+    data::notification::{Notification, NotificationType},
     persistence::notification::{NotificationFilter, NotificationStoreApi},
-    service::notification_service::{ActionType, Notification, NotificationType},
+    service::notification_service::ActionType,
     util::date::{now, DateTimeUtc},
 };
 

--- a/src/persistence/identity.rs
+++ b/src/persistence/identity.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 
 use crate::{
     blockchain::identity::IdentityBlock,
-    service::identity_service::{Identity, IdentityWithAll},
+    data::identity::{Identity, IdentityWithAll},
     util::crypto::BcrKeys,
 };
 #[cfg(test)]

--- a/src/persistence/notification.rs
+++ b/src/persistence/notification.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 
 use super::Result;
-use crate::service::notification_service::{ActionType, Notification, NotificationType};
+use crate::data::notification::{Notification, NotificationType};
+use crate::service::notification_service::ActionType;
 #[cfg(test)]
 use mockall::automock;
 

--- a/src/service/file_upload_service.rs
+++ b/src/service/file_upload_service.rs
@@ -1,7 +1,7 @@
 use super::{Error, Result};
 use crate::constants::{MAX_FILE_NAME_CHARACTERS, MAX_FILE_SIZE_BYTES, VALID_FILE_MIME_TYPES};
+use crate::data::UploadFilesResult;
 use crate::persistence::file_upload::FileUploadStoreApi;
-use crate::web::data::UploadFilesResponse;
 use crate::{persistence, util};
 use async_trait::async_trait;
 use log::error;
@@ -16,7 +16,7 @@ pub trait FileUploadServiceApi: Send + Sync {
     async fn upload_files(
         &self,
         files: Vec<&dyn util::file::UploadFileHandler>,
-    ) -> Result<UploadFilesResponse>;
+    ) -> Result<UploadFilesResult>;
 
     /// returns a temp upload file
     async fn get_temp_file(&self, file_upload_id: &str) -> Result<Option<(String, Vec<u8>)>>;
@@ -80,7 +80,7 @@ impl FileUploadServiceApi for FileUploadService {
     async fn upload_files(
         &self,
         files: Vec<&dyn util::file::UploadFileHandler>,
-    ) -> Result<UploadFilesResponse> {
+    ) -> Result<UploadFilesResult> {
         // create a new random id
         let file_upload_id = util::get_uuid_v4().to_string();
         // create a folder to store the files
@@ -102,7 +102,7 @@ impl FileUploadServiceApi for FileUploadService {
                 .write_temp_upload_file(&file_upload_id, &file_name, &read_file)
                 .await?;
         }
-        Ok(UploadFilesResponse { file_upload_id })
+        Ok(UploadFilesResult { file_upload_id })
     }
 
     async fn get_temp_file(&self, file_upload_id: &str) -> Result<Option<(String, Vec<u8>)>> {

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -4,15 +4,15 @@ use crate::{util, CONFIG};
 
 use crate::blockchain::identity::{IdentityBlock, IdentityBlockchain, IdentityUpdateBlockData};
 use crate::blockchain::Blockchain;
+use crate::data::{
+    identity::{Identity, IdentityWithAll},
+    File, OptionalPostalAddress,
+};
 use crate::persistence::file_upload::FileUploadStoreApi;
 use crate::persistence::identity::IdentityChainStoreApi;
-use crate::web::data::{File, OptionalPostalAddress};
 use async_trait::async_trait;
-use borsh_derive::{BorshDeserialize, BorshSerialize};
 use log::info;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use utoipa::ToSchema;
 
 #[async_trait]
 pub trait IdentityServiceApi: Send + Sync {
@@ -61,38 +61,6 @@ pub trait IdentityServiceApi: Send + Sync {
         file_name: &str,
         private_key: &str,
     ) -> Result<Vec<u8>>;
-}
-
-#[repr(u8)]
-#[derive(
-    Debug,
-    Clone,
-    serde_repr::Serialize_repr,
-    serde_repr::Deserialize_repr,
-    PartialEq,
-    Eq,
-    ToSchema,
-    BorshSerialize,
-    BorshDeserialize,
-)]
-#[borsh(use_discriminant = true)]
-pub enum IdentityType {
-    Person = 0,
-    Company = 1,
-}
-
-impl TryFrom<u64> for IdentityType {
-    type Error = super::Error;
-
-    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
-        match value {
-            0 => Ok(IdentityType::Person),
-            1 => Ok(IdentityType::Company),
-            _ => Err(super::Error::Validation(format!(
-                "Invalid identity type found: {value}"
-            ))),
-        }
-    }
 }
 
 /// The identity service is responsible for managing the local identity and syncing it
@@ -380,88 +348,6 @@ impl IdentityServiceApi for IdentityService {
             .await?;
         let decrypted = util::crypto::decrypt_ecies(&read_file, private_key)?;
         Ok(decrypted)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct IdentityWithAll {
-    pub identity: Identity,
-    pub key_pair: BcrKeys,
-}
-
-#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct Identity {
-    pub node_id: String,
-    pub name: String,
-    pub email: String,
-    pub postal_address: OptionalPostalAddress,
-    pub date_of_birth: Option<String>,
-    pub country_of_birth: Option<String>,
-    pub city_of_birth: Option<String>,
-    pub identification_number: Option<String>,
-    pub nostr_relay: Option<String>,
-    pub profile_picture_file: Option<File>,
-    pub identity_document_file: Option<File>,
-}
-
-impl Identity {
-    #[cfg(test)]
-    pub fn new_empty() -> Self {
-        Self {
-            node_id: "".to_string(),
-            name: "".to_string(),
-            email: "".to_string(),
-            postal_address: OptionalPostalAddress::new_empty(),
-            date_of_birth: None,
-            country_of_birth: None,
-            city_of_birth: None,
-            identification_number: None,
-            nostr_relay: None,
-            profile_picture_file: None,
-            identity_document_file: None,
-        }
-    }
-
-    pub fn get_nostr_name(&self) -> String {
-        self.name.clone()
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct IdentityToReturn {
-    pub node_id: String,
-    pub name: String,
-    pub email: String,
-    pub bitcoin_public_key: String,
-    pub npub: String,
-    #[serde(flatten)]
-    pub postal_address: OptionalPostalAddress,
-    pub date_of_birth: Option<String>,
-    pub country_of_birth: Option<String>,
-    pub city_of_birth: Option<String>,
-    pub identification_number: Option<String>,
-    pub profile_picture_file: Option<File>,
-    pub identity_document_file: Option<File>,
-    pub nostr_relay: Option<String>,
-}
-
-impl IdentityToReturn {
-    pub fn from(identity: Identity, keys: BcrKeys) -> Result<Self> {
-        Ok(Self {
-            node_id: identity.node_id.clone(),
-            name: identity.name,
-            email: identity.email,
-            bitcoin_public_key: identity.node_id.clone(),
-            npub: keys.get_nostr_npub()?,
-            postal_address: identity.postal_address,
-            date_of_birth: identity.date_of_birth,
-            country_of_birth: identity.country_of_birth,
-            city_of_birth: identity.city_of_birth,
-            identification_number: identity.identification_number,
-            profile_picture_file: identity.profile_picture_file,
-            identity_document_file: identity.identity_document_file,
-            nostr_relay: identity.nostr_relay,
-        })
     }
 }
 

--- a/src/service/notification_service/bill_action_event_handler.rs
+++ b/src/service/notification_service/bill_action_event_handler.rs
@@ -2,13 +2,13 @@ use super::{NotificationType, Result};
 use std::sync::Arc;
 
 use crate::{
+    data::notification::Notification,
     persistence::notification::NotificationStoreApi,
     service::notification_service::event::{BillActionEventPayload, Event},
 };
 
 use super::{
     handler::NotificationHandlerApi, push_notification::PushApi, EventEnvelope, EventType,
-    Notification,
 };
 use async_trait::async_trait;
 

--- a/src/service/notification_service/default_service.rs
+++ b/src/service/notification_service/default_service.rs
@@ -5,10 +5,13 @@ use async_trait::async_trait;
 
 use super::event::{ActionType, BillActionEventPayload, Event, EventType};
 use super::transport::NotificationJsonTransportApi;
-use super::{Notification, NotificationServiceApi, NotificationType, Result};
+use super::{NotificationServiceApi, Result};
+use crate::data::{
+    bill::BitcreditBill,
+    contact::IdentityPublicData,
+    notification::{Notification, NotificationType},
+};
 use crate::persistence::notification::{NotificationFilter, NotificationStoreApi};
-use crate::service::bill_service::BitcreditBill;
-use crate::service::contact_service::IdentityPublicData;
 
 /// A default implementation of the NotificationServiceApi that can
 /// send events via json and email transports.

--- a/src/service/notification_service/nostr.rs
+++ b/src/service/notification_service/nostr.rs
@@ -11,9 +11,9 @@ use crate::persistence::NostrEventOffsetStoreApi;
 use crate::service::contact_service::ContactServiceApi;
 use crate::util::{crypto, BcrKeys};
 
-use super::super::contact_service::IdentityPublicData;
 use super::handler::NotificationHandlerApi;
 use super::{EventEnvelope, NotificationJsonTransportApi, Result};
+use crate::data::contact::IdentityPublicData;
 
 #[derive(Clone, Debug)]
 pub struct NostrConfig {

--- a/src/service/notification_service/test_utils.rs
+++ b/src/service/notification_service/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::{
+    data::{bill::BitcreditBill, contact::IdentityPublicData},
     persistence::{
         backup::MockBackupStoreApi,
         bill::{MockBillChainStoreApi, MockBillStoreApi},
@@ -10,7 +11,6 @@ use crate::{
         notification::MockNotificationStoreApi,
         DbContext,
     },
-    service::{bill_service::BitcreditBill, contact_service::IdentityPublicData},
     util::BcrKeys,
 };
 use nostr_relay_builder::prelude::*;

--- a/src/service/notification_service/transport.rs
+++ b/src/service/notification_service/transport.rs
@@ -1,5 +1,5 @@
-use super::super::contact_service::IdentityPublicData;
 use super::{EventEnvelope, Result};
+use crate::data::contact::IdentityPublicData;
 use async_trait::async_trait;
 use log::info;
 #[cfg(test)]

--- a/src/service/search_service.rs
+++ b/src/service/search_service.rs
@@ -3,7 +3,8 @@ use super::{
     bill_service::BillServiceApi, company_service::CompanyServiceApi,
     contact_service::ContactServiceApi,
 };
-use crate::web::data::{BillsFilterRole, GeneralSearchFilterItemType, GeneralSearchResponse};
+use crate::data::GeneralSearchResult;
+use crate::data::{bill::BillsFilterRole, GeneralSearchFilterItemType};
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -16,7 +17,7 @@ pub trait SearchServiceApi: Send + Sync {
         currency: &str,
         item_types: &[GeneralSearchFilterItemType],
         current_identity_node_id: &str,
-    ) -> Result<GeneralSearchResponse>;
+    ) -> Result<GeneralSearchResult>;
 }
 
 /// The serach service is responsible for implementing cross-domain search
@@ -49,7 +50,7 @@ impl SearchServiceApi for SearchService {
         currency: &str,
         item_types: &[GeneralSearchFilterItemType],
         current_identity_node_id: &str,
-    ) -> Result<GeneralSearchResponse> {
+    ) -> Result<GeneralSearchResult> {
         let search_term_lc = search_term.to_lowercase();
         let bills = if item_types.contains(&GeneralSearchFilterItemType::Bill) {
             self.bill_service
@@ -78,7 +79,7 @@ impl SearchServiceApi for SearchService {
             vec![]
         };
 
-        Ok(GeneralSearchResponse {
+        Ok(GeneralSearchResult {
             bills,
             contacts,
             companies,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 pub mod tests {
-    use crate::service::bill_service::BillKeys;
+    use crate::data::bill::BillKeys;
 
     pub fn get_bill_keys() -> BillKeys {
         BillKeys {

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -1,20 +1,37 @@
-use crate::service::contact_service::{ContactType, LightIdentityPublicDataWithAddress};
-use crate::service::identity_service::IdentityType;
-use crate::service::{
-    bill_service::LightBitcreditBillToReturn,
-    company_service::CompanyToReturn,
-    contact_service::{Contact, LightIdentityPublicData},
-    Error,
+use crate::data::{
+    bill::{
+        BillCombinedBitcoinKey, BillsFilterRole, BitcreditBillResult, Endorsement,
+        LightBitcreditBillResult, LightSignedBy, PastEndorsee,
+    },
+    company::Company,
+    contact::{
+        Contact, ContactType, IdentityPublicData, LightIdentityPublicData,
+        LightIdentityPublicDataWithAddress,
+    },
+    identity::{Identity, IdentityType},
+    notification::{Notification, NotificationType},
+    File, GeneralSearchFilterItemType, GeneralSearchResult, OptionalPostalAddress, PostalAddress,
+    UploadFilesResult,
 };
+use crate::service::{Error, Result};
 use crate::util::file::{detect_content_type_for_bytes, UploadFileHandler};
+use crate::util::{date::DateTimeUtc, BcrKeys};
 use async_trait::async_trait;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use rocket::fs::TempFile;
 use rocket::FromForm;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use serde_json::Value;
 use tokio::io::AsyncReadExt;
 use utoipa::ToSchema;
+
+pub trait IntoWeb<T> {
+    fn into_web(self) -> T;
+}
+
+pub trait FromWeb<T> {
+    fn from_web(value: T) -> Self;
+}
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct StatusResponse {
@@ -36,42 +53,29 @@ impl SuccessResponse {
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct EndorsementsResponse {
-    pub endorsements: Vec<Endorsement>,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct Endorsement {
-    pub pay_to_the_order_of: LightIdentityPublicDataWithAddress,
-    pub signed: LightSignedBy,
-    pub signing_timestamp: u64,
-    pub signing_address: PostalAddress,
+    pub endorsements: Vec<EndorsementWeb>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PastEndorseesResponse {
-    pub past_endorsees: Vec<PastEndorsee>,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct PastEndorsee {
-    pub pay_to_the_order_of: LightIdentityPublicData,
-    pub signed: LightSignedBy,
-    pub signing_timestamp: u64,
-    pub signing_address: PostalAddress,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct LightSignedBy {
-    #[serde(flatten)]
-    pub data: LightIdentityPublicData,
-    pub signatory: Option<LightIdentityPublicData>,
+    pub past_endorsees: Vec<PastEndorseeWeb>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct GeneralSearchResponse {
-    pub bills: Vec<LightBitcreditBillToReturn>,
-    pub contacts: Vec<Contact>,
-    pub companies: Vec<CompanyToReturn>,
+    pub bills: Vec<LightBitcreditBillWeb>,
+    pub contacts: Vec<ContactWeb>,
+    pub companies: Vec<CompanyWeb>,
+}
+
+impl IntoWeb<GeneralSearchResponse> for GeneralSearchResult {
+    fn into_web(self) -> GeneralSearchResponse {
+        GeneralSearchResponse {
+            bills: self.bills.into_iter().map(|b| b.into_web()).collect(),
+            contacts: self.contacts.into_iter().map(|c| c.into_web()).collect(),
+            companies: self.companies.into_iter().map(|c| c.into_web()).collect(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -89,76 +93,78 @@ pub struct CompaniesResponse<T: Serialize> {
     pub companies: Vec<T>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GeneralSearchFilterPayload {
     pub filter: GeneralSearchFilter,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum GeneralSearchFilterItemType {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub enum GeneralSearchFilterItemTypeWeb {
     Company,
     Bill,
     Contact,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl FromWeb<GeneralSearchFilterItemTypeWeb> for GeneralSearchFilterItemType {
+    fn from_web(value: GeneralSearchFilterItemTypeWeb) -> Self {
+        match value {
+            GeneralSearchFilterItemTypeWeb::Company => GeneralSearchFilterItemType::Company,
+            GeneralSearchFilterItemTypeWeb::Bill => GeneralSearchFilterItemType::Bill,
+            GeneralSearchFilterItemTypeWeb::Contact => GeneralSearchFilterItemType::Contact,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GeneralSearchFilter {
     pub search_term: String,
     pub currency: String,
-    pub item_types: Vec<GeneralSearchFilterItemType>,
+    pub item_types: Vec<GeneralSearchFilterItemTypeWeb>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BillsSearchFilterPayload {
     pub filter: BillsSearchFilter,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BillsSearchFilter {
     pub search_term: Option<String>,
     pub date_range: Option<DateRange>,
-    pub role: BillsFilterRole,
+    pub role: BillsFilterRoleWeb,
     pub currency: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub enum BillsFilterRole {
-    All,
-    Payer,
-    Payee,
-    Contingent,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct DateRange {
     pub from: String,
     pub to: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct OverviewResponse {
     pub currency: String,
     pub balances: OverviewBalanceResponse,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct OverviewBalanceResponse {
     pub payee: BalanceResponse,
     pub payer: BalanceResponse,
     pub contingent: BalanceResponse,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BalanceResponse {
     pub sum: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CurrenciesResponse {
     pub currencies: Vec<CurrencyResponse>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CurrencyResponse {
     pub code: String,
 }
@@ -197,7 +203,7 @@ impl TryFrom<u64> for BillType {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BitcreditBillPayload {
     #[serde(rename = "type")]
     pub t: u64,
@@ -226,24 +232,24 @@ pub struct UploadFileForm<'r> {
     pub file: TempFile<'r>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BillId {
     pub id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BillNumbersToWordsForSum {
     pub sum: u64,
     pub sum_as_words: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct EndorseBitcreditBillPayload {
     pub endorsee: String,
     pub bill_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct MintBitcreditBillPayload {
     pub mint_node: String,
     pub bill_id: String,
@@ -251,13 +257,13 @@ pub struct MintBitcreditBillPayload {
     pub currency: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct RequestToMintBitcreditBillPayload {
     pub mint_node: String,
     pub bill_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct OfferToSellBitcreditBillPayload {
     pub buyer: String,
     pub bill_id: String,
@@ -265,35 +271,134 @@ pub struct OfferToSellBitcreditBillPayload {
     pub currency: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RequestToAcceptBitcreditBillPayload {
     pub bill_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RejectActionBillPayload {
     pub bill_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct BillCombinedBitcoinKey {
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct BillCombinedBitcoinKeyWeb {
     pub private_key: String,
+}
+
+impl IntoWeb<BillCombinedBitcoinKeyWeb> for BillCombinedBitcoinKey {
+    fn into_web(self) -> BillCombinedBitcoinKeyWeb {
+        BillCombinedBitcoinKeyWeb {
+            private_key: self.private_key,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub enum BillsFilterRoleWeb {
+    All,
+    Payer,
+    Payee,
+    Contingent,
+}
+
+impl FromWeb<BillsFilterRoleWeb> for BillsFilterRole {
+    fn from_web(value: BillsFilterRoleWeb) -> Self {
+        match value {
+            BillsFilterRoleWeb::All => BillsFilterRole::All,
+            BillsFilterRoleWeb::Payer => BillsFilterRole::Payer,
+            BillsFilterRoleWeb::Payee => BillsFilterRole::Payee,
+            BillsFilterRoleWeb::Contingent => BillsFilterRole::Contingent,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PastEndorseeWeb {
+    pub pay_to_the_order_of: LightIdentityPublicDataWeb,
+    pub signed: LightSignedByWeb,
+    pub signing_timestamp: u64,
+    pub signing_address: PostalAddressWeb,
+}
+
+impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
+    fn into_web(self) -> PastEndorseeWeb {
+        PastEndorseeWeb {
+            pay_to_the_order_of: self.pay_to_the_order_of.into_web(),
+            signed: self.signed.into_web(),
+            signing_timestamp: self.signing_timestamp,
+            signing_address: self.signing_address.into_web(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LightSignedByWeb {
+    #[serde(flatten)]
+    pub data: LightIdentityPublicDataWeb,
+    pub signatory: Option<LightIdentityPublicDataWeb>,
+}
+
+impl IntoWeb<LightSignedByWeb> for LightSignedBy {
+    fn into_web(self) -> LightSignedByWeb {
+        LightSignedByWeb {
+            data: self.data.into_web(),
+            signatory: self.signatory.map(|s| s.into_web()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EndorsementWeb {
+    pub pay_to_the_order_of: LightIdentityPublicDataWithAddressWeb,
+    pub signed: LightSignedByWeb,
+    pub signing_timestamp: u64,
+    pub signing_address: PostalAddressWeb,
+}
+
+impl IntoWeb<EndorsementWeb> for Endorsement {
+    fn into_web(self) -> EndorsementWeb {
+        EndorsementWeb {
+            pay_to_the_order_of: self.pay_to_the_order_of.into_web(),
+            signed: self.signed.into_web(),
+            signing_timestamp: self.signing_timestamp,
+            signing_address: self.signing_address.into_web(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SwitchIdentity {
     #[serde(rename = "type")]
-    pub t: Option<IdentityType>,
+    pub t: Option<IdentityTypeWeb>,
     pub node_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[repr(u8)]
+#[derive(
+    Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq, ToSchema,
+)]
+pub enum IdentityTypeWeb {
+    Person = 0,
+    Company = 1,
+}
+
+impl IntoWeb<IdentityTypeWeb> for IdentityType {
+    fn into_web(self) -> IdentityTypeWeb {
+        match self {
+            IdentityType::Person => IdentityTypeWeb::Person,
+            IdentityType::Company => IdentityTypeWeb::Company,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RequestToPayBitcreditBillPayload {
     pub bill_id: String,
     pub currency: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RequestRecourseForPaymentPayload {
     pub bill_id: String,
     pub recoursee: String,
@@ -301,13 +406,13 @@ pub struct RequestRecourseForPaymentPayload {
     pub sum: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RequestRecourseForAcceptancePayload {
     pub bill_id: String,
     pub recoursee: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct AcceptBitcreditBillPayload {
     pub bill_id: String,
 }
@@ -317,7 +422,7 @@ pub struct ChangeIdentityPayload {
     pub name: Option<String>,
     pub email: Option<String>,
     #[serde(flatten)]
-    pub postal_address: OptionalPostalAddress,
+    pub postal_address: OptionalPostalAddressWeb,
     pub date_of_birth: Option<String>,
     pub country_of_birth: Option<String>,
     pub city_of_birth: Option<String>,
@@ -331,7 +436,7 @@ pub struct NewIdentityPayload {
     pub name: String,
     pub email: String,
     #[serde(flatten)]
-    pub postal_address: OptionalPostalAddress,
+    pub postal_address: OptionalPostalAddressWeb,
     pub date_of_birth: Option<String>,
     pub country_of_birth: Option<String>,
     pub city_of_birth: Option<String>,
@@ -340,7 +445,7 @@ pub struct NewIdentityPayload {
     pub identity_document_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct NewContactPayload {
     #[serde(rename = "type")]
     pub t: u64,
@@ -348,7 +453,7 @@ pub struct NewContactPayload {
     pub name: String,
     pub email: String,
     #[serde(flatten)]
-    pub postal_address: PostalAddress,
+    pub postal_address: PostalAddressWeb,
     pub date_of_birth_or_registration: Option<String>,
     pub country_of_birth_or_registration: Option<String>,
     pub city_of_birth_or_registration: Option<String>,
@@ -357,13 +462,13 @@ pub struct NewContactPayload {
     pub proof_document_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct EditContactPayload {
     pub node_id: String,
     pub name: Option<String>,
     pub email: Option<String>,
     #[serde(flatten)]
-    pub postal_address: OptionalPostalAddress,
+    pub postal_address: OptionalPostalAddressWeb,
     pub date_of_birth_or_registration: Option<String>,
     pub country_of_birth_or_registration: Option<String>,
     pub city_of_birth_or_registration: Option<String>,
@@ -372,99 +477,15 @@ pub struct EditContactPayload {
     pub proof_document_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct UploadFilesResponse {
     pub file_upload_id: String,
 }
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema,
-)]
-pub struct File {
-    pub name: String,
-    pub hash: String,
-}
-
-#[derive(
-    BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema,
-)]
-pub struct OptionalPostalAddress {
-    pub country: Option<String>,
-    pub city: Option<String>,
-    pub zip: Option<String>,
-    pub address: Option<String>,
-}
-
-impl OptionalPostalAddress {
-    pub fn is_none(&self) -> bool {
-        self.country.is_none()
-            && self.city.is_none()
-            && self.zip.is_none()
-            && self.address.is_none()
-    }
-
-    pub fn is_fully_set(&self) -> bool {
-        self.country.is_some() && self.city.is_some() && self.address.is_some()
-    }
-
-    pub fn to_full_postal_address(&self) -> Option<PostalAddress> {
-        if self.is_fully_set() {
-            return Some(PostalAddress {
-                country: self.country.clone().expect("checked above"),
-                city: self.city.clone().expect("checked above"),
-                zip: self.zip.clone(),
-                address: self.address.clone().expect("checked above"),
-            });
-        }
-        None
-    }
-
-    #[cfg(test)]
-    pub fn new_empty() -> Self {
-        Self {
-            country: None,
-            city: None,
-            zip: None,
-            address: None,
-        }
-    }
-}
-
-#[derive(
-    BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema,
-)]
-pub struct PostalAddress {
-    pub country: String,
-    pub city: String,
-    pub zip: Option<String>,
-    pub address: String,
-}
-
-impl fmt::Display for PostalAddress {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.zip {
-            Some(ref zip) => {
-                write!(
-                    f,
-                    "{}, {} {}, {}",
-                    self.address, zip, self.city, self.country
-                )
-            }
-            None => {
-                write!(f, "{}, {}, {}", self.address, self.city, self.country)
-            }
-        }
-    }
-}
-
-impl PostalAddress {
-    #[cfg(test)]
-    pub fn new_empty() -> Self {
-        Self {
-            country: "".to_string(),
-            city: "".to_string(),
-            zip: None,
-            address: "".to_string(),
+impl IntoWeb<UploadFilesResponse> for UploadFilesResult {
+    fn into_web(self) -> UploadFilesResponse {
+        UploadFilesResponse {
+            file_upload_id: self.file_upload_id,
         }
     }
 }
@@ -477,13 +498,13 @@ pub struct SeedPhrase {
 }
 
 // Company
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct CreateCompanyPayload {
     pub name: String,
     pub country_of_registration: Option<String>,
     pub city_of_registration: Option<String>,
     #[serde(flatten)]
-    pub postal_address: PostalAddress,
+    pub postal_address: PostalAddressWeb,
     pub email: String,
     pub registration_number: Option<String>,
     pub registration_date: Option<String>,
@@ -491,13 +512,13 @@ pub struct CreateCompanyPayload {
     pub logo_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct EditCompanyPayload {
     pub id: String,
     pub name: Option<String>,
     pub email: Option<String>,
     #[serde(flatten)]
-    pub postal_address: OptionalPostalAddress,
+    pub postal_address: OptionalPostalAddressWeb,
     pub country_of_registration: Option<String>,
     pub city_of_registration: Option<String>,
     pub registration_number: Option<String>,
@@ -506,42 +527,517 @@ pub struct EditCompanyPayload {
     pub proof_of_registration_file_upload_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct AddSignatoryPayload {
     pub id: String,
     pub signatory_node_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct RemoveSignatoryPayload {
     pub id: String,
     pub signatory_node_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct ListSignatoriesResponse {
     pub signatories: Vec<SignatoryResponse>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct SignatoryResponse {
     #[serde(rename = "type")]
-    pub t: ContactType,
+    pub t: ContactTypeWeb,
     pub node_id: String,
     pub name: String,
     #[serde(flatten)]
-    pub postal_address: PostalAddress,
-    pub avatar_file: Option<File>,
+    pub postal_address: PostalAddressWeb,
+    pub avatar_file: Option<FileWeb>,
 }
 
 impl From<Contact> for SignatoryResponse {
     fn from(value: Contact) -> Self {
         Self {
-            t: value.t,
+            t: value.t.into_web(),
             node_id: value.node_id,
             name: value.name,
-            postal_address: value.postal_address,
-            avatar_file: value.avatar_file,
+            postal_address: value.postal_address.into_web(),
+            avatar_file: value.avatar_file.map(|f| f.into_web()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct IdentityWeb {
+    pub node_id: String,
+    pub name: String,
+    pub email: String,
+    pub bitcoin_public_key: String,
+    pub npub: String,
+    #[serde(flatten)]
+    pub postal_address: OptionalPostalAddressWeb,
+    pub date_of_birth: Option<String>,
+    pub country_of_birth: Option<String>,
+    pub city_of_birth: Option<String>,
+    pub identification_number: Option<String>,
+    pub profile_picture_file: Option<FileWeb>,
+    pub identity_document_file: Option<FileWeb>,
+    pub nostr_relay: Option<String>,
+}
+
+impl IdentityWeb {
+    pub fn from(identity: Identity, keys: BcrKeys) -> Result<Self> {
+        Ok(Self {
+            node_id: identity.node_id.clone(),
+            name: identity.name,
+            email: identity.email,
+            bitcoin_public_key: identity.node_id.clone(),
+            npub: keys.get_nostr_npub()?,
+            postal_address: identity.postal_address.into_web(),
+            date_of_birth: identity.date_of_birth,
+            country_of_birth: identity.country_of_birth,
+            city_of_birth: identity.city_of_birth,
+            identification_number: identity.identification_number,
+            profile_picture_file: identity.profile_picture_file.map(|f| f.into_web()),
+            identity_document_file: identity.identity_document_file.map(|f| f.into_web()),
+            nostr_relay: identity.nostr_relay,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PostalAddressWeb {
+    pub country: String,
+    pub city: String,
+    pub zip: Option<String>,
+    pub address: String,
+}
+
+impl FromWeb<PostalAddressWeb> for PostalAddress {
+    fn from_web(value: PostalAddressWeb) -> Self {
+        Self {
+            country: value.country,
+            city: value.city,
+            zip: value.zip,
+            address: value.address,
+        }
+    }
+}
+
+impl IntoWeb<PostalAddressWeb> for PostalAddress {
+    fn into_web(self) -> PostalAddressWeb {
+        PostalAddressWeb {
+            country: self.country,
+            city: self.city,
+            zip: self.zip,
+            address: self.address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct OptionalPostalAddressWeb {
+    pub country: Option<String>,
+    pub city: Option<String>,
+    pub zip: Option<String>,
+    pub address: Option<String>,
+}
+
+impl OptionalPostalAddressWeb {
+    pub fn is_none(&self) -> bool {
+        self.country.is_none()
+            && self.city.is_none()
+            && self.zip.is_none()
+            && self.address.is_none()
+    }
+}
+
+impl FromWeb<OptionalPostalAddressWeb> for OptionalPostalAddress {
+    fn from_web(value: OptionalPostalAddressWeb) -> Self {
+        Self {
+            country: value.country,
+            city: value.city,
+            zip: value.zip,
+            address: value.address,
+        }
+    }
+}
+
+impl IntoWeb<OptionalPostalAddressWeb> for OptionalPostalAddress {
+    fn into_web(self) -> OptionalPostalAddressWeb {
+        OptionalPostalAddressWeb {
+            country: self.country,
+            city: self.city,
+            zip: self.zip,
+            address: self.address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FileWeb {
+    pub name: String,
+    pub hash: String,
+}
+
+impl FromWeb<FileWeb> for File {
+    fn from_web(value: FileWeb) -> Self {
+        Self {
+            name: value.name,
+            hash: value.hash,
+        }
+    }
+}
+
+impl IntoWeb<FileWeb> for File {
+    fn into_web(self) -> FileWeb {
+        FileWeb {
+            name: self.name,
+            hash: self.hash,
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(
+    Debug, Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, PartialEq, Eq, ToSchema,
+)]
+pub enum ContactTypeWeb {
+    Person = 0,
+    Company = 1,
+}
+
+impl TryFrom<u64> for ContactTypeWeb {
+    type Error = Error;
+
+    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ContactTypeWeb::Person),
+            1 => Ok(ContactTypeWeb::Company),
+            _ => Err(Error::Validation(format!(
+                "Invalid contact type found: {value}"
+            ))),
+        }
+    }
+}
+
+impl IntoWeb<ContactTypeWeb> for ContactType {
+    fn into_web(self) -> ContactTypeWeb {
+        match self {
+            ContactType::Person => ContactTypeWeb::Person,
+            ContactType::Company => ContactTypeWeb::Company,
+        }
+    }
+}
+
+impl FromWeb<ContactTypeWeb> for ContactType {
+    fn from_web(value: ContactTypeWeb) -> Self {
+        match value {
+            ContactTypeWeb::Person => ContactType::Person,
+            ContactTypeWeb::Company => ContactType::Company,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ContactWeb {
+    #[serde(rename = "type")]
+    pub t: ContactTypeWeb,
+    pub node_id: String,
+    pub name: String,
+    pub email: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddressWeb,
+    pub date_of_birth_or_registration: Option<String>,
+    pub country_of_birth_or_registration: Option<String>,
+    pub city_of_birth_or_registration: Option<String>,
+    pub identification_number: Option<String>,
+    pub avatar_file: Option<FileWeb>,
+    pub proof_document_file: Option<FileWeb>,
+    pub nostr_relays: Vec<String>,
+}
+
+impl IntoWeb<ContactWeb> for Contact {
+    fn into_web(self) -> ContactWeb {
+        ContactWeb {
+            t: self.t.into_web(),
+            node_id: self.node_id,
+            name: self.name,
+            email: self.email,
+            postal_address: self.postal_address.into_web(),
+            date_of_birth_or_registration: self.date_of_birth_or_registration,
+            country_of_birth_or_registration: self.country_of_birth_or_registration,
+            city_of_birth_or_registration: self.city_of_birth_or_registration,
+            identification_number: self.identification_number,
+            avatar_file: self.avatar_file.map(|f| f.into_web()),
+            proof_document_file: self.proof_document_file.map(|f| f.into_web()),
+            nostr_relays: self.nostr_relays,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct CompanyWeb {
+    pub id: String,
+    pub name: String,
+    pub country_of_registration: Option<String>,
+    pub city_of_registration: Option<String>,
+    #[serde(flatten)]
+    pub postal_address: PostalAddressWeb,
+    pub email: String,
+    pub registration_number: Option<String>,
+    pub registration_date: Option<String>,
+    pub proof_of_registration_file: Option<FileWeb>,
+    pub logo_file: Option<FileWeb>,
+    pub signatories: Vec<String>,
+}
+
+impl IntoWeb<CompanyWeb> for Company {
+    fn into_web(self) -> CompanyWeb {
+        CompanyWeb {
+            id: self.id,
+            name: self.name,
+            country_of_registration: self.country_of_registration,
+            city_of_registration: self.city_of_registration,
+            postal_address: self.postal_address.into_web(),
+            email: self.email,
+            registration_number: self.registration_number,
+            registration_date: self.registration_date,
+            proof_of_registration_file: self.proof_of_registration_file.map(|f| f.into_web()),
+            logo_file: self.logo_file.map(|f| f.into_web()),
+            signatories: self.signatories,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct BitcreditEbillQuote {
+    pub bill_id: String,
+    pub quote_id: String,
+    pub sum: u64,
+    pub mint_node_id: String,
+    pub mint_url: String,
+    pub accepted: bool,
+    pub token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct BitcreditBillWeb {
+    pub id: String,
+    pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
+    pub country_of_issuing: String,
+    pub city_of_issuing: String,
+    pub drawee: IdentityPublicDataWeb,
+    pub drawer: IdentityPublicDataWeb,
+    pub payee: IdentityPublicDataWeb,
+    pub endorsee: Option<IdentityPublicDataWeb>,
+    pub currency: String,
+    pub sum: String,
+    pub maturity_date: String,
+    pub issue_date: String,
+    pub country_of_payment: String,
+    pub city_of_payment: String,
+    pub language: String,
+    pub accepted: bool,
+    pub endorsed: bool,
+    pub requested_to_pay: bool,
+    pub requested_to_accept: bool,
+    pub paid: bool,
+    pub waiting_for_payment: bool,
+    pub buyer: Option<IdentityPublicDataWeb>,
+    pub seller: Option<IdentityPublicDataWeb>,
+    pub in_recourse: bool,
+    pub recourser: Option<IdentityPublicDataWeb>,
+    pub recoursee: Option<IdentityPublicDataWeb>,
+    pub link_for_buy: String,
+    pub link_to_pay: String,
+    pub link_to_pay_recourse: String,
+    pub address_to_pay: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub files: Vec<FileWeb>,
+    pub active_notification: Option<NotificationWeb>,
+    pub bill_participants: Vec<String>,
+    pub endorsements_count: u64,
+}
+
+impl IntoWeb<BitcreditBillWeb> for BitcreditBillResult {
+    fn into_web(self) -> BitcreditBillWeb {
+        BitcreditBillWeb {
+            id: self.id,
+            drawee: self.drawee.into_web(),
+            drawer: self.drawer.into_web(),
+            payee: self.payee.into_web(),
+            endorsee: self.endorsee.map(|e| e.into_web()),
+            active_notification: self.active_notification.map(|n| n.into_web()),
+            sum: self.sum,
+            currency: self.currency,
+            issue_date: self.issue_date,
+            time_of_drawing: self.time_of_drawing,
+            time_of_maturity: self.time_of_maturity,
+            country_of_issuing: self.country_of_issuing,
+            city_of_issuing: self.city_of_issuing,
+            maturity_date: self.maturity_date,
+            country_of_payment: self.country_of_payment,
+            city_of_payment: self.city_of_payment,
+            language: self.language,
+            accepted: self.accepted,
+            endorsed: self.endorsed,
+            requested_to_pay: self.requested_to_pay,
+            requested_to_accept: self.requested_to_accept,
+            paid: self.paid,
+            waiting_for_payment: self.waiting_for_payment,
+            buyer: self.buyer.map(|b| b.into_web()),
+            seller: self.seller.map(|b| b.into_web()),
+            in_recourse: self.in_recourse,
+            recourser: self.recourser.map(|r| r.into_web()),
+            recoursee: self.recoursee.map(|r| r.into_web()),
+            link_for_buy: self.link_for_buy,
+            link_to_pay: self.link_to_pay,
+            link_to_pay_recourse: self.link_to_pay_recourse,
+            address_to_pay: self.address_to_pay,
+            mempool_link_for_address_to_pay: self.mempool_link_for_address_to_pay,
+            files: self.files.into_iter().map(|f| f.into_web()).collect(),
+            bill_participants: self.bill_participants,
+            endorsements_count: self.endorsements_count,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct LightBitcreditBillWeb {
+    pub id: String,
+    pub drawee: LightIdentityPublicDataWeb,
+    pub drawer: LightIdentityPublicDataWeb,
+    pub payee: LightIdentityPublicDataWeb,
+    pub endorsee: Option<LightIdentityPublicDataWeb>,
+    pub active_notification: Option<NotificationWeb>,
+    pub sum: String,
+    pub currency: String,
+    pub issue_date: String,
+    pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
+}
+impl IntoWeb<LightBitcreditBillWeb> for LightBitcreditBillResult {
+    fn into_web(self) -> LightBitcreditBillWeb {
+        LightBitcreditBillWeb {
+            id: self.id,
+            drawee: self.drawee.into_web(),
+            drawer: self.drawer.into_web(),
+            payee: self.payee.into_web(),
+            endorsee: self.endorsee.map(|e| e.into_web()),
+            active_notification: self.active_notification.map(|n| n.into_web()),
+            sum: self.sum,
+            currency: self.currency,
+            issue_date: self.issue_date,
+            time_of_drawing: self.time_of_drawing,
+            time_of_maturity: self.time_of_maturity,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct IdentityPublicDataWeb {
+    #[serde(rename = "type")]
+    pub t: ContactTypeWeb,
+    pub node_id: String,
+    pub name: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddressWeb,
+    pub email: Option<String>,
+    pub nostr_relay: Option<String>,
+}
+
+impl IntoWeb<IdentityPublicDataWeb> for IdentityPublicData {
+    fn into_web(self) -> IdentityPublicDataWeb {
+        IdentityPublicDataWeb {
+            t: self.t.into_web(),
+            name: self.name,
+            node_id: self.node_id,
+            postal_address: self.postal_address.into_web(),
+            email: self.email,
+            nostr_relay: self.nostr_relay,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct LightIdentityPublicDataWithAddressWeb {
+    #[serde(rename = "type")]
+    pub t: ContactTypeWeb,
+    pub name: String,
+    pub node_id: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddressWeb,
+}
+
+impl IntoWeb<LightIdentityPublicDataWithAddressWeb> for LightIdentityPublicDataWithAddress {
+    fn into_web(self) -> LightIdentityPublicDataWithAddressWeb {
+        LightIdentityPublicDataWithAddressWeb {
+            t: self.t.into_web(),
+            name: self.name,
+            node_id: self.node_id,
+            postal_address: self.postal_address.into_web(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct LightIdentityPublicDataWeb {
+    #[serde(rename = "type")]
+    pub t: ContactTypeWeb,
+    pub name: String,
+    pub node_id: String,
+}
+
+impl IntoWeb<LightIdentityPublicDataWeb> for LightIdentityPublicData {
+    fn into_web(self) -> LightIdentityPublicDataWeb {
+        LightIdentityPublicDataWeb {
+            t: self.t.into_web(),
+            name: self.name,
+            node_id: self.node_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NotificationWeb {
+    pub id: String,
+    pub node_id: Option<String>,
+    pub notification_type: NotificationTypeWeb,
+    pub reference_id: Option<String>,
+    pub description: String,
+    #[schema(value_type = chrono::DateTime<chrono::Utc>)]
+    pub datetime: DateTimeUtc,
+    pub active: bool,
+    pub payload: Option<Value>,
+}
+impl IntoWeb<NotificationWeb> for Notification {
+    fn into_web(self) -> NotificationWeb {
+        NotificationWeb {
+            id: self.id,
+            node_id: self.node_id,
+            notification_type: self.notification_type.into_web(),
+            reference_id: self.reference_id,
+            description: self.description,
+            datetime: self.datetime,
+            active: self.active,
+            payload: self.payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub enum NotificationTypeWeb {
+    General,
+    Bill,
+}
+
+impl IntoWeb<NotificationTypeWeb> for NotificationType {
+    fn into_web(self) -> NotificationTypeWeb {
+        match self {
+            NotificationType::Bill => NotificationTypeWeb::Bill,
+            NotificationType::General => NotificationTypeWeb::General,
         }
     }
 }

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -1,5 +1,6 @@
 use super::middleware::IdentityCheck;
-use crate::service::{bill_service::BitcreditEbillQuote, Error, Result, ServiceContext};
+use crate::service::{Error, Result, ServiceContext};
+use crate::web::data::BitcreditEbillQuote;
 use log::info;
 use rocket::serde::json::Json;
 use rocket::{get, put, State};


### PR DESCRIPTION
## 📝 Description

* Split up data objects between `web` and the rest of the code base, creating two traits to convert between them
  * We can't just use `From` and `Into`, because of the orphan rule.
* Remove unnecessary `chain_of_blocks` code and elements from the API
* Consistently annotate data objects
* A further split within `src/web/data` might later be done if necessary within the split up crates

The idea is to move out a `web` crate containing all web logic, as well as a `core` crate, which contains the code data structures and traits.

Relates to #245 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Nothing in terms of logic should have been changed

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #245 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
