### PR TITLE
Nip 04 messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ uuid = { version = "1", default-features = false, features = ["v4", "js"] }
 bitcoin = { version = "0.32", default-features = false }
 bip39 = { version = "2.1", features = ["rand"] }
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
-nostr-sdk = { version = "0.40", features = ["nip59"] }
+nostr-sdk = { version = "0.40", features = ["nip04", "nip59"] }
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 async-broadcast = "0.7.2"

--- a/crates/bcr-ebill-api/src/constants.rs
+++ b/crates/bcr-ebill-api/src/constants.rs
@@ -2,3 +2,6 @@
 pub const MAX_FILE_SIZE_BYTES: usize = 1_000_000; // ~1 MB
 pub const MAX_FILE_NAME_CHARACTERS: usize = 200;
 pub const VALID_FILE_MIME_TYPES: [&str; 3] = ["image/jpeg", "image/png", "application/pdf"];
+
+// When subscribing events we subtract this from the last received event time
+pub const NOSTR_EVENT_TIME_SLACK: u64 = 3600; // 1 hour

--- a/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
@@ -461,12 +461,12 @@ fn create_nip04_event(
 ) -> Result<EventBuilder> {
     Ok(EventBuilder::new(
         Kind::EncryptedDirectMessage,
-        nip04::encrypt(secret_key, &public_key, message).map_err(|e| {
+        nip04::encrypt(secret_key, public_key, message).map_err(|e| {
             error!("Failed to encrypt direct private message: {e}");
             Error::Crypto("Failed to encrypt direct private message".to_string())
         })?,
     )
-    .tag(Tag::public_key(public_key.clone())))
+    .tag(Tag::public_key(*public_key)))
 }
 
 /// Handle extracted event with given handlers.

--- a/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
@@ -1,19 +1,19 @@
 use async_trait::async_trait;
-use bcr_ebill_core::contact::IdentityPublicData;
+use bcr_ebill_core::{contact::IdentityPublicData, util::crypto};
 use bcr_ebill_transport::event::EventEnvelope;
 use bcr_ebill_transport::handler::NotificationHandlerApi;
-use log::{error, trace, warn};
-use nostr_sdk::nips::nip59::UnwrappedGift;
+use log::{error, info, trace, warn};
 use nostr_sdk::{
-    Client, EventId, Filter, Kind, Metadata, Options, PublicKey, RelayPoolNotification, Timestamp,
-    ToBech32, UnsignedEvent,
+    Client, EventBuilder, EventId, Filter, Kind, Metadata, Options, PublicKey,
+    RelayPoolNotification, SecretKey, Tag, Timestamp, ToBech32, UnsignedEvent,
+    nips::{nip04, nip59::UnwrappedGift},
 };
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::service::contact_service::ContactServiceApi;
-use crate::util::{BcrKeys, crypto};
+use crate::util::BcrKeys;
 use bcr_ebill_core::ServiceTraitBounds;
 use bcr_ebill_persistence::{NostrEventOffset, NostrEventOffsetStoreApi};
 use bcr_ebill_transport::{Error, NotificationJsonTransportApi, Result};
@@ -47,7 +47,7 @@ impl NostrConfig {
 /// A wrapper around nostr_sdk that implements the NotificationJsonTransportApi.
 ///
 /// # Example:
-/// ```ignore
+/// ```no_run
 /// let config = NostrConfig {
 ///     keys: BcrKeys::new(),
 ///     relays: vec!["wss://relay.example.com".to_string()],
@@ -95,6 +95,14 @@ impl NostrClient {
         self.keys.get_public_key()
     }
 
+    pub fn get_nostr_keys(&self) -> nostr_sdk::Keys {
+        self.keys.get_nostr_keys()
+    }
+
+    fn use_nip04(&self) -> bool {
+        true
+    }
+
     /// Subscribe to some nostr events with a filter
     pub async fn subscribe(&self, subscription: Filter) -> Result<()> {
         self.client
@@ -107,8 +115,19 @@ impl NostrClient {
         Ok(())
     }
 
-    /// Unwrap envelope from private direct message
     pub async fn unwrap_envelope(
+        &self,
+        note: RelayPoolNotification,
+    ) -> Option<(EventEnvelope, PublicKey, EventId, Timestamp)> {
+        if self.use_nip04() {
+            self.unwrap_nip04_envelope(note).await
+        } else {
+            self.unwrap_nip17_envelope(note).await
+        }
+    }
+
+    /// Unwrap envelope from private direct message
+    async fn unwrap_nip17_envelope(
         &self,
         note: RelayPoolNotification,
     ) -> Option<(EventEnvelope, PublicKey, EventId, Timestamp)> {
@@ -127,17 +146,68 @@ impl NostrClient {
         }
         result
     }
-}
 
-impl ServiceTraitBounds for NostrClient {}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl NotificationJsonTransportApi for NostrClient {
-    fn get_sender_key(&self) -> String {
-        self.get_node_id()
+    /// Unwrap envelope from private direct message
+    async fn unwrap_nip04_envelope(
+        &self,
+        note: RelayPoolNotification,
+    ) -> Option<(EventEnvelope, PublicKey, EventId, Timestamp)> {
+        let mut result: Option<(EventEnvelope, PublicKey, EventId, Timestamp)> = None;
+        if let RelayPoolNotification::Event { event, .. } = note {
+            if event.kind == Kind::EncryptedDirectMessage {
+                match nip04::decrypt(
+                    self.keys.get_nostr_keys().secret_key(),
+                    &event.pubkey,
+                    &event.content,
+                ) {
+                    Ok(decrypted) => {
+                        result = extract_text_envelope(&decrypted)
+                            .map(|e| (e, event.pubkey, event.id, event.created_at));
+                    }
+                    Err(e) => {
+                        error!("Decrypting event failed: {e}");
+                    }
+                }
+            } else {
+                info!(
+                    "Received event with kind {} but expected GiftWrap",
+                    event.kind
+                );
+            }
+        }
+        result
     }
-    async fn send(
+
+    pub async fn send_nip04_message(
+        &self,
+        recipient: &IdentityPublicData,
+        event: EventEnvelope,
+    ) -> bcr_ebill_transport::Result<()> {
+        if let Ok(npub) = crypto::get_nostr_npub_as_hex_from_node_id(&recipient.node_id) {
+            let public_key = PublicKey::from_str(&npub).map_err(|e| {
+                error!("Failed to parse Nostr npub when sending a notification: {e}");
+                Error::Crypto("Failed to parse Nostr npub".to_string())
+            })?;
+            let message = serde_json::to_string(&event)?;
+            let event =
+                create_nip04_event(self.get_nostr_keys().secret_key(), &public_key, &message)?;
+            if let Some(relay) = &recipient.nostr_relay {
+                if let Err(e) = self.client.send_event_builder_to(vec![relay], event).await {
+                    error!("Error sending Nostr message: {e}")
+                };
+            } else if let Err(e) = self.client.send_event_builder(event).await {
+                error!("Error sending Nostr message: {e}")
+            }
+        } else {
+            error!(
+                "Try to send Nostr message but Nostr npub not found in contact {}",
+                recipient.name
+            );
+        }
+        Ok(())
+    }
+
+    async fn send_nip17_message(
         &self,
         recipient: &IdentityPublicData,
         event: EventEnvelope,
@@ -168,6 +238,28 @@ impl NotificationJsonTransportApi for NostrClient {
                 "Try to send Nostr message but Nostr npub not found in contact {}",
                 recipient.name
             );
+        }
+        Ok(())
+    }
+}
+
+impl ServiceTraitBounds for NostrClient {}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl NotificationJsonTransportApi for NostrClient {
+    fn get_sender_key(&self) -> String {
+        self.get_node_id()
+    }
+    async fn send(
+        &self,
+        recipient: &IdentityPublicData,
+        event: EventEnvelope,
+    ) -> bcr_ebill_transport::Result<()> {
+        if self.use_nip04() {
+            self.send_nip04_message(recipient, event).await?;
+        } else {
+            self.send_nip17_message(recipient, event).await?;
         }
         Ok(())
     }
@@ -226,15 +318,14 @@ impl NostrConsumer {
                 // continue where we left off
                 let offset_ts = get_offset(&offset_store, &node_id).await;
                 let public_key = current_client.keys.get_nostr_keys().public_key();
+                let filter = Filter::new()
+                    .pubkey(public_key)
+                    .kind(Kind::EncryptedDirectMessage)
+                    .since(offset_ts);
 
                 // subscribe only to private messages sent to our pubkey
                 current_client
-                    .subscribe(
-                        Filter::new()
-                            .pubkey(public_key)
-                            .kind(Kind::GiftWrap)
-                            .since(offset_ts),
-                    )
+                    .subscribe(filter)
                     .await
                     .expect("Failed to subscribe to Nostr events");
 
@@ -306,13 +397,19 @@ async fn valid_sender(
 }
 
 async fn get_offset(db: &Arc<dyn NostrEventOffsetStoreApi>, node_id: &str) -> Timestamp {
-    Timestamp::from_secs(
-        db.current_offset(node_id)
-            .await
-            .map_err(|e| error!("Could not get event offset: {e}"))
-            .ok()
-            .unwrap_or(0),
-    )
+    let slack = 3600;
+    let current = db
+        .current_offset(node_id)
+        .await
+        .map_err(|e| error!("Could not get event offset: {e}"))
+        .ok()
+        .unwrap_or(0);
+    let ts = if current <= slack {
+        current
+    } else {
+        current - slack
+    };
+    Timestamp::from_secs(ts)
 }
 
 async fn add_offset(
@@ -333,6 +430,16 @@ async fn add_offset(
     .ok();
 }
 
+fn extract_text_envelope(message: &str) -> Option<EventEnvelope> {
+    match serde_json::from_str::<EventEnvelope>(message) {
+        Ok(envelope) => Some(envelope),
+        Err(e) => {
+            error!("Json deserializing event envelope failed: {e}");
+            None
+        }
+    }
+}
+
 fn extract_event_envelope(rumor: UnsignedEvent) -> Option<EventEnvelope> {
     if rumor.kind == Kind::PrivateDirectMessage {
         match serde_json::from_str::<EventEnvelope>(rumor.content.as_str()) {
@@ -345,6 +452,21 @@ fn extract_event_envelope(rumor: UnsignedEvent) -> Option<EventEnvelope> {
     } else {
         None
     }
+}
+
+fn create_nip04_event(
+    secret_key: &SecretKey,
+    public_key: &PublicKey,
+    message: &str,
+) -> Result<EventBuilder> {
+    Ok(EventBuilder::new(
+        Kind::EncryptedDirectMessage,
+        nip04::encrypt(secret_key, &public_key, message).map_err(|e| {
+            error!("Failed to encrypt direct private message: {e}");
+            Error::Crypto("Failed to encrypt direct private message".to_string())
+        })?,
+    )
+    .tag(Tag::public_key(public_key.clone())))
 }
 
 /// Handle extracted event with given handlers.

--- a/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::service::contact_service::ContactServiceApi;
 use crate::util::BcrKeys;
+use crate::{constants::NOSTR_EVENT_TIME_SLACK, service::contact_service::ContactServiceApi};
 use bcr_ebill_core::ServiceTraitBounds;
 use bcr_ebill_persistence::{NostrEventOffset, NostrEventOffsetStoreApi};
 use bcr_ebill_transport::{Error, NotificationJsonTransportApi, Result};
@@ -397,17 +397,16 @@ async fn valid_sender(
 }
 
 async fn get_offset(db: &Arc<dyn NostrEventOffsetStoreApi>, node_id: &str) -> Timestamp {
-    let slack = 3600;
     let current = db
         .current_offset(node_id)
         .await
         .map_err(|e| error!("Could not get event offset: {e}"))
         .ok()
         .unwrap_or(0);
-    let ts = if current <= slack {
+    let ts = if current <= NOSTR_EVENT_TIME_SLACK {
         current
     } else {
-        current - slack
+        current - NOSTR_EVENT_TIME_SLACK
     };
     Timestamp::from_secs(ts)
 }

--- a/crates/bcr-ebill-transport/src/event/mod.rs
+++ b/crates/bcr-ebill-transport/src/event/mod.rs
@@ -85,8 +85,9 @@ impl<T: Serialize> TryFrom<Event<T>> for EventEnvelope {
 /// Allows generic deserialization of an event from an envelope.
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use serde::{Deserialize, Serialize};
+/// use bcr_ebill_transport::{EventType, Event, EventEnvelope};
 ///
 /// #[derive(Serialize, Deserialize)]
 /// struct MyEventPayload {
@@ -99,10 +100,9 @@ impl<T: Serialize> TryFrom<Event<T>> for EventEnvelope {
 ///     bar: 42,
 /// };
 ///
-/// let event = Event::new(EventType::BillSigned, "recipient".to_string(), payload);
+/// let event = Event::new(EventType::Bill, "recipient", payload);
 /// let event: EventEnvelope = event.try_into().unwrap();
 /// let deserialized_event: Event<MyEventPayload> = event.try_into().unwrap();
-/// assert_eq!(deserialized_event.data, payload);
 ///
 /// ```
 ///

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -278,6 +278,7 @@ impl NotificationHandlerApi for BillChainEventHandler {
                     .await
                 {
                     error!("Failed to process chain data: {}", e);
+                    return Ok(());
                 }
             }
             if let Err(e) = self.create_notification(&decoded.data, node_id).await {

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -81,12 +81,6 @@ async function start() {
   console.log(current_identity);
   document.getElementById("current_identity").innerHTML = current_identity.node_id;
 
-  try {
-    await identityApi.switch({ t: 1, node_id: "test" });
-  } catch (err) {
-    console.error("switching identity failed: ", err);
-  }
-
   // Company
   let companies = await companyApi.list();
   console.log("companies:", companies.companies.length, companies);


### PR DESCRIPTION
## 📝 Description

Allows us to switch between NIP-04 and NIP-17 private messages by setting a flag. For now it is configured to use NIP-04 until NIP-17 messages can be subscribed to reliably. Running a whole series of Bill ops between multiple parties via NIP-04 did not miss a single message (it works on both the current dev and the new custom relay).

Relates to #424

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Allow sending and subscription to either NIP-04 or NIP-17 private messages

- **Bug Fixes:**
  - Will probably fix the issue where certain messages (chain events) where not received when doing multiple ops with a single identity

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #297

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
