### PR TITLE
Bill Action tests, Add validation that multi-party bill actions can't be done with 2 identical parties

### DIFF
--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -818,6 +818,7 @@ pub mod tests {
         let returned_bills = res.unwrap();
         assert!(returned_bills.len() == 1);
         assert_eq!(returned_bills[0].id, TEST_BILL_ID.to_string());
+        assert!(returned_bills[0].status.payment.requested_to_pay);
         assert!(returned_bills[0].status.payment.paid);
     }
 
@@ -4012,6 +4013,23 @@ pub mod tests {
         assert!(
             service
                 .check_requests_for_expiration(&bill_payment, 1731593928)
+                .unwrap()
+        );
+        assert!(
+            !service
+                .check_requests_for_expiration(&bill_payment, 1431593928)
+                .unwrap()
+        );
+        bill_payment.data.maturity_date = "2018-07-15".into(); // before ts
+        assert!(
+            !service
+                .check_requests_for_expiration(&bill_payment, 1531593929)
+                .unwrap()
+        );
+        // 2 days after req to pay, but not yet 2 days after end of day maturity date
+        assert!(
+            !service
+                .check_requests_for_expiration(&bill_payment, 1531780429)
                 .unwrap()
         );
 

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -176,9 +176,11 @@ pub fn get_service(mut ctx: MockBillContext) -> BillService {
             )
         });
     bitcoin_client.expect_generate_link_to_pay().returning(|_,_,_| String::from("bitcoin:1Jfn2nZcJ4T7bhE8FdMRz8T3P3YV4LsWn2?amount=0.01&message=Payment in relation to bill some bill"));
-    ctx.contact_store
-        .expect_get()
-        .returning(|_| Ok(Some(get_baseline_contact())));
+    ctx.contact_store.expect_get().returning(|node_id| {
+        let mut contact = get_baseline_contact();
+        contact.node_id = node_id.to_owned();
+        Ok(Some(contact))
+    });
     ctx.contact_store
         .expect_get_map()
         .returning(|| Ok(HashMap::new()));

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -200,6 +200,18 @@ pub enum ValidationError {
     #[error("Drawee can't be Payee at the same time")]
     DraweeCantBePayee,
 
+    /// errors stemming from when the endorser is the endorsee
+    #[error("Endorser can't be Endorsee at the same time")]
+    EndorserCantBeEndorsee,
+
+    /// errors stemming from when the buyer is the seller
+    #[error("Buyer can't be Seller at the same time")]
+    BuyerCantBeSeller,
+
+    /// errors stemming from when the recourser is the recoursee
+    #[error("Recourser can't be Recoursee at the same time")]
+    RecourserCantBeRecoursee,
+
     /// error returned if a bill was already accepted and is attempted to be accepted again
     #[error("Bill was already accepted")]
     BillAlreadyAccepted,

--- a/crates/bcr-ebill-core/src/tests/mod.rs
+++ b/crates/bcr-ebill-core/src/tests/mod.rs
@@ -168,6 +168,9 @@ pub mod tests {
     pub const TEST_PRIVATE_KEY_SECP: &str =
         "d1ff7427912d3b81743d3b67ffa1e65df2156d3dab257316cbc8d0f35eeeabe9";
 
+    pub const OTHER_TEST_PUB_KEY_SECP: &str =
+        "03f9f94d1fdc2090d46f3524807e3f58618c36988e69577d70d5d4d1e9e9645a4f";
+
     pub const TEST_NODE_ID_SECP: &str =
         "03205b8dec12bc9e879f5b517aa32192a2550e88adcee3e54ec2c7294802568fef";
 

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -468,7 +468,8 @@ mod tests {
     #[tokio::test]
     async fn test_creates_new_chain_for_new_chain_event() {
         let payer = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
-        let payee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        let mut payee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        payee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
         let drawer = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, Some(&drawer), None);
         let chain = get_genesis_chain(Some(bill.clone()));
@@ -522,7 +523,8 @@ mod tests {
     #[tokio::test]
     async fn test_fails_to_create_new_chain_for_new_chain_event_if_block_validation_fails() {
         let payer = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
-        let payee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        let mut payee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        payee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
         let drawer = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, Some(&drawer), None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
@@ -649,7 +651,8 @@ mod tests {
     async fn test_adds_block_for_existing_chain_event() {
         let payer = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
         let payee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
-        let endorsee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        let mut endorsee = IdentityPublicData::new(get_baseline_identity().identity).unwrap();
+        endorsee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
         let block = BillBlock::create_block_for_endorse(
@@ -1147,6 +1150,9 @@ mod tests {
 
     pub const TEST_PUB_KEY_SECP: &str =
         "02295fb5f4eeb2f21e01eaf3a2d9a3be10f39db870d28f02146130317973a40ac0";
+
+    pub const OTHER_TEST_PUB_KEY_SECP: &str =
+        "03f9f94d1fdc2090d46f3524807e3f58618c36988e69577d70d5d4d1e9e9645a4f";
 
     pub const TEST_BILL_ID: &str = "KmtMUia3ezhshD9EyzvpT62DUPLr66M5LESy6j8ErCtv1USUDtoTA8JkXnCCGEtZxp41aKne5wVcCjoaFbjDqD4aFk";
 

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -48,6 +48,9 @@ enum JsErrorType {
     InvalidFileUploadId,
     InvalidBillType,
     DraweeCantBePayee,
+    EndorserCantBeEndorsee,
+    BuyerCantBeSeller,
+    RecourserCantBeRecoursee,
     DraweeNotInContacts,
     PayeeNotInContacts,
     MintNotInContacts,
@@ -187,6 +190,11 @@ fn validation_error_data(e: ValidationError) -> JsErrorData {
         ValidationError::InvalidFileUploadId => err_400(e, JsErrorType::InvalidFileUploadId),
         ValidationError::InvalidBillType => err_400(e, JsErrorType::InvalidBillType),
         ValidationError::DraweeCantBePayee => err_400(e, JsErrorType::DraweeCantBePayee),
+        ValidationError::EndorserCantBeEndorsee => err_400(e, JsErrorType::EndorserCantBeEndorsee),
+        ValidationError::BuyerCantBeSeller => err_400(e, JsErrorType::BuyerCantBeSeller),
+        ValidationError::RecourserCantBeRecoursee => {
+            err_400(e, JsErrorType::RecourserCantBeRecoursee)
+        }
         ValidationError::RequestAlreadyExpired => err_400(e, JsErrorType::RequestAlreadyExpired),
         ValidationError::BillAlreadyAccepted => err_400(e, JsErrorType::BillAlreadyAccepted),
         ValidationError::BillWasNotOfferedToSell => {

--- a/crates/bcr-ebill-web/src/handlers/mod.rs
+++ b/crates/bcr-ebill-web/src/handlers/mod.rs
@@ -314,6 +314,9 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ValidationError {
                 | bcr_ebill_api::util::ValidationError::InvalidContentType
                 | bcr_ebill_api::util::ValidationError::InvalidContactType
                 | bcr_ebill_api::util::ValidationError::DraweeCantBePayee
+                | bcr_ebill_api::util::ValidationError::EndorserCantBeEndorsee
+                | bcr_ebill_api::util::ValidationError::BuyerCantBeSeller
+                | bcr_ebill_api::util::ValidationError::RecourserCantBeRecoursee
                 | bcr_ebill_api::util::ValidationError::BillAlreadyAccepted
                 | bcr_ebill_api::util::ValidationError::BillWasNotOfferedToSell
                 | bcr_ebill_api::util::ValidationError::BillWasNotRequestedToPay


### PR DESCRIPTION
## 📝 Description

* Adds missing bill action tests
* Add missing maturity date tests for req to pay
* Add validation that multi-party bill actions can't be done with 2 identical parties

Relates to #317 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. Endorse / Sell / Recourse / Mint with same party for endorser and endorsee fails

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #317 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
