### PR TITLE
Past payments, payment request flag, rejection and expiration validation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add in-depth tests for bill validation
 * Add recourse reason to `Recourse` block data
     * (breaks existing persisted bills, if they had a recourse block)
+* Added `has_requested_funds` flag to `BillStatusWeb`, indicating the caller has requested funds (req to pay, req to recourse, offer to sell) at some point
+* Added `past_payments` endpoint to `Api.bill()`, which returns data about past payments and payment requests where the caller was the beneficiary
 
 # 0.3.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ getrandom = { version = "0.3.1", features = ["wasm_js"] }
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 async-broadcast = "0.7.2"
 rstest = "0.25.0"
+secp256k1 = { version = "0.29" }

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -127,6 +127,7 @@ pub fn get_baseline_cached_bill(id: String) -> BitcreditBillResult {
                 rejected_request_to_recourse: false,
             },
             redeemed_funds_available: false,
+            has_requested_funds: false,
         },
         current_waiting_state: None,
     }

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -20,6 +20,7 @@ bitcoin.workspace = true
 bip39.workspace = true
 ecies.workspace = true
 nostr-sdk.workspace = true
+secp256k1 = { workspace = true, features = ["global-context"] }
 rust_decimal = { version = "1.36.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/bcr-ebill-core/src/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/bill/mod.rs
@@ -169,6 +169,7 @@ pub struct BillStatus {
     pub sell: BillSellStatus,
     pub recourse: BillRecourseStatus,
     pub redeemed_funds_available: bool,
+    pub has_requested_funds: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -417,4 +418,60 @@ pub struct Endorsement {
 pub struct LightSignedBy {
     pub data: LightIdentityPublicData,
     pub signatory: Option<LightIdentityPublicData>,
+}
+
+#[derive(Debug, Clone)]
+pub enum PastPaymentResult {
+    Sell(PastPaymentDataSell),
+    Payment(PastPaymentDataPayment),
+    Recourse(PastPaymentDataRecourse),
+}
+
+#[derive(Debug, Clone)]
+pub enum PastPaymentStatus {
+    Paid(u64),     // timestamp
+    Rejected(u64), // timestamp
+    Expired(u64),  // timestamp
+}
+
+#[derive(Debug, Clone)]
+pub struct PastPaymentDataSell {
+    pub time_of_request: u64,
+    pub buyer: IdentityPublicData,
+    pub seller: IdentityPublicData,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatus,
+}
+
+#[derive(Debug, Clone)]
+pub struct PastPaymentDataPayment {
+    pub time_of_request: u64,
+    pub payer: IdentityPublicData,
+    pub payee: IdentityPublicData,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatus,
+}
+
+#[derive(Debug, Clone)]
+pub struct PastPaymentDataRecourse {
+    pub time_of_request: u64,
+    pub recourser: IdentityPublicData,
+    pub recoursee: IdentityPublicData,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatus,
 }

--- a/crates/bcr-ebill-core/src/blockchain/bill/block.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/block.rs
@@ -1180,6 +1180,30 @@ impl BillBlock {
         }
     }
 
+    /// If the block is a request with a financial beneficiary(req to pay, offer to sell, req to recourse),
+    /// return the node_id of the beneficiary
+    pub fn get_beneficiary_from_request_funds_block(
+        &self,
+        bill_keys: &BillKeys,
+    ) -> Result<Option<String>> {
+        match self.op_code {
+            OfferToSell => {
+                let block: BillOfferToSellBlockData = self.get_decrypted_block_bytes(bill_keys)?;
+                Ok(Some(block.seller.node_id))
+            }
+            RequestRecourse => {
+                let block: BillRequestRecourseBlockData =
+                    self.get_decrypted_block_bytes(bill_keys)?;
+                Ok(Some(block.recourser.node_id))
+            }
+            RequestToPay => {
+                let block: BillRequestToPayBlockData = self.get_decrypted_block_bytes(bill_keys)?;
+                Ok(Some(block.requester.node_id))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// If the block is holder-changing block (issue, endorse, sell, mint, recourse), returns
     /// the new holder and signer data from the block
     pub fn get_holder_from_block(&self, bill_keys: &BillKeys) -> Result<Option<HolderFromBlock>> {

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -238,6 +238,34 @@ pub enum ValidationError {
     #[error("Bill was not yet accepted")]
     BillNotAccepted,
 
+    /// error returned if a bill was rejected to pay
+    #[error("Bill was rejected to pay")]
+    BillWasRejectedToPay,
+
+    /// error returned if a bill payment expired
+    #[error("Bill payment expired")]
+    BillPaymentExpired,
+
+    /// error returned if a bill was rejected to accept
+    #[error("Bill was rejected to accept")]
+    BillWasRejectedToAccept,
+
+    /// error returned if a bill acceptance expired
+    #[error("Bill acceptance expired")]
+    BillAcceptanceExpired,
+
+    /// error returned if a bill was rejected to recourse
+    #[error("Bill was rejected to recourse")]
+    BillWasRejectedToRecourse,
+
+    /// error returned if a bill request to recourse expired
+    #[error("Bill request to recourse expired")]
+    BillRequestToRecourseExpired,
+
+    /// error returned if a bill was recoursed to the end
+    #[error("Bill was recoursed to the end")]
+    BillWasRecoursedToTheEnd,
+
     /// error returned if the caller of a reject operation is not the recoursee
     #[error("Caller is not the recoursee and can't reject")]
     CallerIsNotRecoursee,

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -450,6 +450,7 @@ pub struct BillStatusDb {
     pub sell: BillSellStatusDb,
     pub recourse: BillRecourseStatusDb,
     pub redeemed_funds_available: bool,
+    pub has_requested_funds: bool,
 }
 
 impl From<BillStatusDb> for BillStatus {
@@ -460,6 +461,7 @@ impl From<BillStatusDb> for BillStatus {
             sell: value.sell.into(),
             recourse: value.recourse.into(),
             redeemed_funds_available: value.redeemed_funds_available,
+            has_requested_funds: value.has_requested_funds,
         }
     }
 }
@@ -472,6 +474,7 @@ impl From<&BillStatus> for BillStatusDb {
             sell: (&value.sell).into(),
             recourse: (&value.recourse).into(),
             redeemed_funds_available: value.redeemed_funds_available,
+            has_requested_funds: value.has_requested_funds,
         }
     }
 }

--- a/crates/bcr-ebill-persistence/src/tests/mod.rs
+++ b/crates/bcr-ebill-persistence/src/tests/mod.rs
@@ -143,6 +143,7 @@ pub mod tests {
                     rejected_request_to_recourse: false,
                 },
                 redeemed_funds_available: false,
+                has_requested_funds: false,
             },
             current_waiting_state: None,
         }

--- a/crates/bcr-ebill-wasm/build.rs
+++ b/crates/bcr-ebill-wasm/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    println!("cargo:rustc-env=CRATE_VERSION={}", version);
+}

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -54,6 +54,15 @@
             Endorsee Id: <input type="text" id="endorsee_id"/>
             <button type="button" id="endorse_bill">Endorse bill to Endorsee</button>
             <button type="button" id="req_to_accept_bill">Request to Accept</button>
+            <button type="button" id="req_to_pay_bill">Request to Pay</button>
+            <button type="button" id="offer_to_sell_bill">Offer To Sell</button>
+            <button type="button" id="req_to_recourse_bill">Request to Recourse</button>
+            <br />
+            <br />
+            <button type="button" id="reject_accept">Reject Acceptance</button>
+            <button type="button" id="reject_pay">Reject Payment</button>
+            <button type="button" id="reject_buying">Reject to Buy</button>
+            <button type="button" id="reject_recourse">Reject to Recourse</button>
         </div>
         <h2>Bill Performance</h2>
         <div>
@@ -61,6 +70,7 @@
             <button type="button" id="bill_fetch_detail">Fetch Detail</button>
             <button type="button" id="bill_fetch_endorsements">Fetch Endorsements</button>
             <button type="button" id="bill_fetch_past_endorsees">Fetch Past Endorsees</button>
+            <button type="button" id="bill_fetch_past_payments">Fetch Past Payments</button>
             <button type="button" id="bill_fetch_bills">Fetch Bills</button>
             <button type="button" id="bill_balances">Fetch Balances</button>
             <button type="button" id="bill_search">Search Bills</button>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -11,11 +11,19 @@ document.getElementById("switch_identity").addEventListener("click", switchIdent
 document.getElementById("bill_fetch_detail").addEventListener("click", fetchBillDetail);
 document.getElementById("bill_fetch_endorsements").addEventListener("click", fetchBillEndorsements);
 document.getElementById("bill_fetch_past_endorsees").addEventListener("click", fetchBillPastEndorsees);
+document.getElementById("bill_fetch_past_payments").addEventListener("click", fetchBillPastPayments);
 document.getElementById("bill_fetch_bills").addEventListener("click", fetchBillBills);
 document.getElementById("bill_balances").addEventListener("click", fetchBillBalances);
 document.getElementById("bill_search").addEventListener("click", fetchBillSearch);
 document.getElementById("endorse_bill").addEventListener("click", endorseBill);
 document.getElementById("req_to_accept_bill").addEventListener("click", requestToAcceptBill);
+document.getElementById("req_to_pay_bill").addEventListener("click", requestToPayBill);
+document.getElementById("offer_to_sell_bill").addEventListener("click", offerToSellBill);
+document.getElementById("req_to_recourse_bill").addEventListener("click", requestToRecourseBill);
+document.getElementById("reject_accept").addEventListener("click", rejectAcceptBill);
+document.getElementById("reject_pay").addEventListener("click", rejectPayBill);
+document.getElementById("reject_buying").addEventListener("click", rejectBuyingBill);
+document.getElementById("reject_recourse").addEventListener("click", rejectRecourseBill);
 document.getElementById("bill_test").addEventListener("click", triggerBill);
 
 async function start() {
@@ -135,6 +143,7 @@ let generalApi = apis.generalApi;
 let identityApi = apis.identityApi;
 let billApi = apis.billApi;
 window.billApi = billApi;
+window.generalApi = generalApi;
 let notificationTriggerApi = apis.notificationApi;
 
 async function uploadFile(event) {
@@ -217,8 +226,8 @@ async function triggerBill() {
         t: 1,
         country_of_issuing: "AT",
         city_of_issuing: "Vienna",
-        issue_date: "2025-01-22",
-        maturity_date: "2025-06-22",
+        issue_date: "2024-01-22",
+        maturity_date: "2024-06-22",
         payee: identity.node_id,
         drawee: node_id,
         sum: "1500",
@@ -287,6 +296,64 @@ async function requestToAcceptBill() {
   await measured();
 }
 
+async function requestToPayBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return await billApi.request_to_pay({ bill_id, currency: "sat" });
+  });
+  await measured();
+}
+
+async function offerToSellBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let endorsee = document.getElementById("endorsee_id").value;
+  let measured = measure(async () => {
+    return await billApi.offer_to_sell({ bill_id, sum: "500", currency: "sat", buyer: endorsee });
+  });
+  await measured();
+}
+
+async function requestToRecourseBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let endorsee = document.getElementById("endorsee_id").value;
+  let measured = measure(async () => {
+    return await billApi.request_to_recourse_bill_acceptance({ bill_id, recoursee: endorsee });
+  });
+  await measured();
+}
+
+async function rejectAcceptBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return await billApi.reject_to_accept({ bill_id });
+  });
+  await measured();
+}
+
+async function rejectPayBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return await billApi.reject_to_pay({ bill_id });
+  });
+  await measured();
+}
+
+async function rejectBuyingBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return await billApi.reject_to_buy({ bill_id });
+  });
+  await measured();
+}
+
+async function rejectRecourseBill() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return await billApi.reject_to_pay_recourse({ bill_id });
+  });
+  await measured();
+}
+
 async function fetchBillDetail() {
   let measured = measure(async () => {
     return await billApi.detail(document.getElementById("bill_id").value);
@@ -304,6 +371,13 @@ async function fetchBillEndorsements() {
 async function fetchBillPastEndorsees() {
   let measured = measure(async () => {
     return await billApi.past_endorsees(document.getElementById("bill_id").value);
+  });
+  await measured();
+}
+
+async function fetchBillPastPayments() {
+  let measured = measure(async () => {
+    return await billApi.past_payments(document.getElementById("bill_id").value);
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -25,10 +25,10 @@ use crate::{
             AcceptBitcreditBillPayload, BillId, BillNumbersToWordsForSum, BillsResponse,
             BillsSearchFilterPayload, BitcreditBillPayload, EndorseBitcreditBillPayload,
             EndorsementsResponse, LightBillsResponse, MintBitcreditBillPayload,
-            OfferToSellBitcreditBillPayload, PastEndorseesResponse, RejectActionBillPayload,
-            RequestRecourseForAcceptancePayload, RequestRecourseForPaymentPayload,
-            RequestToAcceptBitcreditBillPayload, RequestToMintBitcreditBillPayload,
-            RequestToPayBitcreditBillPayload,
+            OfferToSellBitcreditBillPayload, PastEndorseesResponse, PastPaymentsResponse,
+            RejectActionBillPayload, RequestRecourseForAcceptancePayload,
+            RequestRecourseForPaymentPayload, RequestToAcceptBitcreditBillPayload,
+            RequestToMintBitcreditBillPayload, RequestToPayBitcreditBillPayload,
         },
     },
 };
@@ -53,6 +53,24 @@ impl Bill {
             .await?;
         let res = serde_wasm_bindgen::to_value(&EndorsementsResponse {
             endorsements: result.into_iter().map(|e| e.into_web()).collect(),
+        })?;
+        Ok(res)
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "PastPaymentsResponse")]
+    pub async fn past_payments(&self, id: &str) -> Result<JsValue> {
+        let (caller_public_data, caller_keys) = get_signer_public_data_and_keys().await?;
+        let result = get_ctx()
+            .bill_service
+            .get_past_payments(
+                id,
+                &caller_public_data,
+                &caller_keys,
+                util::date::now().timestamp() as u64,
+            )
+            .await?;
+        let res = serde_wasm_bindgen::to_value(&PastPaymentsResponse {
+            past_payments: result.into_iter().map(|e| e.into_web()).collect(),
         })?;
         Ok(res)
     }

--- a/crates/bcr-ebill-wasm/src/api/general.rs
+++ b/crates/bcr-ebill-wasm/src/api/general.rs
@@ -16,6 +16,8 @@ use crate::{
     },
 };
 
+pub const VERSION: &str = env!("CRATE_VERSION");
+
 #[wasm_bindgen]
 pub struct General;
 
@@ -30,7 +32,7 @@ impl General {
     pub async fn status(&self) -> Result<JsValue> {
         let res = serde_wasm_bindgen::to_value(&StatusResponse {
             bitcoin_network: get_ctx().cfg.bitcoin_network.clone(),
-            app_version: String::from("0.3.0"),
+            app_version: VERSION.to_owned(),
         })?;
         Ok(res)
     }

--- a/crates/bcr-ebill-wasm/src/constants.rs
+++ b/crates/bcr-ebill-wasm/src/constants.rs
@@ -1,2 +1,1 @@
 pub const SURREAL_DB_CON_INDXDB_DATA: &str = "indxdb://data";
-pub const API_VERSION: &str = "0.3.4";

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -4,7 +4,8 @@ use bcr_ebill_api::data::{
         BillParticipants, BillPaymentStatus, BillRecourseStatus, BillSellStatus, BillStatus,
         BillWaitingForPaymentState, BillWaitingForRecourseState, BillWaitingForSellState,
         BillsFilterRole, BitcreditBillResult, Endorsement, LightBitcreditBillResult, LightSignedBy,
-        PastEndorsee,
+        PastEndorsee, PastPaymentDataPayment, PastPaymentDataRecourse, PastPaymentDataSell,
+        PastPaymentResult, PastPaymentStatus,
     },
     contact::{IdentityPublicData, LightIdentityPublicData, LightIdentityPublicDataWithAddress},
 };
@@ -257,6 +258,143 @@ pub struct PastEndorseesResponse {
     pub past_endorsees: Vec<PastEndorseeWeb>,
 }
 
+#[derive(Tsify, Debug, Clone, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct PastPaymentsResponse {
+    pub past_payments: Vec<PastPaymentResultWeb>,
+}
+
+#[derive(Tsify, Debug, Clone, Serialize)]
+#[tsify(into_wasm_abi)]
+pub enum PastPaymentResultWeb {
+    Sell(PastPaymentDataSellWeb),
+    Payment(PastPaymentDataPaymentWeb),
+    Recourse(PastPaymentDataRecourseWeb),
+}
+
+impl IntoWeb<PastPaymentResultWeb> for PastPaymentResult {
+    fn into_web(self) -> PastPaymentResultWeb {
+        match self {
+            PastPaymentResult::Sell(state) => PastPaymentResultWeb::Sell(state.into_web()),
+            PastPaymentResult::Payment(state) => PastPaymentResultWeb::Payment(state.into_web()),
+            PastPaymentResult::Recourse(state) => PastPaymentResultWeb::Recourse(state.into_web()),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Clone, Serialize)]
+#[tsify(into_wasm_abi)]
+pub enum PastPaymentStatusWeb {
+    Paid(u64),
+    Rejected(u64),
+    Expired(u64),
+}
+
+impl IntoWeb<PastPaymentStatusWeb> for PastPaymentStatus {
+    fn into_web(self) -> PastPaymentStatusWeb {
+        match self {
+            PastPaymentStatus::Paid(ts) => PastPaymentStatusWeb::Paid(ts),
+            PastPaymentStatus::Rejected(ts) => PastPaymentStatusWeb::Rejected(ts),
+            PastPaymentStatus::Expired(ts) => PastPaymentStatusWeb::Expired(ts),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct PastPaymentDataSellWeb {
+    pub time_of_request: u64,
+    pub buyer: IdentityPublicDataWeb,
+    pub seller: IdentityPublicDataWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatusWeb,
+}
+
+impl IntoWeb<PastPaymentDataSellWeb> for PastPaymentDataSell {
+    fn into_web(self) -> PastPaymentDataSellWeb {
+        PastPaymentDataSellWeb {
+            time_of_request: self.time_of_request,
+            buyer: self.buyer.into_web(),
+            seller: self.seller.into_web(),
+            currency: self.currency,
+            sum: self.sum,
+            link_to_pay: self.link_to_pay,
+            address_to_pay: self.address_to_pay,
+            private_key_to_spend: self.private_key_to_spend,
+            mempool_link_for_address_to_pay: self.mempool_link_for_address_to_pay,
+            status: self.status.into_web(),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct PastPaymentDataPaymentWeb {
+    pub time_of_request: u64,
+    pub payer: IdentityPublicDataWeb,
+    pub payee: IdentityPublicDataWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatusWeb,
+}
+impl IntoWeb<PastPaymentDataPaymentWeb> for PastPaymentDataPayment {
+    fn into_web(self) -> PastPaymentDataPaymentWeb {
+        PastPaymentDataPaymentWeb {
+            time_of_request: self.time_of_request,
+            payer: self.payer.into_web(),
+            payee: self.payee.into_web(),
+            currency: self.currency,
+            sum: self.sum,
+            link_to_pay: self.link_to_pay,
+            address_to_pay: self.address_to_pay,
+            private_key_to_spend: self.private_key_to_spend,
+            mempool_link_for_address_to_pay: self.mempool_link_for_address_to_pay,
+            status: self.status.into_web(),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct PastPaymentDataRecourseWeb {
+    pub time_of_request: u64,
+    pub recourser: IdentityPublicDataWeb,
+    pub recoursee: IdentityPublicDataWeb,
+    pub currency: String,
+    pub sum: String,
+    pub link_to_pay: String,
+    pub address_to_pay: String,
+    pub private_key_to_spend: String,
+    pub mempool_link_for_address_to_pay: String,
+    pub status: PastPaymentStatusWeb,
+}
+
+impl IntoWeb<PastPaymentDataRecourseWeb> for PastPaymentDataRecourse {
+    fn into_web(self) -> PastPaymentDataRecourseWeb {
+        PastPaymentDataRecourseWeb {
+            time_of_request: self.time_of_request,
+            recourser: self.recourser.into_web(),
+            recoursee: self.recoursee.into_web(),
+            currency: self.currency,
+            sum: self.sum,
+            link_to_pay: self.link_to_pay,
+            address_to_pay: self.address_to_pay,
+            private_key_to_spend: self.private_key_to_spend,
+            mempool_link_for_address_to_pay: self.mempool_link_for_address_to_pay,
+            status: self.status.into_web(),
+        }
+    }
+}
+
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub struct BitcreditEbillQuote {
@@ -406,6 +544,7 @@ pub struct BillStatusWeb {
     pub sell: BillSellStatusWeb,
     pub recourse: BillRecourseStatusWeb,
     pub redeemed_funds_available: bool,
+    pub has_requested_funds: bool,
 }
 
 impl IntoWeb<BillStatusWeb> for BillStatus {
@@ -416,6 +555,7 @@ impl IntoWeb<BillStatusWeb> for BillStatus {
             sell: self.sell.into_web(),
             recourse: self.recourse.into_web(),
             redeemed_funds_available: self.redeemed_funds_available,
+            has_requested_funds: self.has_requested_funds,
         }
     }
 }

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -72,6 +72,13 @@ enum JsErrorType {
     //bill
     InvalidOperation,
     BillAlreadyAccepted,
+    BillWasRejectedToAccept,
+    BillAcceptanceExpired,
+    BillWasRejectedToPay,
+    BillPaymentExpired,
+    BillWasRejectedToRecourse,
+    BillRequestToRecourseExpired,
+    BillWasRecoursedToTheEnd,
     BillAlreadyRequestedToAccept,
     BillNotAccepted,
     CallerIsNotDrawee,
@@ -197,6 +204,21 @@ fn validation_error_data(e: ValidationError) -> JsErrorData {
         }
         ValidationError::RequestAlreadyExpired => err_400(e, JsErrorType::RequestAlreadyExpired),
         ValidationError::BillAlreadyAccepted => err_400(e, JsErrorType::BillAlreadyAccepted),
+        ValidationError::BillWasRejectedToAccept => {
+            err_400(e, JsErrorType::BillWasRejectedToAccept)
+        }
+        ValidationError::BillAcceptanceExpired => err_400(e, JsErrorType::BillAcceptanceExpired),
+        ValidationError::BillWasRejectedToPay => err_400(e, JsErrorType::BillWasRejectedToPay),
+        ValidationError::BillPaymentExpired => err_400(e, JsErrorType::BillPaymentExpired),
+        ValidationError::BillWasRejectedToRecourse => {
+            err_400(e, JsErrorType::BillWasRejectedToRecourse)
+        }
+        ValidationError::BillRequestToRecourseExpired => {
+            err_400(e, JsErrorType::BillRequestToRecourseExpired)
+        }
+        ValidationError::BillWasRecoursedToTheEnd => {
+            err_400(e, JsErrorType::BillWasRecoursedToTheEnd)
+        }
         ValidationError::BillWasNotOfferedToSell => {
             err_400(e, JsErrorType::BillWasNotOfferedToSell)
         }

--- a/crates/bcr-ebill-wasm/src/lib.rs
+++ b/crates/bcr-ebill-wasm/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arc_with_non_send_sync)]
+use api::general::VERSION;
 use bcr_ebill_api::{Config as ApiConfig, get_db_context, init};
-use constants::{API_VERSION, SURREAL_DB_CON_INDXDB_DATA};
+use constants::SURREAL_DB_CON_INDXDB_DATA;
 use context::{Context, get_ctx};
 use futures::{StreamExt, future::ready};
 use gloo_timers::future::{IntervalStream, TimeoutFuture};
@@ -69,7 +70,7 @@ pub async fn initialize_api(
     let db = get_db_context(&api_config).await?;
     let keys = db.identity_store.get_or_create_key_pair().await?;
 
-    info!("Initialized WASM API {}", API_VERSION);
+    info!("Initialized WASM API {}", VERSION);
     info!("Local node id: {:?}", keys.get_public_key());
     info!("Local npub: {:?}", keys.get_nostr_npub());
     info!("Local npub as hex: {:?}", keys.get_nostr_npub_as_hex());

--- a/crates/bcr-ebill-web/src/data.rs
+++ b/crates/bcr-ebill-web/src/data.rs
@@ -916,6 +916,7 @@ pub struct BillStatusWeb {
     pub sell: BillSellStatusWeb,
     pub recourse: BillRecourseStatusWeb,
     pub redeemed_funds_available: bool,
+    pub has_requested_funds: bool,
 }
 
 impl IntoWeb<BillStatusWeb> for BillStatus {
@@ -926,6 +927,7 @@ impl IntoWeb<BillStatusWeb> for BillStatus {
             sell: self.sell.into_web(),
             recourse: self.recourse.into_web(),
             redeemed_funds_available: self.redeemed_funds_available,
+            has_requested_funds: self.has_requested_funds,
         }
     }
 }

--- a/crates/bcr-ebill-web/src/handlers/mod.rs
+++ b/crates/bcr-ebill-web/src/handlers/mod.rs
@@ -318,6 +318,13 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ValidationError {
                 | bcr_ebill_api::util::ValidationError::BuyerCantBeSeller
                 | bcr_ebill_api::util::ValidationError::RecourserCantBeRecoursee
                 | bcr_ebill_api::util::ValidationError::BillAlreadyAccepted
+                | bcr_ebill_api::util::ValidationError::BillWasRejectedToAccept
+                | bcr_ebill_api::util::ValidationError::BillAcceptanceExpired
+                | bcr_ebill_api::util::ValidationError::BillWasRejectedToPay
+                | bcr_ebill_api::util::ValidationError::BillPaymentExpired
+                | bcr_ebill_api::util::ValidationError::BillWasRejectedToRecourse
+                | bcr_ebill_api::util::ValidationError::BillRequestToRecourseExpired
+                | bcr_ebill_api::util::ValidationError::BillWasRecoursedToTheEnd
                 | bcr_ebill_api::util::ValidationError::BillWasNotOfferedToSell
                 | bcr_ebill_api::util::ValidationError::BillWasNotRequestedToPay
                 | bcr_ebill_api::util::ValidationError::BillWasNotRequestedToAccept


### PR DESCRIPTION
## 📝 Description

* Add additional validation rules for rejection, expiration and recourse
* Add flag for `has_requested_payment`, which indicates if there is a payment request (offer to sell, req to pay, recourse) with the caller as beneficiary
* Add endpoint `past_payments`, which returns data for payments and payment requests, together with their metadata and results

Relates to #467 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. Create bills with req to pay / offer to sell / recourse combinations and call past_payments to check the data

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #467 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
