### PR TITLE
Fix request to recourse accept validation

### DIFF
--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-api"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-core"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-persistence/Cargo.toml
+++ b/crates/bcr-ebill-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-persistence"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-transport"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-wasm/Cargo.toml
+++ b/crates/bcr-ebill-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-wasm"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-web/Cargo.toml
+++ b/crates/bcr-ebill-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-web"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## 📝 Description

Fix req to recourse accept validation to not require a request to accept.
If the bill was rejected to accept without a request to accept, it can also be recoursed.

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. reject to accept a bill, req to recourse

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
