### PR TITLE
Blank Bill Endorsement Data Model Baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # 0.3.8
 
 * Add Blank Endorse Bill data model implementation
-    * Rename `IdentityPublicData` to `BillIdentifiedParticipant`
+    * Rename `IdentityPublicData` to `BillIdentParticipant`
         * same for `LightIdentityPublicData`
-    * Introduce the concept of `BillParticipant`, with the variants `Identified` and `Anonymous`
-        * `Anonymous` includes a `BillAnonymousParticipant`
-        * `Identified` includes a `BillIdentifiedParticipant`
+    * Introduce the concept of `BillParticipant`, with the variants `Ident` and `Anon`
+        * `Anon` includes a `BillAnonParticipant`
+        * `Ident` includes a `BillIdentParticipant`
     * Use `BillParticipant` in parts of the bill where a participant can be anonymous
 
 # 0.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.8
+
+* Add Blank Endorse Bill data model implementation
+    * Rename `IdentityPublicData` to `BillIdentifiedParticipant`
+        * same for `LightIdentityPublicData`
+    * Introduce the concept of `BillParticipant`, with the variants `Identified` and `Anonymous`
+        * `Anonymous` includes a `BillAnonymousParticipant`
+        * `Identified` includes a `BillIdentifiedParticipant`
+    * Use `BillParticipant` in parts of the bill where a participant can be anonymous
+
 # 0.3.7
 
 * Fix request recourse to accept validation - does not require a request to accept anymore

--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-api"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
@@ -43,7 +43,7 @@ impl BillService {
 
         let block = match bill_action {
             BillAction::Accept => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let block_data = BillAcceptBlockData {
                         accepter: signer.clone().into(),
                         signatory: signing_keys.signatory_identity,
@@ -61,7 +61,7 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
             BillAction::RequestAcceptance => {
@@ -102,7 +102,7 @@ impl BillService {
                 )?
             }
             BillAction::RequestRecourse(recoursee, recourse_reason) => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let (sum, currency, reason) = match *recourse_reason {
                         RecourseReason::Accept => (
                             bill.sum,
@@ -134,11 +134,11 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
             BillAction::Recourse(recoursee, sum, currency, recourse_reason) => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let reason = match *recourse_reason {
                         RecourseReason::Accept => BillRecourseReasonBlockData::Accept,
                         RecourseReason::Pay(_, _) => BillRecourseReasonBlockData::Pay,
@@ -164,7 +164,7 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
             BillAction::Mint(mint, sum, currency) => {
@@ -255,7 +255,7 @@ impl BillService {
                 )?
             }
             BillAction::RejectAcceptance => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let block_data = BillRejectBlockData {
                         rejecter: signer.clone().into(),
                         signatory: signing_keys.signatory_identity,
@@ -273,7 +273,7 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
             BillAction::RejectBuying => {
@@ -295,7 +295,7 @@ impl BillService {
                 )?
             }
             BillAction::RejectPayment => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let block_data = BillRejectBlockData {
                         rejecter: signer.clone().into(),
                         signatory: signing_keys.signatory_identity,
@@ -313,11 +313,11 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
             BillAction::RejectPaymentForRecourse => {
-                if let BillParticipant::Identified(signer) = signer_public_data {
+                if let BillParticipant::Ident(signer) = signer_public_data {
                     let block_data = BillRejectBlockData {
                         rejecter: signer.clone().into(),
                         signatory: signing_keys.signatory_identity,
@@ -335,7 +335,7 @@ impl BillService {
                         timestamp,
                     )?
                 } else {
-                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnon));
                 }
             }
         };
@@ -381,7 +381,7 @@ impl BillService {
         timestamp: u64,
     ) -> Result<()> {
         match signer_public_data {
-            BillParticipant::Identified(identified) => {
+            BillParticipant::Ident(identified) => {
                 match identified.t {
                     ContactType::Person => {
                         self.add_block_to_identity_chain_for_signed_bill_action(
@@ -418,7 +418,7 @@ impl BillService {
                 };
             }
             // for anon, we only add to our identity chain, since we're no company
-            BillParticipant::Anonymous(_) => {
+            BillParticipant::Anon(_) => {
                 self.add_block_to_identity_chain_for_signed_bill_action(
                     bill_id,
                     block,

--- a/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
@@ -1,5 +1,5 @@
 use bcr_ebill_core::{
-    Validate,
+    Validate, ValidationError,
     bill::{BillKeys, BitcreditBill, RecourseReason},
     blockchain::{
         self, Blockchain,
@@ -8,8 +8,8 @@ use bcr_ebill_core::{
             block::{
                 BillAcceptBlockData, BillEndorseBlockData, BillMintBlockData,
                 BillOfferToSellBlockData, BillRecourseBlockData, BillRecourseReasonBlockData,
-                BillRejectBlockData, BillRequestRecourseBlockData, BillRequestToAcceptBlockData,
-                BillRequestToPayBlockData, BillSellBlockData,
+                BillRejectBlockData, BillRejectToBuyBlockData, BillRequestRecourseBlockData,
+                BillRequestToAcceptBlockData, BillRequestToPayBlockData, BillSellBlockData, NodeId,
             },
         },
         company::{CompanyBlock, CompanySignCompanyBillBlockData},
@@ -18,7 +18,7 @@ use bcr_ebill_core::{
         },
     },
     company::CompanyKeys,
-    contact::{ContactType, IdentityPublicData},
+    contact::{BillParticipant, ContactType},
     identity::IdentityWithAll,
     util::BcrKeys,
 };
@@ -32,7 +32,7 @@ impl BillService {
         blockchain: &mut BillBlockchain,
         bill_keys: &BillKeys,
         bill_action: &BillAction,
-        signer_public_data: &IdentityPublicData,
+        signer_public_data: &BillParticipant,
         signer_keys: &BcrKeys,
         identity: &IdentityWithAll,
         timestamp: u64,
@@ -43,29 +43,33 @@ impl BillService {
 
         let block = match bill_action {
             BillAction::Accept => {
-                let block_data = BillAcceptBlockData {
-                    accepter: signer_public_data.clone().into(),
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_accept(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(), // company keys
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let block_data = BillAcceptBlockData {
+                        accepter: signer.clone().into(),
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_accept(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(), // company keys
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
             BillAction::RequestAcceptance => {
                 let block_data = BillRequestToAcceptBlockData {
                     requester: signer_public_data.clone().into(),
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_request_to_accept(
@@ -84,7 +88,7 @@ impl BillService {
                     currency: currency.to_owned(),
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_request_to_pay(
@@ -98,62 +102,70 @@ impl BillService {
                 )?
             }
             BillAction::RequestRecourse(recoursee, recourse_reason) => {
-                let (sum, currency, reason) = match *recourse_reason {
-                    RecourseReason::Accept => (
-                        bill.sum,
-                        bill.currency.clone(),
-                        BillRecourseReasonBlockData::Accept,
-                    ),
-                    RecourseReason::Pay(sum, ref currency) => {
-                        (sum, currency.to_owned(), BillRecourseReasonBlockData::Pay)
-                    }
-                };
-                let block_data = BillRequestRecourseBlockData {
-                    recourser: signer_public_data.clone().into(),
-                    recoursee: recoursee.clone().into(),
-                    sum,
-                    currency: currency.to_owned(),
-                    recourse_reason: reason,
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_request_recourse(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(),
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let (sum, currency, reason) = match *recourse_reason {
+                        RecourseReason::Accept => (
+                            bill.sum,
+                            bill.currency.clone(),
+                            BillRecourseReasonBlockData::Accept,
+                        ),
+                        RecourseReason::Pay(sum, ref currency) => {
+                            (sum, currency.to_owned(), BillRecourseReasonBlockData::Pay)
+                        }
+                    };
+                    let block_data = BillRequestRecourseBlockData {
+                        recourser: signer.clone().into(),
+                        recoursee: recoursee.clone().into(),
+                        sum,
+                        currency: currency.to_owned(),
+                        recourse_reason: reason,
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_request_recourse(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(),
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
             BillAction::Recourse(recoursee, sum, currency, recourse_reason) => {
-                let reason = match *recourse_reason {
-                    RecourseReason::Accept => BillRecourseReasonBlockData::Accept,
-                    RecourseReason::Pay(_, _) => BillRecourseReasonBlockData::Pay,
-                };
-                let block_data = BillRecourseBlockData {
-                    recourser: signer_public_data.clone().into(),
-                    recoursee: recoursee.clone().into(),
-                    sum: *sum,
-                    currency: currency.to_owned(),
-                    recourse_reason: reason,
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_recourse(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(),
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let reason = match *recourse_reason {
+                        RecourseReason::Accept => BillRecourseReasonBlockData::Accept,
+                        RecourseReason::Pay(_, _) => BillRecourseReasonBlockData::Pay,
+                    };
+                    let block_data = BillRecourseBlockData {
+                        recourser: signer.clone().into(),
+                        recoursee: recoursee.clone().into(),
+                        sum: *sum,
+                        currency: currency.to_owned(),
+                        recourse_reason: reason,
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_recourse(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(),
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
             BillAction::Mint(mint, sum, currency) => {
                 let block_data = BillMintBlockData {
@@ -163,7 +175,7 @@ impl BillService {
                     sum: *sum,
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_mint(
@@ -179,7 +191,7 @@ impl BillService {
             BillAction::OfferToSell(buyer, sum, currency) => {
                 let address_to_pay = self
                     .bitcoin_client
-                    .get_address_to_pay(&bill_keys.public_key, &signer_public_data.node_id)?;
+                    .get_address_to_pay(&bill_keys.public_key, &signer_public_data.node_id())?;
                 let block_data = BillOfferToSellBlockData {
                     seller: signer_public_data.clone().into(),
                     buyer: buyer.clone().into(),
@@ -188,7 +200,7 @@ impl BillService {
                     payment_address: address_to_pay,
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_offer_to_sell(
@@ -210,7 +222,7 @@ impl BillService {
                     payment_address: payment_address.to_owned(),
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_sell(
@@ -229,7 +241,7 @@ impl BillService {
                     endorsee: endorsee.clone().into(),
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_endorse(
@@ -243,29 +255,33 @@ impl BillService {
                 )?
             }
             BillAction::RejectAcceptance => {
-                let block_data = BillRejectBlockData {
-                    rejecter: signer_public_data.clone().into(),
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_reject_to_accept(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(),
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let block_data = BillRejectBlockData {
+                        rejecter: signer.clone().into(),
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_reject_to_accept(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(),
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
             BillAction::RejectBuying => {
-                let block_data = BillRejectBlockData {
+                let block_data = BillRejectToBuyBlockData {
                     rejecter: signer_public_data.clone().into(),
                     signatory: signing_keys.signatory_identity,
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
+                    signing_address: signer_public_data.postal_address(),
                 };
                 block_data.validate()?;
                 BillBlock::create_block_for_reject_to_buy(
@@ -279,40 +295,48 @@ impl BillService {
                 )?
             }
             BillAction::RejectPayment => {
-                let block_data = BillRejectBlockData {
-                    rejecter: signer_public_data.clone().into(),
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_reject_to_pay(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(),
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let block_data = BillRejectBlockData {
+                        rejecter: signer.clone().into(),
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_reject_to_pay(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(),
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
             BillAction::RejectPaymentForRecourse => {
-                let block_data = BillRejectBlockData {
-                    rejecter: signer_public_data.clone().into(),
-                    signatory: signing_keys.signatory_identity,
-                    signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address.clone(),
-                };
-                block_data.validate()?;
-                BillBlock::create_block_for_reject_to_pay_recourse(
-                    bill_id.to_owned(),
-                    previous_block,
-                    &block_data,
-                    &signing_keys.signatory_keys,
-                    signing_keys.company_keys.as_ref(),
-                    &BcrKeys::from_private_key(&bill_keys.private_key)?,
-                    timestamp,
-                )?
+                if let BillParticipant::Identified(signer) = signer_public_data {
+                    let block_data = BillRejectBlockData {
+                        rejecter: signer.clone().into(),
+                        signatory: signing_keys.signatory_identity,
+                        signing_timestamp: timestamp,
+                        signing_address: signer.postal_address.clone(),
+                    };
+                    block_data.validate()?;
+                    BillBlock::create_block_for_reject_to_pay_recourse(
+                        bill_id.to_owned(),
+                        previous_block,
+                        &block_data,
+                        &signing_keys.signatory_keys,
+                        signing_keys.company_keys.as_ref(),
+                        &BcrKeys::from_private_key(&bill_keys.private_key)?,
+                        timestamp,
+                    )?
+                } else {
+                    return Err(Error::Validation(ValidationError::SignerCantBeAnonymous));
+                }
             }
         };
 
@@ -349,15 +373,52 @@ impl BillService {
 
     pub(super) async fn add_identity_and_company_chain_blocks_for_signed_bill_action(
         &self,
-        signer_public_data: &IdentityPublicData,
+        signer_public_data: &BillParticipant,
         bill_id: &str,
         block: &BillBlock,
         identity_keys: &BcrKeys,
         signer_keys: &BcrKeys,
         timestamp: u64,
     ) -> Result<()> {
-        match signer_public_data.t {
-            ContactType::Person => {
+        match signer_public_data {
+            BillParticipant::Identified(identified) => {
+                match identified.t {
+                    ContactType::Person => {
+                        self.add_block_to_identity_chain_for_signed_bill_action(
+                            bill_id,
+                            block,
+                            identity_keys,
+                            timestamp,
+                        )
+                        .await?;
+                    }
+                    ContactType::Company => {
+                        self.add_block_to_company_chain_for_signed_bill_action(
+                            &identified.node_id, // company id
+                            bill_id,
+                            block,
+                            identity_keys,
+                            &CompanyKeys {
+                                private_key: signer_keys.get_private_key_string(),
+                                public_key: signer_keys.get_public_key(),
+                            },
+                            timestamp,
+                        )
+                        .await?;
+
+                        self.add_block_to_identity_chain_for_signed_company_bill_action(
+                            &identified.node_id, // company id
+                            bill_id,
+                            block,
+                            identity_keys,
+                            timestamp,
+                        )
+                        .await?;
+                    }
+                };
+            }
+            // for anon, we only add to our identity chain, since we're no company
+            BillParticipant::Anonymous(_) => {
                 self.add_block_to_identity_chain_for_signed_bill_action(
                     bill_id,
                     block,
@@ -366,30 +427,7 @@ impl BillService {
                 )
                 .await?;
             }
-            ContactType::Company => {
-                self.add_block_to_company_chain_for_signed_bill_action(
-                    &signer_public_data.node_id, // company id
-                    bill_id,
-                    block,
-                    identity_keys,
-                    &CompanyKeys {
-                        private_key: signer_keys.get_private_key_string(),
-                        public_key: signer_keys.get_public_key(),
-                    },
-                    timestamp,
-                )
-                .await?;
-
-                self.add_block_to_identity_chain_for_signed_company_bill_action(
-                    &signer_public_data.node_id, // company id
-                    bill_id,
-                    block,
-                    identity_keys,
-                    timestamp,
-                )
-                .await?;
-            }
-        };
+        }
         Ok(())
     }
 

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -102,7 +102,7 @@ impl BillService {
         signatory_identity: &IdentityWithAll,
     ) -> BillSigningKeys {
         match signer_public_data {
-            BillParticipant::Identified(identified) => {
+            BillParticipant::Ident(identified) => {
                 let (signatory_keys, company_keys, signatory_identity) = match identified.t {
                     ContactType::Person => (signer_keys.clone(), None, None),
                     ContactType::Company => (
@@ -117,7 +117,7 @@ impl BillService {
                     signatory_identity,
                 }
             }
-            BillParticipant::Anonymous(_) => BillSigningKeys {
+            BillParticipant::Anon(_) => BillSigningKeys {
                 signatory_keys: signer_keys.clone(),
                 company_keys: None,
                 signatory_identity: None,

--- a/crates/bcr-ebill-api/src/service/bill_service/issue.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/issue.rs
@@ -102,13 +102,13 @@ impl BillService {
             language: data.language,
             drawee: public_data_drawee,
             drawer: data.drawer_public_data.clone(),
-            payee: BillParticipant::Identified(public_data_payee), // TODO: support anon
+            payee: BillParticipant::Ident(public_data_payee), // TODO: support anon
             endorsee: None,
             files: bill_files,
         };
 
         let signing_keys = self.get_bill_signing_keys(
-            &BillParticipant::Identified(data.drawer_public_data.clone()), // drawer has to be identified
+            &BillParticipant::Ident(data.drawer_public_data.clone()), // drawer has to be identified
             &data.drawer_keys,
             &identity,
         );
@@ -132,7 +132,7 @@ impl BillService {
         self.blockchain_store.add_block(&bill.id, block).await?;
 
         self.add_identity_and_company_chain_blocks_for_signed_bill_action(
-            &BillParticipant::Identified(data.drawer_public_data.clone()), // drawer is identified
+            &BillParticipant::Ident(data.drawer_public_data.clone()), // drawer is identified
             &bill_id,
             block,
             &identity.key_pair,

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -5,7 +5,7 @@ use crate::data::{
         BillCombinedBitcoinKey, BillKeys, BillsBalanceOverview, BillsFilterRole, BitcreditBill,
         BitcreditBillResult, Endorsement, LightBitcreditBillResult, PastEndorsee,
     },
-    contact::BillIdentifiedParticipant,
+    contact::BillIdentParticipant,
     identity::Identity,
 };
 use crate::util::BcrKeys;
@@ -62,7 +62,7 @@ pub trait BillServiceApi: ServiceTraitBounds {
     async fn get_combined_bitcoin_key_for_bill(
         &self,
         bill_id: &str,
-        caller_public_data: &BillIdentifiedParticipant,
+        caller_public_data: &BillIdentParticipant,
         caller_keys: &BcrKeys,
     ) -> Result<BillCombinedBitcoinKey>;
 
@@ -104,7 +104,7 @@ pub trait BillServiceApi: ServiceTraitBounds {
         &self,
         bill_id: &str,
         bill_action: BillAction,
-        signer_public_data: &BillIdentifiedParticipant,
+        signer_public_data: &BillIdentParticipant,
         signer_keys: &BcrKeys,
         timestamp: u64,
     ) -> Result<BillBlockchain>;
@@ -137,7 +137,7 @@ pub trait BillServiceApi: ServiceTraitBounds {
     async fn get_past_payments(
         &self,
         bill_id: &str,
-        caller_public_data: &BillIdentifiedParticipant,
+        caller_public_data: &BillIdentParticipant,
         caller_keys: &BcrKeys,
         timestamp: u64,
     ) -> Result<Vec<PastPaymentResult>>;
@@ -210,13 +210,13 @@ pub mod tests {
         let mut bill2 = get_baseline_bill("4321");
         bill2.sum = 2000;
         bill2.drawee = bill_identified_participant_only_node_id(company_node_id.clone());
-        bill2.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill2.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         let mut bill3 = get_baseline_bill("9999");
         bill3.sum = 20000;
         bill3.drawer = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
-        bill3.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill3.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             company_node_id.clone(),
         ));
         bill3.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
@@ -281,12 +281,12 @@ pub mod tests {
         bill2.drawee = bill_identified_participant_only_node_id(company_node_id.clone());
         let mut payee = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
         payee.name = "hayek".to_string();
-        bill2.payee = BillParticipant::Identified(payee);
+        bill2.payee = BillParticipant::Ident(payee);
         let mut bill3 = get_baseline_bill("9999");
         bill3.issue_date = "2030-05-01".to_string();
         bill3.sum = 20000;
         bill3.drawer = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
-        bill3.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill3.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             company_node_id.clone(),
         ));
         bill3.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
@@ -443,7 +443,7 @@ pub mod tests {
                 city_of_payment: String::from("Vienna"),
                 language: String::from("en-UK"),
                 file_upload_ids: vec![TEST_BILL_ID.to_string()],
-                drawer_public_data: BillIdentifiedParticipant::new(drawer.identity).unwrap(),
+                drawer_public_data: BillIdentParticipant::new(drawer.identity).unwrap(),
                 drawer_keys: drawer.key_pair,
                 timestamp: 1731593928,
             })
@@ -500,7 +500,7 @@ pub mod tests {
                 city_of_payment: String::from("Vienna"),
                 language: String::from("en-UK"),
                 file_upload_ids: vec![TEST_BILL_ID.to_string()],
-                drawer_public_data: BillIdentifiedParticipant::from(drawer.1.0),
+                drawer_public_data: BillIdentParticipant::from(drawer.1.0),
                 drawer_keys: BcrKeys::from_private_key(&drawer.1.1.private_key).unwrap(),
                 timestamp: 1731593928,
             })
@@ -614,8 +614,8 @@ pub mod tests {
     async fn get_bills_baseline() {
         let mut ctx = get_ctx();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
 
         ctx.bill_blockchain_store
@@ -651,13 +651,13 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut chain_bill = get_baseline_bill("4321");
-        chain_bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+        chain_bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(identity.identity.clone()).unwrap(),
         );
         let mut bill = get_baseline_cached_bill(TEST_BILL_ID.to_string());
         // make sure the local identity is part of the bill
-        bill.participants.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+        bill.participants.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(identity.identity.clone()).unwrap(),
         );
         bill.participants
             .all_participant_node_ids
@@ -698,13 +698,13 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut chain_bill = get_baseline_bill("4321");
-        chain_bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+        chain_bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(identity.identity.clone()).unwrap(),
         );
         let mut bill = get_baseline_cached_bill(TEST_BILL_ID.to_string());
         // make sure the local identity is part of the bill
-        bill.participants.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+        bill.participants.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(identity.identity.clone()).unwrap(),
         );
         bill.participants
             .all_participant_node_ids
@@ -752,8 +752,8 @@ pub mod tests {
         let mut ctx = get_ctx();
         let company_node_id = BcrKeys::new().get_public_key();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
         ctx.bill_blockchain_store
             .expect_get_chain()
@@ -787,8 +787,8 @@ pub mod tests {
     async fn get_bills_req_to_pay() {
         let mut ctx = get_ctx();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
         ctx.bill_blockchain_store
             .expect_get_chain()
@@ -799,8 +799,8 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillRequestToPayBlockData {
-                        requester: BillParticipantBlockData::Identified(
-                            BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        requester: BillParticipantBlockData::Ident(
+                            BillIdentParticipant::new(get_baseline_identity().identity)
                                 .unwrap()
                                 .into(),
                         ),
@@ -892,7 +892,7 @@ pub mod tests {
         let mut bill = get_baseline_cached_bill(TEST_BILL_ID.to_string());
         // make sure the local identity is part of the bill
         bill.participants.drawee =
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+            BillIdentParticipant::new(identity.identity.clone()).unwrap();
         let drawee_node_id = bill.participants.drawee.node_id.clone();
         bill.participants
             .all_participant_node_ids
@@ -936,7 +936,7 @@ pub mod tests {
         let mut bill = get_baseline_cached_bill(TEST_BILL_ID.to_string());
         // make sure the local identity is part of the bill
         bill.participants.drawee =
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+            BillIdentParticipant::new(identity.identity.clone()).unwrap();
         let drawee_node_id = bill.participants.drawee.node_id.clone();
         bill.participants
             .all_participant_node_ids
@@ -2063,7 +2063,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Accept,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2098,7 +2098,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Accept,
-                &BillIdentifiedParticipant::from(company.1.0),
+                &BillIdentParticipant::from(company.1.0),
                 &BcrKeys::from_private_key(&company.1.1.private_key).unwrap(),
                 1731593928,
             )
@@ -2133,7 +2133,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Accept,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2172,7 +2172,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Accept,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2186,7 +2186,7 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.maturity_date = "2022-11-12".to_string(); // maturity date has to be in the past
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_store
@@ -2207,7 +2207,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RequestToPay("sat".to_string()),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2222,7 +2222,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2234,7 +2234,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RequestToPay("sat".to_string()),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2247,7 +2247,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_store
@@ -2267,7 +2267,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RequestAcceptance,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2282,7 +2282,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2294,7 +2294,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RequestAcceptance,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2307,7 +2307,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_store
@@ -2331,13 +2331,13 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Mint(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     5000,
                     "sat".to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2352,7 +2352,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_blockchain_store
@@ -2369,13 +2369,13 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Mint(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     5000,
                     "sat".to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2388,7 +2388,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2400,11 +2400,11 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Mint(
-                    BillParticipant::Identified(empty_bill_identified_participant()),
+                    BillParticipant::Ident(empty_bill_identified_participant()),
                     5000,
                     "sat".to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2417,7 +2417,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_store
@@ -2436,13 +2436,13 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::OfferToSell(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     15000,
                     "sat".to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2457,7 +2457,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2469,13 +2469,13 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::OfferToSell(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     15000,
                     "sat".to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2488,7 +2488,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         let buyer = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
@@ -2505,7 +2505,7 @@ pub mod tests {
                     chain.get_latest_block(),
                     &BillOfferToSellBlockData {
                         seller: bill.payee.clone().into(),
-                        buyer: BillParticipantBlockData::Identified(buyer_clone.clone().into()),
+                        buyer: BillParticipantBlockData::Ident(buyer_clone.clone().into()),
                         currency: "sat".to_owned(),
                         sum: 15000,
                         payment_address: "tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0".to_owned(),
@@ -2533,12 +2533,12 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Sell(
-                    BillParticipant::Identified(buyer),
+                    BillParticipant::Ident(buyer),
                     15000,
                     "sat".to_string(),
                     VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2554,7 +2554,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         let buyer = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
@@ -2595,12 +2595,12 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Sell(
-                    BillParticipant::Identified(buyer),
+                    BillParticipant::Ident(buyer),
                     15000,
                     "sat".to_string(),
                     VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2613,7 +2613,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_blockchain_store
@@ -2629,14 +2629,14 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Sell(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     15000,
                     "sat".to_string(),
                     VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2649,7 +2649,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2661,14 +2661,14 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::Sell(
-                    BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    BillParticipant::Ident(bill_identified_participant_only_node_id(
                         BcrKeys::new().get_public_key(),
                     )),
                     15000,
                     "sat".to_string(),
                     VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2681,7 +2681,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_store
@@ -2699,10 +2699,10 @@ pub mod tests {
         let res = service
             .execute_bill_action(
                 TEST_BILL_ID,
-                BillAction::Endorse(BillParticipant::Identified(
+                BillAction::Endorse(BillParticipant::Ident(
                     bill_identified_participant_only_node_id(BcrKeys::new().get_public_key()),
                 )),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2717,7 +2717,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.identity.node_id.clone(),
         ));
         ctx.bill_blockchain_store
@@ -2738,10 +2738,10 @@ pub mod tests {
         let res = service
             .execute_bill_action(
                 TEST_BILL_ID,
-                BillAction::Endorse(BillParticipant::Identified(
+                BillAction::Endorse(BillParticipant::Ident(
                     bill_identified_participant_only_node_id(BcrKeys::new().get_public_key()),
                 )),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2761,7 +2761,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2772,10 +2772,10 @@ pub mod tests {
         let res = service
             .execute_bill_action(
                 TEST_BILL_ID,
-                BillAction::Endorse(BillParticipant::Identified(
+                BillAction::Endorse(BillParticipant::Ident(
                     empty_bill_identified_participant(),
                 )),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -2789,7 +2789,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             identity.key_pair.get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2800,7 +2800,7 @@ pub mod tests {
         let res = service
             .get_combined_bitcoin_key_for_bill(
                 TEST_BILL_ID,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
             )
             .await;
@@ -2811,7 +2811,7 @@ pub mod tests {
     async fn get_combined_bitcoin_key_for_bill_err() {
         let mut ctx = get_ctx();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(bill_identified_participant_only_node_id(
+        bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
             BcrKeys::new().get_public_key(),
         ));
         ctx.bill_blockchain_store
@@ -2851,8 +2851,8 @@ pub mod tests {
     async fn check_bills_offer_to_sell_payment_baseline() {
         let mut ctx = get_ctx();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
 
         ctx.bill_store
@@ -2891,7 +2891,7 @@ pub mod tests {
         let company = get_baseline_company_data();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.payee =
-            BillParticipant::Identified(BillIdentifiedParticipant::from(company.1.0.clone()));
+            BillParticipant::Ident(BillIdentParticipant::from(company.1.0.clone()));
 
         ctx.bill_store
             .expect_get_bill_ids_waiting_for_sell_payment()
@@ -3071,7 +3071,7 @@ pub mod tests {
             .returning(|_, _, _| Ok(false));
 
         // we should have at least two participants
-        let recipient_check = function(|r: &Vec<BillIdentifiedParticipant>| r.len() >= 2);
+        let recipient_check = function(|r: &Vec<BillIdentParticipant>| r.len() >= 2);
 
         // send accept timeout notification
         ctx.notification_service
@@ -3122,7 +3122,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.drawer = BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+        bill.drawer = BillIdentParticipant::new(identity.identity.clone()).unwrap();
         ctx.bill_store.expect_exists().returning(|_| true);
         ctx.bill_blockchain_store
             .expect_get_chain()
@@ -3151,8 +3151,8 @@ pub mod tests {
             bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
         bill.drawer = drawer.clone();
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
         ctx.bill_store.expect_exists().returning(|_| true);
         let endorse_endorsee_clone = endorse_endorsee.clone();
@@ -3170,12 +3170,12 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         // endorsed by payee
-                        endorser: BillParticipantBlockData::Identified(
-                            BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        endorser: BillParticipantBlockData::Ident(
+                            BillIdentParticipant::new(get_baseline_identity().identity)
                                 .unwrap()
                                 .into(),
                         ),
@@ -3196,9 +3196,9 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillSellBlockData {
-                        buyer: BillParticipantBlockData::Identified(sell_endorsee.clone().into()),
+                        buyer: BillParticipantBlockData::Ident(sell_endorsee.clone().into()),
                         // endorsed by endorsee
-                        seller: BillParticipantBlockData::Identified(
+                        seller: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         currency: "sat".to_string(),
@@ -3221,11 +3221,11 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillMintBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             mint_endorsee.clone().into(),
                         ),
                         // endorsed by sell endorsee
-                        endorser: BillParticipantBlockData::Identified(
+                        endorser: BillParticipantBlockData::Ident(
                             sell_endorsee.clone().into(),
                         ),
                         currency: "sat".to_string(),
@@ -3273,7 +3273,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.drawer = BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+        bill.drawer = BillIdentParticipant::new(identity.identity.clone()).unwrap();
 
         ctx.bill_store.expect_exists().returning(|_| true);
         ctx.bill_blockchain_store
@@ -3294,7 +3294,7 @@ pub mod tests {
         let mut ctx = get_ctx();
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.drawer = BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+        bill.drawer = BillIdentParticipant::new(identity.identity.clone()).unwrap();
 
         ctx.bill_store.expect_exists().returning(|_| true);
         ctx.bill_blockchain_store
@@ -3316,8 +3316,8 @@ pub mod tests {
         let drawer = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
         bill.drawer = drawer.clone();
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
 
         ctx.bill_store.expect_exists().returning(|_| true);
@@ -3353,8 +3353,8 @@ pub mod tests {
 
         bill.drawer = drawer.clone();
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
 
         ctx.bill_store.expect_exists().returning(|_| true);
@@ -3373,12 +3373,12 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         // endorsed by payee
-                        endorser: BillParticipantBlockData::Identified(
-                            BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        endorser: BillParticipantBlockData::Ident(
+                            BillIdentParticipant::new(get_baseline_identity().identity)
                                 .unwrap()
                                 .into(),
                         ),
@@ -3399,9 +3399,9 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillSellBlockData {
-                        buyer: BillParticipantBlockData::Identified(sell_endorsee.clone().into()),
+                        buyer: BillParticipantBlockData::Ident(sell_endorsee.clone().into()),
                         // endorsed by endorsee
-                        seller: BillParticipantBlockData::Identified(
+                        seller: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         currency: "sat".to_string(),
@@ -3424,11 +3424,11 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillMintBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             mint_endorsee.clone().into(),
                         ),
                         // endorsed by sell endorsee
-                        endorser: BillParticipantBlockData::Identified(
+                        endorser: BillParticipantBlockData::Ident(
                             sell_endorsee.clone().into(),
                         ),
                         currency: "sat".to_string(),
@@ -3450,11 +3450,11 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         // endorsed by payee
-                        endorser: BillParticipantBlockData::Identified(
+                        endorser: BillParticipantBlockData::Ident(
                             mint_endorsee.clone().into(),
                         ),
                         signatory: None,
@@ -3474,13 +3474,13 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
-                        endorsee: BillParticipantBlockData::Identified(
-                            BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        endorsee: BillParticipantBlockData::Ident(
+                            BillIdentParticipant::new(get_baseline_identity().identity)
                                 .unwrap()
                                 .into(),
                         ),
                         // endorsed by payee
-                        endorser: BillParticipantBlockData::Identified(
+                        endorser: BillParticipantBlockData::Ident(
                             endorse_endorsee.clone().into(),
                         ),
                         signatory: None,
@@ -3554,19 +3554,19 @@ pub mod tests {
                 assert!(chain.try_add_block(offer_to_sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 assert!(chain.try_add_block(sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                 )));
                 // rejected
                 assert!(chain.try_add_block(offer_to_sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 assert!(
@@ -3576,14 +3576,14 @@ pub mod tests {
                 assert!(chain.try_add_block(offer_to_sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 // active
                 assert!(chain.try_add_block(offer_to_sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     Some(1931593928),
                 )));
 
@@ -3595,7 +3595,7 @@ pub mod tests {
         let res_past_payments = service
             .get_past_payments(
                 TEST_BILL_ID,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1931593928,
             )
@@ -3661,20 +3661,20 @@ pub mod tests {
                 assert!(chain.try_add_block(request_to_recourse_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 // recourse - paid
                 assert!(chain.try_add_block(recourse_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                 )));
                 // req to recourse
                 assert!(chain.try_add_block(request_to_recourse_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 // reject
@@ -3686,14 +3686,14 @@ pub mod tests {
                 assert!(chain.try_add_block(request_to_recourse_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
                 // active
                 assert!(chain.try_add_block(request_to_recourse_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     Some(1931593928),
                 )));
 
@@ -3705,7 +3705,7 @@ pub mod tests {
         let res_past_payments = service
             .get_past_payments(
                 TEST_BILL_ID,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1931593928,
             )
@@ -3785,7 +3785,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RejectAcceptance,
-                &BillIdentifiedParticipant::new(identity.identity).unwrap(),
+                &BillIdentParticipant::new(identity.identity).unwrap(),
                 &identity.key_pair,
                 now + 2,
             )
@@ -3816,7 +3816,7 @@ pub mod tests {
                 assert!(chain.try_add_block(offer_to_sell_block(
                     TEST_BILL_ID,
                     chain.get_latest_block(),
-                    &BillIdentifiedParticipant::new(identity_clone.clone()).unwrap(),
+                    &BillIdentParticipant::new(identity_clone.clone()).unwrap(),
                     None,
                 )));
 
@@ -3833,7 +3833,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RejectBuying,
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -3893,7 +3893,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RejectPayment,
-                &BillIdentifiedParticipant::new(identity.identity).unwrap(),
+                &BillIdentParticipant::new(identity.identity).unwrap(),
                 &identity.key_pair,
                 now + 1,
             )
@@ -3927,7 +3927,7 @@ pub mod tests {
                     chain.get_latest_block(),
                     &BillRequestRecourseBlockData {
                         recourser: bill_identified_participant_only_node_id(payee.node_id()).into(),
-                        recoursee: BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        recoursee: BillIdentParticipant::new(get_baseline_identity().identity)
                             .unwrap()
                             .into(),
                         currency: "sat".to_string(),
@@ -3958,7 +3958,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RejectPaymentForRecourse,
-                &BillIdentifiedParticipant::new(identity.identity).unwrap(),
+                &BillIdentParticipant::new(identity.identity).unwrap(),
                 &identity.key_pair,
                 now + 1,
             )
@@ -3974,8 +3974,8 @@ pub mod tests {
     async fn check_bills_in_recourse_payment_baseline() {
         let mut ctx = get_ctx();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
         );
 
         ctx.bill_store
@@ -3994,7 +3994,7 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillRequestRecourseBlockData {
-                        recourser: BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                        recourser: BillIdentParticipant::new(get_baseline_identity().identity)
                             .unwrap()
                             .into(),
                         recoursee: bill_identified_participant_only_node_id(recoursee.clone())
@@ -4035,7 +4035,7 @@ pub mod tests {
         let company = get_baseline_company_data();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.payee =
-            BillParticipant::Identified(BillIdentifiedParticipant::from(company.1.0.clone()));
+            BillParticipant::Ident(BillIdentParticipant::from(company.1.0.clone()));
 
         ctx.bill_store
             .expect_save_bill_to_cache()
@@ -4063,7 +4063,7 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillRequestRecourseBlockData {
-                        recourser: BillIdentifiedParticipant::from(company_clone.clone()).into(),
+                        recourser: BillIdentParticipant::from(company_clone.clone()).into(),
                         recoursee: bill_identified_participant_only_node_id(recoursee.clone())
                             .into(),
                         currency: "sat".to_string(),
@@ -4101,9 +4101,9 @@ pub mod tests {
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
         let payee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(payee.clone());
+        bill.payee = BillParticipant::Ident(payee.clone());
         let recoursee = payee.clone();
-        let endorsee_caller = BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+        let endorsee_caller = BillIdentParticipant::new(identity.identity.clone()).unwrap();
 
         ctx.bill_store
             .expect_save_bill_to_cache()
@@ -4117,7 +4117,7 @@ pub mod tests {
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
                         endorser: bill.payee.clone().into(),
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             endorsee_caller.clone().into(),
                         ),
                         signatory: None,
@@ -4175,7 +4175,7 @@ pub mod tests {
             .execute_bill_action(
                 TEST_BILL_ID,
                 BillAction::RequestRecourse(recoursee, RecourseReason::Accept),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -4192,9 +4192,9 @@ pub mod tests {
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
         let payee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(payee.clone());
+        bill.payee = BillParticipant::Ident(payee.clone());
         let recoursee = payee.clone();
-        let endorsee_caller = BillIdentifiedParticipant::new(identity.identity.clone()).unwrap();
+        let endorsee_caller = BillIdentParticipant::new(identity.identity.clone()).unwrap();
 
         ctx.bill_store
             .expect_save_bill_to_cache()
@@ -4209,7 +4209,7 @@ pub mod tests {
                     chain.get_latest_block(),
                     &BillEndorseBlockData {
                         endorser: bill.payee.clone().into(),
-                        endorsee: BillParticipantBlockData::Identified(
+                        endorsee: BillParticipantBlockData::Ident(
                             endorsee_caller.clone().into(),
                         ),
                         signatory: None,
@@ -4271,7 +4271,7 @@ pub mod tests {
                     recoursee,
                     RecourseReason::Pay(15000, "sat".to_string()),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )
@@ -4287,8 +4287,8 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill(TEST_BILL_ID);
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(
-            BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+        bill.payee = BillParticipant::Ident(
+            BillIdentParticipant::new(identity.identity.clone()).unwrap(),
         );
         let recoursee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
         let recoursee_clone = recoursee.clone();
@@ -4306,7 +4306,7 @@ pub mod tests {
                     TEST_BILL_ID.to_string(),
                     chain.get_latest_block(),
                     &BillRequestRecourseBlockData {
-                        recourser: BillIdentifiedParticipant::new(identity_clone.clone())
+                        recourser: BillIdentParticipant::new(identity_clone.clone())
                             .unwrap()
                             .into(),
                         recoursee: recoursee_clone.clone().into(),
@@ -4342,7 +4342,7 @@ pub mod tests {
                     "sat".to_string(),
                     RecourseReason::Pay(15000, "sat".into()),
                 ),
-                &BillIdentifiedParticipant::new(identity.identity.clone()).unwrap(),
+                &BillIdentParticipant::new(identity.identity.clone()).unwrap(),
                 &identity.key_pair,
                 1731593928,
             )

--- a/crates/bcr-ebill-api/src/service/bill_service/payment.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/payment.rs
@@ -11,7 +11,7 @@ use bcr_ebill_core::{
         },
     },
     company::{Company, CompanyKeys},
-    contact::BillIdentifiedParticipant,
+    contact::BillIdentParticipant,
     identity::{Identity, IdentityWithAll},
     util::BcrKeys,
 };
@@ -90,7 +90,7 @@ impl BillService {
                     // If we are the recourser and a bill issuer and it's paid, we add a Recourse block
                     if payment_info.recourser.node_id == identity.identity.node_id {
                         if let Some(signer_identity) =
-                            BillIdentifiedParticipant::new(identity.identity.clone())
+                            BillIdentParticipant::new(identity.identity.clone())
                         {
                             let reason = match payment_info.reason {
                                 BillRecourseReasonBlockData::Pay => RecourseReason::Pay(
@@ -147,7 +147,7 @@ impl BillService {
                                     )
                                     .await, payment_info.sum, payment_info.currency, reason),
                                     // signer identity (company)
-                                    &BillIdentifiedParticipant::from(recourser_company.0.clone()),
+                                    &BillIdentParticipant::from(recourser_company.0.clone()),
                                     // signer keys (company keys)
                                     &BcrKeys::from_private_key(&recourser_company.1.private_key)?,
                                     now,
@@ -185,7 +185,7 @@ impl BillService {
                     // If we are the seller and a bill issuer and it's paid, we add a Sell block
                     if payment_info.seller.node_id() == identity.identity.node_id {
                         if let Some(signer_identity) =
-                            BillIdentifiedParticipant::new(identity.identity.clone())
+                            BillIdentParticipant::new(identity.identity.clone())
                         {
                             let _ = self
                                 .execute_bill_action(
@@ -235,7 +235,7 @@ impl BillService {
                                     payment_info.currency,
                                     payment_info.payment_address),
                                     // signer identity (company)
-                                    &BillIdentifiedParticipant::from(seller_company.0.clone()),
+                                    &BillIdentParticipant::from(seller_company.0.clone()),
                                     // signer keys (company keys)
                                     &BcrKeys::from_private_key(&seller_company.1.private_key)?,
                                     now,

--- a/crates/bcr-ebill-api/src/service/bill_service/payment.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/payment.rs
@@ -7,11 +7,11 @@ use bcr_ebill_core::{
         Blockchain,
         bill::{
             BillOpCode, OfferToSellWaitingForPayment, RecourseWaitingForPayment,
-            block::BillRecourseReasonBlockData,
+            block::{BillRecourseReasonBlockData, NodeId},
         },
     },
     company::{Company, CompanyKeys},
-    contact::IdentityPublicData,
+    contact::BillIdentifiedParticipant,
     identity::{Identity, IdentityWithAll},
     util::BcrKeys,
 };
@@ -39,8 +39,8 @@ impl BillService {
         }
 
         let holder_public_key = match bill.endorsee {
-            None => &bill.payee.node_id,
-            Some(ref endorsee) => &endorsee.node_id,
+            None => &bill.payee.node_id(),
+            Some(ref endorsee) => &endorsee.node_id(),
         };
         let address_to_pay = self
             .bitcoin_client
@@ -90,7 +90,7 @@ impl BillService {
                     // If we are the recourser and a bill issuer and it's paid, we add a Recourse block
                     if payment_info.recourser.node_id == identity.identity.node_id {
                         if let Some(signer_identity) =
-                            IdentityPublicData::new(identity.identity.clone())
+                            BillIdentifiedParticipant::new(identity.identity.clone())
                         {
                             let reason = match payment_info.reason {
                                 BillRecourseReasonBlockData::Pay => RecourseReason::Pay(
@@ -147,7 +147,7 @@ impl BillService {
                                     )
                                     .await, payment_info.sum, payment_info.currency, reason),
                                     // signer identity (company)
-                                    &IdentityPublicData::from(recourser_company.0.clone()),
+                                    &BillIdentifiedParticipant::from(recourser_company.0.clone()),
                                     // signer keys (company keys)
                                     &BcrKeys::from_private_key(&recourser_company.1.private_key)?,
                                     now,
@@ -183,16 +183,16 @@ impl BillService {
                 if paid && sum > 0 {
                     debug!("bill {bill_id} got bought - creating sell block if we're seller");
                     // If we are the seller and a bill issuer and it's paid, we add a Sell block
-                    if payment_info.seller.node_id == identity.identity.node_id {
+                    if payment_info.seller.node_id() == identity.identity.node_id {
                         if let Some(signer_identity) =
-                            IdentityPublicData::new(identity.identity.clone())
+                            BillIdentifiedParticipant::new(identity.identity.clone())
                         {
                             let _ = self
                                 .execute_bill_action(
                                     bill_id,
                                     BillAction::Sell(
-                                    self.extend_bill_chain_identity_data_from_contacts_or_identity(
-                                        payment_info.buyer.clone(),
+                                    self.extend_bill_chain_participant_data_from_contacts_or_identity(
+                                        payment_info.buyer.clone().into(),
                                         &identity.identity,
                                         &contacts
                                     )
@@ -212,7 +212,8 @@ impl BillService {
                     let local_companies: HashMap<String, (Company, CompanyKeys)> =
                         self.company_store.get_all().await?;
                     // If a local company is the seller, create the sell block as that company
-                    if let Some(seller_company) = local_companies.get(&payment_info.seller.node_id)
+                    if let Some(seller_company) =
+                        local_companies.get(&payment_info.seller.node_id())
                     {
                         if seller_company
                             .0
@@ -224,8 +225,8 @@ impl BillService {
                                 .execute_bill_action(
                                     bill_id,
                                     BillAction::Sell(
-                                    self.extend_bill_chain_identity_data_from_contacts_or_identity(
-                                        payment_info.buyer.clone(),
+                                    self.extend_bill_chain_participant_data_from_contacts_or_identity(
+                                        payment_info.buyer.clone().into(),
                                         &identity.identity,
                                         &contacts
                                     )
@@ -234,7 +235,7 @@ impl BillService {
                                     payment_info.currency,
                                     payment_info.payment_address),
                                     // signer identity (company)
-                                    &IdentityPublicData::from(seller_company.0.clone()),
+                                    &BillIdentifiedParticipant::from(seller_company.0.clone()),
                                     // signer keys (company keys)
                                     &BcrKeys::from_private_key(&seller_company.1.private_key)?,
                                     now,

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -74,7 +74,7 @@ pub fn get_baseline_cached_bill(id: String) -> BitcreditBillResult {
         participants: BillParticipants {
             drawee: bill_identified_participant_only_node_id("drawee".to_string()),
             drawer: bill_identified_participant_only_node_id("drawer".to_string()),
-            payee: BillParticipant::Identified(bill_identified_participant_only_node_id(
+            payee: BillParticipant::Ident(bill_identified_participant_only_node_id(
                 "payee".to_string(),
             )),
             endorsee: None,
@@ -144,8 +144,8 @@ pub fn get_baseline_bill(bill_id: &str) -> BitcreditBill {
     let mut payee = empty_bill_identified_participant();
     payee.name = "payee".to_owned();
     payee.node_id = keys.get_public_key();
-    bill.payee = BillParticipant::Identified(payee);
-    bill.drawee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+    bill.payee = BillParticipant::Ident(payee);
+    bill.drawee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
     bill.id = bill_id.to_owned();
     bill
 }
@@ -271,7 +271,7 @@ pub fn get_ctx() -> MockBillContext {
 pub fn request_to_recourse_block(
     id: &str,
     first_block: &BillBlock,
-    recoursee: &BillIdentifiedParticipant,
+    recoursee: &BillIdentParticipant,
     ts: Option<u64>,
 ) -> BillBlock {
     let timestamp = ts.unwrap_or(first_block.timestamp + 1);
@@ -304,7 +304,7 @@ pub fn request_to_recourse_block(
 pub fn recourse_block(
     id: &str,
     first_block: &BillBlock,
-    recoursee: &BillIdentifiedParticipant,
+    recoursee: &BillIdentParticipant,
 ) -> BillBlock {
     BillBlock::create_block_for_recourse(
         id.to_string(),
@@ -361,7 +361,7 @@ pub fn request_to_accept_block(id: &str, first_block: &BillBlock, ts: Option<u64
         id.to_string(),
         first_block,
         &BillRequestToAcceptBlockData {
-            requester: BillParticipantBlockData::Identified(
+            requester: BillParticipantBlockData::Ident(
                 bill_identified_participant_only_node_id(
                     BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                         .unwrap()
@@ -407,7 +407,7 @@ pub fn reject_accept_block(id: &str, first_block: &BillBlock) -> BillBlock {
 pub fn offer_to_sell_block(
     id: &str,
     first_block: &BillBlock,
-    buyer: &BillIdentifiedParticipant,
+    buyer: &BillIdentParticipant,
     ts: Option<u64>,
 ) -> BillBlock {
     let timestamp = ts.unwrap_or(first_block.timestamp + 1);
@@ -415,7 +415,7 @@ pub fn offer_to_sell_block(
         id.to_string(),
         first_block,
         &BillOfferToSellBlockData {
-            seller: BillParticipantBlockData::Identified(
+            seller: BillParticipantBlockData::Ident(
                 bill_identified_participant_only_node_id(
                     BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                         .unwrap()
@@ -423,7 +423,7 @@ pub fn offer_to_sell_block(
                 )
                 .into(),
             ),
-            buyer: BillParticipantBlockData::Identified(buyer.to_owned().into()),
+            buyer: BillParticipantBlockData::Ident(buyer.to_owned().into()),
             currency: "sat".to_string(),
             sum: 15000,
             payment_address: VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
@@ -465,13 +465,13 @@ pub fn reject_buy_block(id: &str, first_block: &BillBlock) -> BillBlock {
 pub fn sell_block(
     id: &str,
     first_block: &BillBlock,
-    buyer: &BillIdentifiedParticipant,
+    buyer: &BillIdentParticipant,
 ) -> BillBlock {
     BillBlock::create_block_for_sell(
         id.to_string(),
         first_block,
         &BillSellBlockData {
-            seller: BillParticipantBlockData::Identified(
+            seller: BillParticipantBlockData::Ident(
                 bill_identified_participant_only_node_id(
                     BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                         .unwrap()
@@ -479,7 +479,7 @@ pub fn sell_block(
                 )
                 .into(),
             ),
-            buyer: BillParticipantBlockData::Identified(buyer.to_owned().into()),
+            buyer: BillParticipantBlockData::Ident(buyer.to_owned().into()),
             currency: "sat".to_string(),
             payment_address: VALID_PAYMENT_ADDRESS_TESTNET.to_string(),
             sum: 15000,
@@ -524,7 +524,7 @@ pub fn request_to_pay_block(id: &str, first_block: &BillBlock, ts: Option<u64>) 
         id.to_string(),
         first_block,
         &BillRequestToPayBlockData {
-            requester: BillParticipantBlockData::Identified(
+            requester: BillParticipantBlockData::Ident(
                 bill_identified_participant_only_node_id(
                     BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                         .unwrap()

--- a/crates/bcr-ebill-api/src/service/contact_service.rs
+++ b/crates/bcr-ebill-api/src/service/contact_service.rs
@@ -8,7 +8,7 @@ use mockall::automock;
 use crate::{
     data::{
         File, OptionalPostalAddress, PostalAddress,
-        contact::{BillIdentifiedParticipant, Contact, ContactType},
+        contact::{BillIdentParticipant, Contact, ContactType},
     },
     get_config,
     persistence::{
@@ -35,7 +35,7 @@ pub trait ContactServiceApi: Send + Sync {
     async fn get_identity_by_node_id(
         &self,
         node_id: &str,
-    ) -> Result<Option<BillIdentifiedParticipant>>;
+    ) -> Result<Option<BillIdentParticipant>>;
 
     /// Deletes the contact with the given node_id.
     async fn delete(&self, node_id: &str) -> Result<()>;
@@ -171,7 +171,7 @@ impl ContactServiceApi for ContactService {
     async fn get_identity_by_node_id(
         &self,
         node_id: &str,
-    ) -> Result<Option<BillIdentifiedParticipant>> {
+    ) -> Result<Option<BillIdentParticipant>> {
         let res = self.store.get(node_id).await?;
         Ok(res.map(|c| c.into()))
     }

--- a/crates/bcr-ebill-api/src/service/contact_service.rs
+++ b/crates/bcr-ebill-api/src/service/contact_service.rs
@@ -8,7 +8,7 @@ use mockall::automock;
 use crate::{
     data::{
         File, OptionalPostalAddress, PostalAddress,
-        contact::{Contact, ContactType, IdentityPublicData},
+        contact::{BillIdentifiedParticipant, Contact, ContactType},
     },
     get_config,
     persistence::{
@@ -32,7 +32,10 @@ pub trait ContactServiceApi: Send + Sync {
     async fn get_contact(&self, node_id: &str) -> Result<Contact>;
 
     /// Returns the contact by node id
-    async fn get_identity_by_node_id(&self, node_id: &str) -> Result<Option<IdentityPublicData>>;
+    async fn get_identity_by_node_id(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<BillIdentifiedParticipant>>;
 
     /// Deletes the contact with the given node_id.
     async fn delete(&self, node_id: &str) -> Result<()>;
@@ -165,7 +168,10 @@ impl ContactServiceApi for ContactService {
         }
     }
 
-    async fn get_identity_by_node_id(&self, node_id: &str) -> Result<Option<IdentityPublicData>> {
+    async fn get_identity_by_node_id(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<BillIdentifiedParticipant>> {
         let res = self.store.get(node_id).await?;
         Ok(res.map(|c| c.into()))
     }

--- a/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/nostr.rs
@@ -633,7 +633,7 @@ mod tests {
                 // and send an event
                 client1
                     .send(
-                        &BillParticipant::Identified(contact),
+                        &BillParticipant::Ident(contact),
                         event.try_into().expect("could not convert event"),
                     )
                     .await

--- a/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data::{bill::BitcreditBill, contact::BillIdentifiedParticipant},
+    data::{bill::BitcreditBill, contact::BillIdentParticipant},
     persistence::DbContext,
     tests::tests::{
         MockBackupStoreApiMock, MockBillChainStoreApiMock, MockBillStoreApiMock,
@@ -99,7 +99,7 @@ pub fn get_identity_public_data(
     node_id: &str,
     email: &str,
     nostr_relay: Option<&str>,
-) -> BillIdentifiedParticipant {
+) -> BillIdentParticipant {
     let mut identity = bill_identified_participant_only_node_id(node_id.to_owned());
     identity.email = Some(email.to_owned());
     identity.nostr_relay = nostr_relay.map(|nostr_relay| nostr_relay.to_owned());
@@ -108,19 +108,19 @@ pub fn get_identity_public_data(
 
 pub fn get_test_bitcredit_bill(
     id: &str,
-    payer: &BillIdentifiedParticipant,
-    payee: &BillIdentifiedParticipant,
-    drawer: Option<&BillIdentifiedParticipant>,
-    endorsee: Option<&BillIdentifiedParticipant>,
+    payer: &BillIdentParticipant,
+    payee: &BillIdentParticipant,
+    drawer: Option<&BillIdentParticipant>,
+    endorsee: Option<&BillIdentParticipant>,
 ) -> BitcreditBill {
     let mut bill = empty_bitcredit_bill();
     bill.id = id.to_owned();
-    bill.payee = BillParticipant::Identified(payee.clone());
+    bill.payee = BillParticipant::Ident(payee.clone());
     bill.drawee = payer.clone();
     if let Some(drawer) = drawer {
         bill.drawer = drawer.clone();
     }
-    bill.endorsee = endorsee.map(|e| BillParticipant::Identified(e.clone()));
+    bill.endorsee = endorsee.map(|e| BillParticipant::Ident(e.clone()));
     bill
 }
 pub async fn get_mock_relay() -> MockRelay {

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -12,7 +12,7 @@ pub mod tests {
             identity::IdentityBlock,
         },
         company::{Company, CompanyKeys},
-        contact::{BillIdentifiedParticipant, BillParticipant, Contact, ContactType},
+        contact::{BillIdentParticipant, BillParticipant, Contact, ContactType},
         identity::{ActiveIdentityState, Identity, IdentityWithAll},
         notification::{ActionType, Notification, NotificationType},
         util::crypto::BcrKeys,
@@ -262,7 +262,7 @@ pub mod tests {
             async fn send_bill_recourse_paid_event(
                 &self,
                 event: &BillChainEvent,
-                recoursee: &BillIdentifiedParticipant,
+                recoursee: &BillIdentParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_request_to_action_rejected_event(
                 &self,
@@ -275,13 +275,13 @@ pub mod tests {
                 bill_id: &str,
                 sum: Option<u64>,
                 timed_out_action: ActionType,
-                recipients: Vec<BillIdentifiedParticipant>,
+                recipients: Vec<BillIdentParticipant>,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_recourse_action_event(
                 &self,
                 event: &BillChainEvent,
                 action: ActionType,
-                recoursee: &BillIdentifiedParticipant,
+                recoursee: &BillIdentParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_request_to_mint_event(&self, sender_node_id: &str, bill: &BitcreditBill) -> bcr_ebill_transport::Result<()>;
             async fn send_new_quote_event(&self, quote: &BitcreditBill) -> bcr_ebill_transport::Result<()>;
@@ -358,8 +358,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn empty_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "some@example.com".to_string(),
@@ -370,7 +370,7 @@ pub mod tests {
     }
 
     pub fn bill_participant_only_node_id(node_id: String) -> BillParticipant {
-        BillParticipant::Identified(BillIdentifiedParticipant {
+        BillParticipant::Ident(BillIdentParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),
@@ -380,8 +380,8 @@ pub mod tests {
         })
     }
 
-    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),
@@ -398,7 +398,7 @@ pub mod tests {
             city_of_issuing: "Vienna".to_string(),
             drawee: empty_bill_identified_participant(),
             drawer: empty_bill_identified_participant(),
-            payee: BillParticipant::Identified(empty_bill_identified_participant()),
+            payee: BillParticipant::Ident(empty_bill_identified_participant()),
             endorsee: None,
             currency: "sat".to_string(),
             sum: 5000,

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -12,7 +12,7 @@ pub mod tests {
             identity::IdentityBlock,
         },
         company::{Company, CompanyKeys},
-        contact::{Contact, ContactType, IdentityPublicData},
+        contact::{BillIdentifiedParticipant, BillParticipant, Contact, ContactType},
         identity::{ActiveIdentityState, Identity, IdentityWithAll},
         notification::{ActionType, Notification, NotificationType},
         util::crypto::BcrKeys,
@@ -252,17 +252,17 @@ pub mod tests {
             async fn send_offer_to_sell_event(
                 &self,
                 event: &BillChainEvent,
-                buyer: &IdentityPublicData,
+                buyer: &BillParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_bill_is_sold_event(
                 &self,
                 event: &BillChainEvent,
-                buyer: &IdentityPublicData,
+                buyer: &BillParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_bill_recourse_paid_event(
                 &self,
                 event: &BillChainEvent,
-                recoursee: &IdentityPublicData,
+                recoursee: &BillIdentifiedParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_request_to_action_rejected_event(
                 &self,
@@ -275,13 +275,13 @@ pub mod tests {
                 bill_id: &str,
                 sum: Option<u64>,
                 timed_out_action: ActionType,
-                recipients: Vec<IdentityPublicData>,
+                recipients: Vec<BillIdentifiedParticipant>,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_recourse_action_event(
                 &self,
                 event: &BillChainEvent,
                 action: ActionType,
-                recoursee: &IdentityPublicData,
+                recoursee: &BillIdentifiedParticipant,
             ) -> bcr_ebill_transport::Result<()>;
             async fn send_request_to_mint_event(&self, sender_node_id: &str, bill: &BitcreditBill) -> bcr_ebill_transport::Result<()>;
             async fn send_new_quote_event(&self, quote: &BitcreditBill) -> bcr_ebill_transport::Result<()>;
@@ -358,8 +358,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_identity_public_data() -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "some@example.com".to_string(),
@@ -369,8 +369,19 @@ pub mod tests {
         }
     }
 
-    pub fn identity_public_data_only_node_id(node_id: String) -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn bill_participant_only_node_id(node_id: String) -> BillParticipant {
+        BillParticipant::Identified(BillIdentifiedParticipant {
+            t: ContactType::Person,
+            node_id,
+            name: "some name".to_string(),
+            postal_address: empty_address(),
+            email: None,
+            nostr_relay: None,
+        })
+    }
+
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),
@@ -385,9 +396,9 @@ pub mod tests {
             id: "".to_string(),
             country_of_issuing: "AT".to_string(),
             city_of_issuing: "Vienna".to_string(),
-            drawee: empty_identity_public_data(),
-            drawer: empty_identity_public_data(),
-            payee: empty_identity_public_data(),
+            drawee: empty_bill_identified_participant(),
+            drawer: empty_bill_identified_participant(),
+            payee: BillParticipant::Identified(empty_bill_identified_participant()),
             endorsee: None,
             currency: "sat".to_string(),
             sum: 5000,

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-core"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-core/src/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/bill/mod.rs
@@ -7,8 +7,8 @@ use crate::{
 use super::{
     File, PostalAddress,
     contact::{
-        BillIdentifiedParticipant, LightBillIdentifiedParticipant,
-        LightBillIdentifiedParticipantWithAddress,
+        BillIdentParticipant, LightBillIdentParticipant,
+        LightBillIdentParticipantWithAddress,
     },
     notification::Notification,
 };
@@ -30,9 +30,9 @@ pub enum BillAction {
     // endorsee
     Endorse(BillParticipant),
     // recoursee, recourse reason
-    RequestRecourse(BillIdentifiedParticipant, RecourseReason),
+    RequestRecourse(BillIdentParticipant, RecourseReason),
     // recoursee, sum, currency reason/
-    Recourse(BillIdentifiedParticipant, u64, String, RecourseReason),
+    Recourse(BillIdentParticipant, u64, String, RecourseReason),
     // mint, sum, currency
     Mint(BillParticipant, u64, String),
     RejectAcceptance,
@@ -64,7 +64,7 @@ pub struct BillIssueData {
     pub city_of_payment: String,
     pub language: String,
     pub file_upload_ids: Vec<String>,
-    pub drawer_public_data: BillIdentifiedParticipant,
+    pub drawer_public_data: BillIdentParticipant,
     pub drawer_keys: BcrKeys,
     pub timestamp: u64,
 }
@@ -89,9 +89,9 @@ pub struct BitcreditBill {
     pub country_of_issuing: String,
     pub city_of_issuing: String,
     // The party obliged to pay a Bill
-    pub drawee: BillIdentifiedParticipant,
+    pub drawee: BillIdentParticipant,
     // The party issuing a Bill
-    pub drawer: BillIdentifiedParticipant,
+    pub drawer: BillIdentParticipant,
     pub payee: BillParticipant,
     // The person to whom the Payee or an Endorsee endorses a bill
     pub endorsee: Option<BillParticipant>,
@@ -148,7 +148,7 @@ pub struct BillWaitingForSellState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForPaymentState {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipant,
+    pub payer: BillIdentParticipant,
     pub payee: BillParticipant,
     pub currency: String,
     pub sum: String,
@@ -160,8 +160,8 @@ pub struct BillWaitingForPaymentState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForRecourseState {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipant,
-    pub recoursee: BillIdentifiedParticipant,
+    pub recourser: BillIdentParticipant,
+    pub recoursee: BillIdentParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -234,8 +234,8 @@ pub struct BillData {
 
 #[derive(Debug, Clone)]
 pub struct BillParticipants {
-    pub drawee: BillIdentifiedParticipant,
-    pub drawer: BillIdentifiedParticipant,
+    pub drawee: BillIdentParticipant,
+    pub drawer: BillIdentParticipant,
     pub payee: BillParticipant,
     pub endorsee: Option<BillParticipant>,
     pub endorsements_count: u64,
@@ -351,8 +351,8 @@ impl BitcreditBillResult {
 #[derive(Debug, Clone)]
 pub struct LightBitcreditBillResult {
     pub id: String,
-    pub drawee: LightBillIdentifiedParticipant,
-    pub drawer: LightBillIdentifiedParticipant,
+    pub drawee: LightBillIdentParticipant,
+    pub drawer: LightBillIdentParticipant,
     pub payee: LightBillParticipant,
     pub endorsee: Option<LightBillParticipant>,
     pub active_notification: Option<Notification>,
@@ -415,7 +415,7 @@ pub enum BillsFilterRole {
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct PastEndorsee {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipant,
+    pub pay_to_the_order_of: LightBillIdentParticipant,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddress>,
@@ -423,7 +423,7 @@ pub struct PastEndorsee {
 
 #[derive(Debug)]
 pub struct Endorsement {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipantWithAddress,
+    pub pay_to_the_order_of: LightBillIdentParticipantWithAddress,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddress>,
@@ -432,7 +432,7 @@ pub struct Endorsement {
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct LightSignedBy {
     pub data: LightBillParticipant,
-    pub signatory: Option<LightBillIdentifiedParticipant>,
+    pub signatory: Option<LightBillIdentParticipant>,
 }
 
 #[derive(Debug, Clone)]
@@ -466,7 +466,7 @@ pub struct PastPaymentDataSell {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataPayment {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipant,
+    pub payer: BillIdentParticipant,
     pub payee: BillParticipant,
     pub currency: String,
     pub sum: String,
@@ -480,8 +480,8 @@ pub struct PastPaymentDataPayment {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataRecourse {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipant,
-    pub recoursee: BillIdentifiedParticipant,
+    pub recourser: BillIdentParticipant,
+    pub recoursee: BillIdentParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,

--- a/crates/bcr-ebill-core/src/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/bill/mod.rs
@@ -1,8 +1,15 @@
-use crate::{blockchain::bill::BillBlockchain, util::BcrKeys};
+use crate::{
+    blockchain::bill::{BillBlockchain, block::NodeId},
+    contact::{BillParticipant, LightBillParticipant},
+    util::BcrKeys,
+};
 
 use super::{
     File, PostalAddress,
-    contact::{IdentityPublicData, LightIdentityPublicData, LightIdentityPublicDataWithAddress},
+    contact::{
+        BillIdentifiedParticipant, LightBillIdentifiedParticipant,
+        LightBillIdentifiedParticipantWithAddress,
+    },
     notification::Notification,
 };
 use borsh_derive::{BorshDeserialize, BorshSerialize};
@@ -17,17 +24,17 @@ pub enum BillAction {
     // currency
     RequestToPay(String),
     // buyer, sum, currency
-    OfferToSell(IdentityPublicData, u64, String),
+    OfferToSell(BillParticipant, u64, String),
     // buyer, sum, currency, payment_address
-    Sell(IdentityPublicData, u64, String, String),
+    Sell(BillParticipant, u64, String, String),
     // endorsee
-    Endorse(IdentityPublicData),
+    Endorse(BillParticipant),
     // recoursee, recourse reason
-    RequestRecourse(IdentityPublicData, RecourseReason),
+    RequestRecourse(BillIdentifiedParticipant, RecourseReason),
     // recoursee, sum, currency reason/
-    Recourse(IdentityPublicData, u64, String, RecourseReason),
+    Recourse(BillIdentifiedParticipant, u64, String, RecourseReason),
     // mint, sum, currency
-    Mint(IdentityPublicData, u64, String),
+    Mint(BillParticipant, u64, String),
     RejectAcceptance,
     RejectPayment,
     RejectBuying,
@@ -57,7 +64,7 @@ pub struct BillIssueData {
     pub city_of_payment: String,
     pub language: String,
     pub file_upload_ids: Vec<String>,
-    pub drawer_public_data: IdentityPublicData,
+    pub drawer_public_data: BillIdentifiedParticipant,
     pub drawer_keys: BcrKeys,
     pub timestamp: u64,
 }
@@ -82,12 +89,12 @@ pub struct BitcreditBill {
     pub country_of_issuing: String,
     pub city_of_issuing: String,
     // The party obliged to pay a Bill
-    pub drawee: IdentityPublicData,
+    pub drawee: BillIdentifiedParticipant,
     // The party issuing a Bill
-    pub drawer: IdentityPublicData,
-    pub payee: IdentityPublicData,
+    pub drawer: BillIdentifiedParticipant,
+    pub payee: BillParticipant,
     // The person to whom the Payee or an Endorsee endorses a bill
-    pub endorsee: Option<IdentityPublicData>,
+    pub endorsee: Option<BillParticipant>,
     pub currency: String,
     pub sum: u64,
     pub maturity_date: String,
@@ -129,8 +136,8 @@ pub enum BillCurrentWaitingState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForSellState {
     pub time_of_request: u64,
-    pub buyer: IdentityPublicData,
-    pub seller: IdentityPublicData,
+    pub buyer: BillParticipant,
+    pub seller: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -141,8 +148,8 @@ pub struct BillWaitingForSellState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForPaymentState {
     pub time_of_request: u64,
-    pub payer: IdentityPublicData,
-    pub payee: IdentityPublicData,
+    pub payer: BillIdentifiedParticipant,
+    pub payee: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -153,8 +160,8 @@ pub struct BillWaitingForPaymentState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForRecourseState {
     pub time_of_request: u64,
-    pub recourser: IdentityPublicData,
-    pub recoursee: IdentityPublicData,
+    pub recourser: BillIdentifiedParticipant,
+    pub recoursee: BillIdentifiedParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -227,10 +234,10 @@ pub struct BillData {
 
 #[derive(Debug, Clone)]
 pub struct BillParticipants {
-    pub drawee: IdentityPublicData,
-    pub drawer: IdentityPublicData,
-    pub payee: IdentityPublicData,
-    pub endorsee: Option<IdentityPublicData>,
+    pub drawee: BillIdentifiedParticipant,
+    pub drawer: BillIdentifiedParticipant,
+    pub payee: BillParticipant,
+    pub endorsee: Option<BillParticipant>,
     pub endorsements_count: u64,
     pub all_participant_node_ids: Vec<String>,
 }
@@ -256,10 +263,10 @@ impl BitcreditBillResult {
 
         // Node id is payee, or, if an endorsee is set and node id is endorsee, node id is payee
         if let Some(ref endorsee) = self.participants.endorsee {
-            if endorsee.node_id == *node_id {
+            if endorsee.node_id() == *node_id {
                 return Some(BillRole::Payee);
             }
-        } else if self.participants.payee.node_id == *node_id {
+        } else if self.participants.payee.node_id() == *node_id {
             return Some(BillRole::Payee);
         }
 
@@ -274,9 +281,10 @@ impl BitcreditBillResult {
         if self
             .participants
             .payee
-            .name
-            .to_lowercase()
-            .contains(&search_term_lc)
+            .name()
+            .as_ref()
+            .map(|n| n.to_lowercase().contains(&search_term_lc))
+            .unwrap_or(false)
         {
             return true;
         }
@@ -302,7 +310,12 @@ impl BitcreditBillResult {
         }
 
         if let Some(ref endorsee) = self.participants.endorsee {
-            if endorsee.name.to_lowercase().contains(&search_term_lc) {
+            if endorsee
+                .name()
+                .as_ref()
+                .map(|n| n.to_lowercase().contains(&search_term_lc))
+                .unwrap_or(false)
+            {
                 return true;
             }
         }
@@ -312,18 +325,20 @@ impl BitcreditBillResult {
         {
             if sell_waiting_state
                 .buyer
-                .name
-                .to_lowercase()
-                .contains(&search_term_lc)
+                .name()
+                .as_ref()
+                .map(|n| n.to_lowercase().contains(&search_term_lc))
+                .unwrap_or(false)
             {
                 return true;
             }
 
             if sell_waiting_state
                 .seller
-                .name
-                .to_lowercase()
-                .contains(&search_term_lc)
+                .name()
+                .as_ref()
+                .map(|n| n.to_lowercase().contains(&search_term_lc))
+                .unwrap_or(false)
             {
                 return true;
             }
@@ -336,10 +351,10 @@ impl BitcreditBillResult {
 #[derive(Debug, Clone)]
 pub struct LightBitcreditBillResult {
     pub id: String,
-    pub drawee: LightIdentityPublicData,
-    pub drawer: LightIdentityPublicData,
-    pub payee: LightIdentityPublicData,
-    pub endorsee: Option<LightIdentityPublicData>,
+    pub drawee: LightBillIdentifiedParticipant,
+    pub drawer: LightBillIdentifiedParticipant,
+    pub payee: LightBillParticipant,
+    pub endorsee: Option<LightBillParticipant>,
     pub active_notification: Option<Notification>,
     pub sum: String,
     pub currency: String,
@@ -400,24 +415,24 @@ pub enum BillsFilterRole {
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct PastEndorsee {
-    pub pay_to_the_order_of: LightIdentityPublicData,
+    pub pay_to_the_order_of: LightBillIdentifiedParticipant,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
-    pub signing_address: PostalAddress,
+    pub signing_address: Option<PostalAddress>,
 }
 
 #[derive(Debug)]
 pub struct Endorsement {
-    pub pay_to_the_order_of: LightIdentityPublicDataWithAddress,
+    pub pay_to_the_order_of: LightBillIdentifiedParticipantWithAddress,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
-    pub signing_address: PostalAddress,
+    pub signing_address: Option<PostalAddress>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct LightSignedBy {
-    pub data: LightIdentityPublicData,
-    pub signatory: Option<LightIdentityPublicData>,
+    pub data: LightBillParticipant,
+    pub signatory: Option<LightBillIdentifiedParticipant>,
 }
 
 #[derive(Debug, Clone)]
@@ -437,8 +452,8 @@ pub enum PastPaymentStatus {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataSell {
     pub time_of_request: u64,
-    pub buyer: IdentityPublicData,
-    pub seller: IdentityPublicData,
+    pub buyer: BillParticipant,
+    pub seller: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -451,8 +466,8 @@ pub struct PastPaymentDataSell {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataPayment {
     pub time_of_request: u64,
-    pub payer: IdentityPublicData,
-    pub payee: IdentityPublicData,
+    pub payer: BillIdentifiedParticipant,
+    pub payee: BillParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -465,8 +480,8 @@ pub struct PastPaymentDataPayment {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataRecourse {
     pub time_of_request: u64,
-    pub recourser: IdentityPublicData,
-    pub recoursee: IdentityPublicData,
+    pub recourser: BillIdentifiedParticipant,
+    pub recoursee: BillIdentifiedParticipant,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,

--- a/crates/bcr-ebill-core/src/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/bill/validation.rs
@@ -588,7 +588,7 @@ mod tests {
                 tests::valid_bill_issue_block_data,
             },
         },
-        contact::{BillIdentifiedParticipant, BillParticipant},
+        contact::{BillIdentParticipant, BillParticipant},
         tests::tests::{
             OTHER_TEST_PUB_KEY_SECP, OTHER_VALID_PAYMENT_ADDRESS_TESTNET, TEST_BILL_ID,
             TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP, VALID_PAYMENT_ADDRESS_TESTNET, valid_address,
@@ -639,7 +639,7 @@ mod tests {
     #[case::drawee_equals_payee( BillIssueData { drawee: TEST_PUB_KEY_SECP.into(), payee: TEST_PUB_KEY_SECP.into(), ..valid_bill_issue_data() }, ValidationError::DraweeCantBePayee)]
     #[case::invalid_payee( BillIssueData { payee: "invalidkey".into(), ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
     #[case::invalid_drawee( BillIssueData { drawee: "invalidkey".into(),  ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
-    #[case::invalid_drawer( BillIssueData { drawer_public_data: BillIdentifiedParticipant { node_id: "invalidkey".into(), ..valid_bill_identified_participant() }, ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
+    #[case::invalid_drawer( BillIssueData { drawer_public_data: BillIdentParticipant { node_id: "invalidkey".into(), ..valid_bill_identified_participant() }, ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
     fn test_validate_bill_issue_data_errors(
         #[case] input: BillIssueData,
         #[case] expected: ValidationError,
@@ -687,15 +687,15 @@ mod tests {
 
     fn add_endorse_block(
         mut chain: BillBlockchain,
-        endorsee: BillIdentifiedParticipant,
-        endorser: BillIdentifiedParticipant,
+        endorsee: BillIdentParticipant,
+        endorser: BillIdentParticipant,
     ) -> BillBlockchain {
         let block = BillBlock::create_block_for_endorse(
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillEndorseBlockData {
-                endorser: BillParticipant::Identified(endorser).into(),
-                endorsee: BillParticipant::Identified(endorsee).into(),
+                endorser: BillParticipant::Ident(endorser).into(),
+                endorsee: BillParticipant::Ident(endorsee).into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
                 signing_address: Some(valid_address()),

--- a/crates/bcr-ebill-core/src/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/bill/validation.rs
@@ -4,7 +4,7 @@ use crate::{
         Block, Blockchain,
         bill::{
             BillOpCode, OfferToSellWaitingForPayment, RecourseWaitingForPayment,
-            block::BillRecourseReasonBlockData,
+            block::{BillRecourseReasonBlockData, NodeId},
         },
     },
     constants::{ACCEPT_DEADLINE_SECONDS, PAYMENT_DEADLINE_SECONDS, RECOURSE_DEADLINE_SECONDS},
@@ -320,8 +320,8 @@ impl Validate for BillValidateActionData {
                     if payment_info.sum != *sum
                         || payment_info.currency != *currency
                         || payment_info.payment_address != *payment_address
-                        || payment_info.buyer.node_id != buyer.node_id
-                        || payment_info.seller.node_id != self.signer_node_id
+                        || payment_info.buyer.node_id() != buyer.node_id()
+                        || payment_info.seller.node_id() != self.signer_node_id
                     {
                         return Err(ValidationError::BillSellDataInvalid);
                     }
@@ -372,7 +372,7 @@ impl Validate for BillValidateActionData {
                     )?
                 {
                     // caller has to be buyer of the offer to sell
-                    if self.signer_node_id != payment_info.buyer.node_id {
+                    if self.signer_node_id != payment_info.buyer.node_id() {
                         return Err(ValidationError::CallerIsNotBuyer);
                     }
                 } else {
@@ -583,15 +583,17 @@ mod tests {
             block::{
                 BillAcceptBlockData, BillEndorseBlockData, BillIssueBlockData,
                 BillOfferToSellBlockData, BillRecourseBlockData, BillRejectBlockData,
-                BillRequestRecourseBlockData, BillRequestToAcceptBlockData,
-                BillRequestToPayBlockData, tests::valid_bill_issue_block_data,
+                BillRejectToBuyBlockData, BillRequestRecourseBlockData,
+                BillRequestToAcceptBlockData, BillRequestToPayBlockData,
+                tests::valid_bill_issue_block_data,
             },
         },
-        contact::IdentityPublicData,
+        contact::{BillIdentifiedParticipant, BillParticipant},
         tests::tests::{
             OTHER_TEST_PUB_KEY_SECP, OTHER_VALID_PAYMENT_ADDRESS_TESTNET, TEST_BILL_ID,
             TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP, VALID_PAYMENT_ADDRESS_TESTNET, valid_address,
-            valid_identity_public_data, valid_other_identity_public_data,
+            valid_bill_identified_participant, valid_bill_participant,
+            valid_other_bill_identified_participant, valid_other_bill_participant,
         },
         util::{BcrKeys, date::now},
     };
@@ -614,7 +616,7 @@ mod tests {
             city_of_payment: "Paris".into(),
             language: "de".into(),
             file_upload_ids: vec![],
-            drawer_public_data: valid_identity_public_data(),
+            drawer_public_data: valid_bill_identified_participant(),
             drawer_keys: BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP).unwrap(),
             timestamp: 1731593928,
         }
@@ -637,7 +639,7 @@ mod tests {
     #[case::drawee_equals_payee( BillIssueData { drawee: TEST_PUB_KEY_SECP.into(), payee: TEST_PUB_KEY_SECP.into(), ..valid_bill_issue_data() }, ValidationError::DraweeCantBePayee)]
     #[case::invalid_payee( BillIssueData { payee: "invalidkey".into(), ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
     #[case::invalid_drawee( BillIssueData { drawee: "invalidkey".into(),  ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
-    #[case::invalid_drawer( BillIssueData { drawer_public_data: IdentityPublicData { node_id: "invalidkey".into(), ..valid_identity_public_data() }, ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
+    #[case::invalid_drawer( BillIssueData { drawer_public_data: BillIdentifiedParticipant { node_id: "invalidkey".into(), ..valid_bill_identified_participant() }, ..valid_bill_issue_data() }, ValidationError::InvalidSecp256k1Key("invalidkey".into()))]
     fn test_validate_bill_issue_data_errors(
         #[case] input: BillIssueData,
         #[case] expected: ValidationError,
@@ -667,10 +669,10 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRequestToAcceptBlockData {
-                requester: valid_identity_public_data().into(),
+                requester: valid_bill_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,
@@ -685,18 +687,18 @@ mod tests {
 
     fn add_endorse_block(
         mut chain: BillBlockchain,
-        endorsee: IdentityPublicData,
-        endorser: IdentityPublicData,
+        endorsee: BillIdentifiedParticipant,
+        endorser: BillIdentifiedParticipant,
     ) -> BillBlockchain {
         let block = BillBlock::create_block_for_endorse(
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillEndorseBlockData {
-                endorser: endorser.into(),
-                endorsee: endorsee.into(),
+                endorser: BillParticipant::Identified(endorser).into(),
+                endorsee: BillParticipant::Identified(endorsee).into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,
@@ -714,7 +716,7 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillAcceptBlockData {
-                accepter: valid_identity_public_data().into(),
+                accepter: valid_bill_identified_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
                 signing_address: valid_address(),
@@ -735,11 +737,11 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRequestToPayBlockData {
-                requester: valid_identity_public_data().into(),
+                requester: valid_bill_participant().into(),
                 currency: "sat".into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,
@@ -757,14 +759,14 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillOfferToSellBlockData {
-                buyer: valid_identity_public_data().into(),
-                seller: valid_other_identity_public_data().into(),
+                buyer: valid_bill_participant().into(),
+                seller: valid_other_bill_participant().into(),
                 sum: 500,
                 currency: "sat".into(),
                 payment_address: VALID_PAYMENT_ADDRESS_TESTNET.into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,
@@ -782,8 +784,8 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRequestRecourseBlockData {
-                recourser: valid_identity_public_data().into(),
-                recoursee: valid_other_identity_public_data().into(),
+                recourser: valid_bill_identified_participant().into(),
+                recoursee: valid_other_bill_identified_participant().into(),
                 sum: 500,
                 currency: "sat".into(),
                 recourse_reason: BillRecourseReasonBlockData::Accept,
@@ -807,7 +809,7 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRejectBlockData {
-                rejecter: valid_identity_public_data().into(),
+                rejecter: valid_bill_identified_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
                 signing_address: valid_address(),
@@ -828,7 +830,7 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRejectBlockData {
-                rejecter: valid_identity_public_data().into(),
+                rejecter: valid_bill_identified_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
                 signing_address: valid_address(),
@@ -848,11 +850,11 @@ mod tests {
         let block = BillBlock::create_block_for_reject_to_buy(
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
-            &BillRejectBlockData {
-                rejecter: valid_identity_public_data().into(),
+            &BillRejectToBuyBlockData {
+                rejecter: valid_bill_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,
@@ -870,7 +872,7 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRejectBlockData {
-                rejecter: valid_identity_public_data().into(),
+                rejecter: valid_bill_identified_participant().into(),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
                 signing_address: valid_address(),
@@ -891,8 +893,8 @@ mod tests {
             TEST_BILL_ID.into(),
             chain.get_latest_block(),
             &BillRecourseBlockData {
-                recourser: valid_identity_public_data().into(),
-                recoursee: valid_other_identity_public_data().into(),
+                recourser: valid_bill_identified_participant().into(),
+                recoursee: valid_other_bill_identified_participant().into(),
                 sum: 500,
                 currency: "sat".into(),
                 recourse_reason: BillRecourseReasonBlockData::Accept,
@@ -1029,9 +1031,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case::req_to_recourse_not_rejected_but_expired(BillValidateActionData { timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Ok(()))]
-    #[case::req_to_recourse_not_expired_but_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_accept_block(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data())))) }, Ok(()))]
-    #[case::req_to_recourse_not_req_to_accept_but_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Ok(()))]
+    #[case::req_to_recourse_not_rejected_but_expired(BillValidateActionData { timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Ok(()))]
+    #[case::req_to_recourse_not_expired_but_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_accept_block(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant())))) }, Ok(()))]
+    #[case::req_to_recourse_not_req_to_accept_but_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Ok(()))]
     fn test_validate_bill_req_to_recourse_accept_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1040,16 +1042,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::req_to_recourse_not_holder(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Accept), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
-    #[case::req_to_recourse_not_past_endorsee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data())) }, Err(ValidationError::RecourseeNotPastHolder))]
-    #[case::req_to_recourse_not_req_to_accept_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data())) }, Err(ValidationError::BillRequestToAcceptDidNotExpireAndWasNotRejected))]
-    #[case::req_to_recourse_not_expired_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillRequestToAcceptDidNotExpireAndWasNotRejected))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::req_to_recourse_not_holder(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Accept), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::req_to_recourse_not_past_endorsee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant())) }, Err(ValidationError::RecourseeNotPastHolder))]
+    #[case::req_to_recourse_not_req_to_accept_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant())) }, Err(ValidationError::BillRequestToAcceptDidNotExpireAndWasNotRejected))]
+    #[case::req_to_recourse_not_expired_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillRequestToAcceptDidNotExpireAndWasNotRejected))]
     fn test_validate_bill_req_to_recourse_accept_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1058,8 +1060,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::req_to_recourse_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_reject_pay_block(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data())))) }, Ok(()))]
-    #[case::req_to_recourse_expired(BillValidateActionData { timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Ok(()))]
+    #[case::req_to_recourse_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_reject_pay_block(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant())))) }, Ok(()))]
+    #[case::req_to_recourse_expired(BillValidateActionData { timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Ok(()))]
     fn test_validate_bill_req_to_recourse_payment_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1068,17 +1070,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::req_to_recourse_not_holder(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_identity_public_data(), RecourseReason::Pay(500, "sat".into())), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
-    #[case::req_to_recourse_not_past_endorsee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data())) }, Err(ValidationError::RecourseeNotPastHolder))]
-    #[case::req_to_recourse_paid(BillValidateActionData { is_paid: true, endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data())) }, Err(ValidationError::BillAlreadyPaid))]
-    #[case::req_to_recourse_not_req_to_pay(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data())) }, Err(ValidationError::BillWasNotRequestedToPay))]
-    #[case::req_to_recourse_not_expired_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_identity_public_data(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::req_to_recourse_not_holder(BillValidateActionData { bill_action: BillAction::RequestRecourse(valid_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::req_to_recourse_not_past_endorsee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant())) }, Err(ValidationError::RecourseeNotPastHolder))]
+    #[case::req_to_recourse_paid(BillValidateActionData { is_paid: true, endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant())) }, Err(ValidationError::BillAlreadyPaid))]
+    #[case::req_to_recourse_not_req_to_pay(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant())) }, Err(ValidationError::BillWasNotRequestedToPay))]
+    #[case::req_to_recourse_not_expired_or_rejected(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::RequestRecourse(valid_other_bill_identified_participant(), RecourseReason::Pay(500, "sat".into())), ..valid_bill_validate_action_data(add_req_to_pay_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
     fn test_validate_bill_req_to_recourse_payment_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1087,7 +1089,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::recourse(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Ok(()))]
+    #[case::recourse(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Ok(()))]
     fn test_validate_bill_recourse_payment_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1096,17 +1098,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::recourse_not_holder(BillValidateActionData { bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
-    #[case::recourse_not_in_recourse(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data())) }, Err(ValidationError::BillIsNotRequestedToRecourseAndWaitingForPayment))]
-    #[case::recourse_invalid_data_sum(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_identity_public_data(), 700, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillRecourseDataInvalid))]
-    #[case::recourse_invalid_data_currency(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_identity_public_data(), 500, "invalidcurrency".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillRecourseDataInvalid))]
-    #[case::recourse_invalid_data_reason(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_identity_public_data(), 500, "sat".into(), RecourseReason::Pay(100, "sat".into())), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillRecourseDataInvalid))]
-    #[case::recourse_invalid_data_recoursee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_identity_public_data(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_identity_public_data(), valid_identity_public_data()), valid_identity_public_data(), valid_other_identity_public_data()))) }, Err(ValidationError::BillRecourseDataInvalid))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::recourse_not_holder(BillValidateActionData { bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::recourse_not_in_recourse(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant())) }, Err(ValidationError::BillIsNotRequestedToRecourseAndWaitingForPayment))]
+    #[case::recourse_invalid_data_sum(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_bill_identified_participant(), 700, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillRecourseDataInvalid))]
+    #[case::recourse_invalid_data_currency(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_bill_identified_participant(), 500, "invalidcurrency".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillRecourseDataInvalid))]
+    #[case::recourse_invalid_data_reason(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_other_bill_identified_participant(), 500, "sat".into(), RecourseReason::Pay(100, "sat".into())), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillRecourseDataInvalid))]
+    #[case::recourse_invalid_data_recoursee(BillValidateActionData { endorsee_node_id: Some(TEST_PUB_KEY_SECP.into()), bill_action: BillAction::Recourse(valid_bill_identified_participant(), 500, "sat".into(), RecourseReason::Accept), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(add_endorse_block(add_endorse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),), valid_other_bill_identified_participant(), valid_bill_identified_participant()), valid_bill_identified_participant(), valid_other_bill_identified_participant()))) }, Err(ValidationError::BillRecourseDataInvalid))]
     fn test_validate_bill_recourse_payment_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1115,7 +1117,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::mint(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
+    #[case::mint(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
     fn test_validate_bill_mint_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1124,18 +1126,18 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
-    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
-    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
-    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
-    #[case::mint_not_accepted(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::BillNotAccepted))]
-    #[case::mint_not_holder(BillValidateActionData { bill_action: BillAction::Mint(valid_other_identity_public_data(), 500, "sat".into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
+    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
+    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
+    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
+    #[case::mint_not_accepted(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::BillNotAccepted))]
+    #[case::mint_not_holder(BillValidateActionData { bill_action: BillAction::Mint(valid_other_bill_participant(), 500, "sat".into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::CallerIsNotHolder))]
     fn test_validate_bill_mint_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1144,7 +1146,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::endorse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
+    #[case::endorse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
     fn test_validate_bill_endorse_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1153,17 +1155,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
-    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
-    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
-    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
-    #[case::endorse_not_holder(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_identity_public_data()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
+    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
+    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
+    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
+    #[case::endorse_not_holder(BillValidateActionData { bill_action: BillAction::Endorse(valid_other_bill_participant()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::CallerIsNotHolder))]
     fn test_validate_bill_endorse_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1172,7 +1174,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::offer_to_sell(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
+    #[case::offer_to_sell(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
     fn test_validate_bill_offer_to_sell_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1181,17 +1183,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
-    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
-    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
-    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
-    #[case::offer_to_sell_not_holder(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_identity_public_data(), 500, "sat".into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_offer_to_sell_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsOfferedToSellAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
+    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
+    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
+    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
+    #[case::offer_to_sell_not_holder(BillValidateActionData { bill_action: BillAction::OfferToSell(valid_other_bill_participant(), 500, "sat".into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
     fn test_validate_bill_offer_to_sell_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1200,7 +1202,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::sell_invalid_data_buyer(BillValidateActionData { bill_action: BillAction::Sell(valid_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
+    #[case::sell_invalid_data_buyer(BillValidateActionData { bill_action: BillAction::Sell(valid_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
     fn test_validate_bill_sell_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,
@@ -1209,21 +1211,21 @@ mod tests {
     }
 
     #[rstest]
-    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
-    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
-    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
-    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
-    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
-    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
-    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
-    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
-    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
-    #[case::sell_not_holder(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
-    #[case::sell_not_offered_to_sell(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::BillIsNotOfferToSellWaitingForPayment))]
-    #[case::sell_invalid_data_sum(BillValidateActionData { bill_action: BillAction::Sell(valid_identity_public_data(), 700, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
-    #[case::sell_invalid_data_currency(BillValidateActionData { bill_action: BillAction::Sell(valid_identity_public_data(), 500, "invalidcurrency".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
-    #[case::sell_invalid_data_buyer(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
-    #[case::sell_invalid_data_payment_address(BillValidateActionData { bill_action: BillAction::Sell(valid_other_identity_public_data(), 500, "sat".into(), OTHER_VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
+    #[case::rejected_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_recourse_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToRecourse))]
+    #[case::last_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRecoursedToTheEnd))]
+    #[case::expired_req_to_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (RECOURSE_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillRequestToRecourseExpired))]
+    #[case::active_req_to_pay_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::active_recourse_blocked(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_req_to_recourse_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillIsInRecourseAndWaitingForPayment))]
+    #[case::rejected_to_accept_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToAccept))]
+    #[case::rejected_to_pay_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), ..valid_bill_validate_action_data(add_reject_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillWasRejectedToPay))]
+    #[case::payment_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (PAYMENT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillPaymentExpired))]
+    #[case::acceptance_expired_only_recourse(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), timestamp: now().timestamp() as u64 + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillAcceptanceExpired))]
+    #[case::sell_not_holder(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::CallerIsNotHolder))]
+    #[case::sell_not_offered_to_sell(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ValidationError::BillIsNotOfferToSellWaitingForPayment))]
+    #[case::sell_invalid_data_sum(BillValidateActionData { bill_action: BillAction::Sell(valid_bill_participant(), 700, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
+    #[case::sell_invalid_data_currency(BillValidateActionData { bill_action: BillAction::Sell(valid_bill_participant(), 500, "invalidcurrency".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
+    #[case::sell_invalid_data_buyer(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
+    #[case::sell_invalid_data_payment_address(BillValidateActionData { bill_action: BillAction::Sell(valid_other_bill_participant(), 500, "sat".into(), OTHER_VALID_PAYMENT_ADDRESS_TESTNET.into()), signer_node_id: OTHER_TEST_PUB_KEY_SECP.into(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ValidationError::BillSellDataInvalid))]
     fn test_validate_bill_sell_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ValidationError>,

--- a/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
@@ -5,7 +5,7 @@ pub mod block;
 pub mod chain;
 
 pub use block::BillBlock;
-use block::{BillIdentifiedParticipantBlockData, BillRecourseReasonBlockData};
+use block::{BillIdentParticipantBlockData, BillRecourseReasonBlockData};
 pub use chain::BillBlockchain;
 
 use crate::contact::BillParticipant;
@@ -53,8 +53,8 @@ pub struct PaymentInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoursePaymentInfo {
-    pub recourser: BillIdentifiedParticipantBlockData, // recourser has to be identified
-    pub recoursee: BillIdentifiedParticipantBlockData, // recoursee has to be identified
+    pub recourser: BillIdentParticipantBlockData, // recourser has to be identified
+    pub recoursee: BillIdentParticipantBlockData, // recoursee has to be identified
     pub sum: u64,
     pub currency: String,
     pub reason: BillRecourseReasonBlockData,

--- a/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
@@ -5,8 +5,10 @@ pub mod block;
 pub mod chain;
 
 pub use block::BillBlock;
-use block::{BillIdentityBlockData, BillRecourseReasonBlockData};
+use block::{BillIdentifiedParticipantBlockData, BillRecourseReasonBlockData};
 pub use chain::BillBlockchain;
+
+use crate::contact::BillParticipant;
 
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
@@ -42,8 +44,8 @@ pub enum RecourseWaitingForPayment {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PaymentInfo {
-    pub buyer: BillIdentityBlockData,
-    pub seller: BillIdentityBlockData,
+    pub buyer: BillParticipant,  // buyer can be anone
+    pub seller: BillParticipant, // seller can be anone
     pub sum: u64,
     pub currency: String,
     pub payment_address: String,
@@ -51,8 +53,8 @@ pub struct PaymentInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoursePaymentInfo {
-    pub recourser: BillIdentityBlockData,
-    pub recoursee: BillIdentityBlockData,
+    pub recourser: BillIdentifiedParticipantBlockData, // recourser has to be identified
+    pub recoursee: BillIdentifiedParticipantBlockData, // recoursee has to be identified
     pub sum: u64,
     pub currency: String,
     pub reason: BillRecourseReasonBlockData,

--- a/crates/bcr-ebill-core/src/constants.rs
+++ b/crates/bcr-ebill-core/src/constants.rs
@@ -1,5 +1,5 @@
 pub const PAYMENT_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
 pub const ACCEPT_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
 pub const RECOURSE_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
-//
+
 pub const VALID_CURRENCIES: [&str; 1] = ["sat"];

--- a/crates/bcr-ebill-core/src/contact.rs
+++ b/crates/bcr-ebill-core/src/contact.rs
@@ -43,36 +43,36 @@ pub struct Contact {
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum BillParticipant {
-    Anonymous(BillAnonymousParticipant),
-    Identified(BillIdentifiedParticipant),
+    Anon(BillAnonParticipant),
+    Ident(BillIdentParticipant),
 }
 
 impl BillParticipant {
     pub fn postal_address(&self) -> Option<PostalAddress> {
         match self {
-            BillParticipant::Identified(data) => Some(data.postal_address.clone()),
-            BillParticipant::Anonymous(_) => None,
+            BillParticipant::Ident(data) => Some(data.postal_address.clone()),
+            BillParticipant::Anon(_) => None,
         }
     }
 
     pub fn name(&self) -> Option<String> {
         match self {
-            BillParticipant::Identified(data) => Some(data.name.to_owned()),
-            BillParticipant::Anonymous(_) => None,
+            BillParticipant::Ident(data) => Some(data.name.to_owned()),
+            BillParticipant::Anon(_) => None,
         }
     }
 
     pub fn email(&self) -> Option<String> {
         match self {
-            BillParticipant::Identified(data) => data.email.to_owned(),
-            BillParticipant::Anonymous(data) => data.email.to_owned(),
+            BillParticipant::Ident(data) => data.email.to_owned(),
+            BillParticipant::Anon(data) => data.email.to_owned(),
         }
     }
 
     pub fn nostr_relay(&self) -> Option<String> {
         match self {
-            BillParticipant::Identified(data) => data.nostr_relay.to_owned(),
-            BillParticipant::Anonymous(data) => data.nostr_relay.to_owned(),
+            BillParticipant::Ident(data) => data.nostr_relay.to_owned(),
+            BillParticipant::Anon(data) => data.nostr_relay.to_owned(),
         }
     }
 }
@@ -80,14 +80,14 @@ impl BillParticipant {
 impl NodeId for BillParticipant {
     fn node_id(&self) -> String {
         match self {
-            BillParticipant::Identified(data) => data.node_id.clone(),
-            BillParticipant::Anonymous(data) => data.node_id.clone(),
+            BillParticipant::Ident(data) => data.node_id.clone(),
+            BillParticipant::Anon(data) => data.node_id.clone(),
         }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct BillAnonymousParticipant {
+pub struct BillAnonParticipant {
     /// The node id of the participant
     pub node_id: String,
     /// email address of the participant
@@ -99,7 +99,7 @@ pub struct BillAnonymousParticipant {
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default,
 )]
-pub struct BillIdentifiedParticipant {
+pub struct BillIdentParticipant {
     /// The type of identity (0 = person, 1 = company)
     #[serde(rename = "type")]
     pub t: ContactType,
@@ -118,17 +118,17 @@ pub struct BillIdentifiedParticipant {
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
 pub enum LightBillParticipant {
-    Anonymous(LightBillAnonymousParticipant),
-    Identified(LightBillIdentifiedParticipant),
+    Anon(LightBillAnonParticipant),
+    Ident(LightBillIdentParticipant),
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Default)]
-pub struct LightBillAnonymousParticipant {
+pub struct LightBillAnonParticipant {
     pub node_id: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Default)]
-pub struct LightBillIdentifiedParticipant {
+pub struct LightBillIdentParticipant {
     #[serde(rename = "type")]
     pub t: ContactType,
     pub name: String,
@@ -138,14 +138,14 @@ pub struct LightBillIdentifiedParticipant {
 impl From<BillParticipant> for LightBillParticipant {
     fn from(value: BillParticipant) -> Self {
         match value {
-            BillParticipant::Identified(data) => LightBillParticipant::Identified(data.into()),
-            BillParticipant::Anonymous(data) => LightBillParticipant::Anonymous(data.into()),
+            BillParticipant::Ident(data) => LightBillParticipant::Ident(data.into()),
+            BillParticipant::Anon(data) => LightBillParticipant::Anon(data.into()),
         }
     }
 }
 
-impl From<BillIdentifiedParticipant> for LightBillIdentifiedParticipant {
-    fn from(value: BillIdentifiedParticipant) -> Self {
+impl From<BillIdentParticipant> for LightBillIdentParticipant {
+    fn from(value: BillIdentParticipant) -> Self {
         Self {
             t: value.t,
             name: value.name,
@@ -154,8 +154,8 @@ impl From<BillIdentifiedParticipant> for LightBillIdentifiedParticipant {
     }
 }
 
-impl From<BillAnonymousParticipant> for LightBillAnonymousParticipant {
-    fn from(value: BillAnonymousParticipant) -> Self {
+impl From<BillAnonParticipant> for LightBillAnonParticipant {
+    fn from(value: BillAnonParticipant) -> Self {
         Self {
             node_id: value.node_id,
         }
@@ -163,7 +163,7 @@ impl From<BillAnonymousParticipant> for LightBillAnonymousParticipant {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Default)]
-pub struct LightBillIdentifiedParticipantWithAddress {
+pub struct LightBillIdentParticipantWithAddress {
     #[serde(rename = "type")]
     pub t: ContactType,
     pub name: String,
@@ -172,8 +172,8 @@ pub struct LightBillIdentifiedParticipantWithAddress {
     pub postal_address: PostalAddress,
 }
 
-impl From<BillIdentifiedParticipant> for LightBillIdentifiedParticipantWithAddress {
-    fn from(value: BillIdentifiedParticipant) -> Self {
+impl From<BillIdentParticipant> for LightBillIdentParticipantWithAddress {
+    fn from(value: BillIdentParticipant) -> Self {
         Self {
             t: value.t,
             name: value.name,
@@ -183,7 +183,7 @@ impl From<BillIdentifiedParticipant> for LightBillIdentifiedParticipantWithAddre
     }
 }
 
-impl From<Contact> for BillIdentifiedParticipant {
+impl From<Contact> for BillIdentParticipant {
     fn from(value: Contact) -> Self {
         Self {
             t: value.t,
@@ -196,7 +196,7 @@ impl From<Contact> for BillIdentifiedParticipant {
     }
 }
 
-impl From<Company> for BillIdentifiedParticipant {
+impl From<Company> for BillIdentParticipant {
     fn from(value: Company) -> Self {
         Self {
             t: ContactType::Company,
@@ -209,7 +209,7 @@ impl From<Company> for BillIdentifiedParticipant {
     }
 }
 
-impl BillIdentifiedParticipant {
+impl BillIdentParticipant {
     pub fn new(identity: Identity) -> Option<Self> {
         match identity.postal_address.to_full_postal_address() {
             Some(postal_address) => Some(Self {

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -191,7 +191,7 @@ pub enum ValidationError {
 
     /// error returned if the signer for a certain action is not allowed to be anonymous
     #[error("The signer can't be anonymous")]
-    SignerCantBeAnonymous,
+    SignerCantBeAnon,
 
     /// error returned if the maturity date is in the past
     #[error("maturity date can't be in the past")]

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -61,6 +61,15 @@ impl Validate for PostalAddress {
     }
 }
 
+impl Validate for Option<PostalAddress> {
+    fn validate(&self) -> Result<(), ValidationError> {
+        if let Some(data) = self {
+            data.validate()?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for PostalAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.zip {
@@ -179,6 +188,10 @@ pub enum ValidationError {
     /// error returned if the date was invalid
     #[error("invalid date")]
     InvalidDate,
+
+    /// error returned if the signer for a certain action is not allowed to be anonymous
+    #[error("The signer can't be anonymous")]
+    SignerCantBeAnonymous,
 
     /// error returned if the maturity date is in the past
     #[error("maturity date can't be in the past")]

--- a/crates/bcr-ebill-core/src/tests/mod.rs
+++ b/crates/bcr-ebill-core/src/tests/mod.rs
@@ -6,7 +6,7 @@ pub mod tests {
     use crate::{
         Field, OptionalPostalAddress, PostalAddress, ValidationError,
         bill::{BillKeys, BitcreditBill},
-        contact::{BillIdentifiedParticipant, ContactType},
+        contact::{BillIdentParticipant, ContactType},
         identity::Identity,
     };
     use rstest::rstest;
@@ -113,7 +113,7 @@ pub mod tests {
     }
 
     pub fn valid_bill_participant() -> BillParticipant {
-        BillParticipant::Identified(BillIdentifiedParticipant {
+        BillParticipant::Ident(BillIdentParticipant {
             t: ContactType::Person,
             node_id: TEST_PUB_KEY_SECP.into(),
             name: "Johanna Smith".into(),
@@ -124,7 +124,7 @@ pub mod tests {
     }
 
     pub fn valid_other_bill_participant() -> BillParticipant {
-        BillParticipant::Identified(BillIdentifiedParticipant {
+        BillParticipant::Ident(BillIdentParticipant {
             t: ContactType::Person,
             node_id: OTHER_TEST_PUB_KEY_SECP.into(),
             name: "John Smith".into(),
@@ -134,8 +134,8 @@ pub mod tests {
         })
     }
 
-    pub fn valid_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn valid_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: TEST_PUB_KEY_SECP.into(),
             name: "Johanna Smith".into(),
@@ -145,8 +145,8 @@ pub mod tests {
         }
     }
 
-    pub fn valid_other_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn valid_other_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: OTHER_TEST_PUB_KEY_SECP.into(),
             name: "John Smith".into(),
@@ -156,8 +156,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn empty_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "some name".to_string(),
@@ -168,7 +168,7 @@ pub mod tests {
     }
 
     pub fn bill_participant_only_node_id(node_id: String) -> BillParticipant {
-        BillParticipant::Identified(BillIdentifiedParticipant {
+        BillParticipant::Ident(BillIdentParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),
@@ -178,8 +178,8 @@ pub mod tests {
         })
     }
 
-    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),

--- a/crates/bcr-ebill-core/src/tests/mod.rs
+++ b/crates/bcr-ebill-core/src/tests/mod.rs
@@ -2,10 +2,11 @@
 #[allow(clippy::module_inception)]
 pub mod tests {
     use crate::Validate;
+    use crate::contact::BillParticipant;
     use crate::{
         Field, OptionalPostalAddress, PostalAddress, ValidationError,
         bill::{BillKeys, BitcreditBill},
-        contact::{ContactType, IdentityPublicData},
+        contact::{BillIdentifiedParticipant, ContactType},
         identity::Identity,
     };
     use rstest::rstest;
@@ -111,8 +112,30 @@ pub mod tests {
         }
     }
 
-    pub fn valid_identity_public_data() -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn valid_bill_participant() -> BillParticipant {
+        BillParticipant::Identified(BillIdentifiedParticipant {
+            t: ContactType::Person,
+            node_id: TEST_PUB_KEY_SECP.into(),
+            name: "Johanna Smith".into(),
+            postal_address: valid_address(),
+            email: None,
+            nostr_relay: None,
+        })
+    }
+
+    pub fn valid_other_bill_participant() -> BillParticipant {
+        BillParticipant::Identified(BillIdentifiedParticipant {
+            t: ContactType::Person,
+            node_id: OTHER_TEST_PUB_KEY_SECP.into(),
+            name: "John Smith".into(),
+            postal_address: valid_address(),
+            email: None,
+            nostr_relay: None,
+        })
+    }
+
+    pub fn valid_bill_identified_participant() -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id: TEST_PUB_KEY_SECP.into(),
             name: "Johanna Smith".into(),
@@ -122,8 +145,8 @@ pub mod tests {
         }
     }
 
-    pub fn valid_other_identity_public_data() -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn valid_other_bill_identified_participant() -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id: OTHER_TEST_PUB_KEY_SECP.into(),
             name: "John Smith".into(),
@@ -133,8 +156,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_identity_public_data() -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "some name".to_string(),
@@ -144,8 +167,19 @@ pub mod tests {
         }
     }
 
-    pub fn identity_public_data_only_node_id(node_id: String) -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn bill_participant_only_node_id(node_id: String) -> BillParticipant {
+        BillParticipant::Identified(BillIdentifiedParticipant {
+            t: ContactType::Person,
+            node_id,
+            name: "some name".to_string(),
+            postal_address: valid_address(),
+            email: None,
+            nostr_relay: None,
+        })
+    }
+
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id,
             name: "some name".to_string(),
@@ -160,9 +194,9 @@ pub mod tests {
             id: TEST_BILL_ID.to_owned(),
             country_of_issuing: "AT".to_string(),
             city_of_issuing: "Vienna".to_string(),
-            drawee: empty_identity_public_data(),
-            drawer: empty_identity_public_data(),
-            payee: empty_identity_public_data(),
+            drawee: empty_bill_identified_participant(),
+            drawer: empty_bill_identified_participant(),
+            payee: valid_bill_participant(),
             endorsee: None,
             currency: "sat".to_string(),
             sum: 500,

--- a/crates/bcr-ebill-persistence/Cargo.toml
+++ b/crates/bcr-ebill-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-persistence"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -13,7 +13,7 @@ use bcr_ebill_core::bill::{
 };
 use bcr_ebill_core::constants::{PAYMENT_DEADLINE_SECONDS, RECOURSE_DEADLINE_SECONDS};
 use bcr_ebill_core::contact::{
-    BillAnonymousParticipant, BillIdentifiedParticipant, BillParticipant, ContactType,
+    BillAnonParticipant, BillIdentParticipant, BillParticipant, ContactType,
 };
 use bcr_ebill_core::{bill::BillKeys, blockchain::bill::BillOpCode, util};
 use serde::{Deserialize, Serialize};
@@ -369,7 +369,7 @@ impl From<&BillWaitingForSellState> for BillWaitingForSellStateDb {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillWaitingForPaymentStateDb {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipantDb,
+    pub payer: BillIdentParticipantDb,
     pub payee: BillParticipantDb,
     pub currency: String,
     pub sum: String,
@@ -411,8 +411,8 @@ impl From<&BillWaitingForPaymentState> for BillWaitingForPaymentStateDb {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillWaitingForRecourseStateDb {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipantDb,
-    pub recoursee: BillIdentifiedParticipantDb,
+    pub recourser: BillIdentParticipantDb,
+    pub recoursee: BillIdentParticipantDb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -675,8 +675,8 @@ impl From<&BillData> for BillDataDb {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillParticipantsDb {
-    pub drawee: BillIdentifiedParticipantDb,
-    pub drawer: BillIdentifiedParticipantDb,
+    pub drawee: BillIdentParticipantDb,
+    pub drawer: BillIdentParticipantDb,
     pub payee: BillParticipantDb,
     pub endorsee: Option<BillParticipantDb>,
     pub endorsements_count: u64,
@@ -711,12 +711,12 @@ impl From<&BillParticipants> for BillParticipantsDb {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum BillParticipantDb {
-    Anonymous(BillAnonymousParticipantDb),
-    Identified(BillIdentifiedParticipantDb),
+    Anon(BillAnonParticipantDb),
+    Ident(BillIdentParticipantDb),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BillIdentifiedParticipantDb {
+pub struct BillIdentParticipantDb {
     pub t: ContactType,
     pub node_id: String,
     pub name: String,
@@ -724,21 +724,21 @@ pub struct BillIdentifiedParticipantDb {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BillAnonymousParticipantDb {
+pub struct BillAnonParticipantDb {
     pub node_id: String,
 }
 
 impl From<BillParticipantDb> for BillParticipant {
     fn from(value: BillParticipantDb) -> Self {
         match value {
-            BillParticipantDb::Anonymous(data) => BillParticipant::Anonymous(data.into()),
-            BillParticipantDb::Identified(data) => BillParticipant::Identified(data.into()),
+            BillParticipantDb::Anon(data) => BillParticipant::Anon(data.into()),
+            BillParticipantDb::Ident(data) => BillParticipant::Ident(data.into()),
         }
     }
 }
 
-impl From<BillAnonymousParticipantDb> for BillAnonymousParticipant {
-    fn from(value: BillAnonymousParticipantDb) -> Self {
+impl From<BillAnonParticipantDb> for BillAnonParticipant {
+    fn from(value: BillAnonParticipantDb) -> Self {
         Self {
             node_id: value.node_id,
             email: None,
@@ -747,8 +747,8 @@ impl From<BillAnonymousParticipantDb> for BillAnonymousParticipant {
     }
 }
 
-impl From<BillIdentifiedParticipantDb> for BillIdentifiedParticipant {
-    fn from(value: BillIdentifiedParticipantDb) -> Self {
+impl From<BillIdentParticipantDb> for BillIdentParticipant {
+    fn from(value: BillIdentParticipantDb) -> Self {
         Self {
             t: value.t,
             node_id: value.node_id,
@@ -763,22 +763,22 @@ impl From<BillIdentifiedParticipantDb> for BillIdentifiedParticipant {
 impl From<&BillParticipant> for BillParticipantDb {
     fn from(value: &BillParticipant) -> Self {
         match value {
-            BillParticipant::Anonymous(data) => BillParticipantDb::Anonymous(data.into()),
-            BillParticipant::Identified(data) => BillParticipantDb::Identified(data.into()),
+            BillParticipant::Anon(data) => BillParticipantDb::Anon(data.into()),
+            BillParticipant::Ident(data) => BillParticipantDb::Ident(data.into()),
         }
     }
 }
 
-impl From<&BillAnonymousParticipant> for BillAnonymousParticipantDb {
-    fn from(value: &BillAnonymousParticipant) -> Self {
+impl From<&BillAnonParticipant> for BillAnonParticipantDb {
+    fn from(value: &BillAnonParticipant) -> Self {
         Self {
             node_id: value.node_id.clone(),
         }
     }
 }
 
-impl From<&BillIdentifiedParticipant> for BillIdentifiedParticipantDb {
-    fn from(value: &BillIdentifiedParticipant) -> Self {
+impl From<&BillIdentParticipant> for BillIdentParticipantDb {
+    fn from(value: &BillIdentParticipant) -> Self {
         Self {
             t: value.t.clone(),
             node_id: value.node_id.clone(),
@@ -874,7 +874,7 @@ pub mod tests {
         bill.maturity_date = "2099-05-05".to_string();
         bill.id = id.to_owned();
         bill.drawer = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
-        bill.payee = BillParticipant::Identified(bill.drawer.clone());
+        bill.payee = BillParticipant::Ident(bill.drawer.clone());
         bill.drawee = bill_identified_participant_only_node_id(BcrKeys::new().get_public_key());
 
         BillBlock::create_block_for_issue(
@@ -995,7 +995,7 @@ pub mod tests {
                     "1234".to_string(),
                     &first_block,
                     &BillRequestToPayBlockData {
-                        requester: BillParticipantBlockData::Identified(
+                        requester: BillParticipantBlockData::Ident(
                             bill_identified_participant_only_node_id(
                                 BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                                     .unwrap()
@@ -1050,7 +1050,7 @@ pub mod tests {
             "1234".to_string(),
             &first_block,
             &BillOfferToSellBlockData {
-                seller: BillParticipantBlockData::Identified(
+                seller: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(
                         BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                             .unwrap()
@@ -1058,7 +1058,7 @@ pub mod tests {
                     )
                     .into(),
                 ),
-                buyer: BillParticipantBlockData::Identified(
+                buyer: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(BcrKeys::new().get_public_key())
                         .into(),
                 ),
@@ -1088,7 +1088,7 @@ pub mod tests {
                     "1234".to_string(),
                     &second_block,
                     &BillSellBlockData {
-                        seller: BillParticipantBlockData::Identified(
+                        seller: BillParticipantBlockData::Ident(
                             bill_identified_participant_only_node_id(
                                 BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                                     .unwrap()
@@ -1096,7 +1096,7 @@ pub mod tests {
                             )
                             .into(),
                         ),
-                        buyer: BillParticipantBlockData::Identified(
+                        buyer: BillParticipantBlockData::Ident(
                             bill_identified_participant_only_node_id(
                                 BcrKeys::new().get_public_key(),
                             )
@@ -1145,7 +1145,7 @@ pub mod tests {
             "1234".to_string(),
             &first_block,
             &BillOfferToSellBlockData {
-                seller: BillParticipantBlockData::Identified(
+                seller: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(
                         BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                             .unwrap()
@@ -1153,7 +1153,7 @@ pub mod tests {
                     )
                     .into(),
                 ),
-                buyer: BillParticipantBlockData::Identified(
+                buyer: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(BcrKeys::new().get_public_key())
                         .into(),
                 ),
@@ -1259,7 +1259,7 @@ pub mod tests {
             id.to_string(),
             first_block,
             &BillRequestToAcceptBlockData {
-                requester: BillParticipantBlockData::Identified(
+                requester: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(
                         BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                             .unwrap()
@@ -1284,7 +1284,7 @@ pub mod tests {
             id.to_string(),
             first_block,
             &BillRequestToPayBlockData {
-                requester: BillParticipantBlockData::Identified(
+                requester: BillParticipantBlockData::Ident(
                     bill_identified_participant_only_node_id(
                         BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP)
                             .unwrap()

--- a/crates/bcr-ebill-persistence/src/db/bill_chain.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill_chain.rs
@@ -235,7 +235,7 @@ mod tests {
     use bcr_ebill_core::{
         blockchain::{
             Blockchain,
-            bill::block::{BillAcceptBlockData, BillIdentifiedParticipantBlockData},
+            bill::block::{BillAcceptBlockData, BillIdentParticipantBlockData},
         },
         contact::ContactType,
         util::BcrKeys,
@@ -261,7 +261,7 @@ mod tests {
             "1234".to_string(),
             &block,
             &BillAcceptBlockData {
-                accepter: BillIdentifiedParticipantBlockData {
+                accepter: BillIdentParticipantBlockData {
                     t: ContactType::Person,
                     node_id: "555555".to_owned(),
                     name: "some dude".to_owned(),

--- a/crates/bcr-ebill-persistence/src/db/bill_chain.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill_chain.rs
@@ -235,7 +235,7 @@ mod tests {
     use bcr_ebill_core::{
         blockchain::{
             Blockchain,
-            bill::block::{BillAcceptBlockData, BillIdentityBlockData},
+            bill::block::{BillAcceptBlockData, BillIdentifiedParticipantBlockData},
         },
         contact::ContactType,
         util::BcrKeys,
@@ -261,7 +261,7 @@ mod tests {
             "1234".to_string(),
             &block,
             &BillAcceptBlockData {
-                accepter: BillIdentityBlockData {
+                accepter: BillIdentifiedParticipantBlockData {
                     t: ContactType::Person,
                     node_id: "555555".to_owned(),
                     name: "some dude".to_owned(),

--- a/crates/bcr-ebill-persistence/src/tests/mod.rs
+++ b/crates/bcr-ebill-persistence/src/tests/mod.rs
@@ -7,7 +7,7 @@ pub mod tests {
             BillAcceptanceStatus, BillData, BillKeys, BillParticipants, BillPaymentStatus,
             BillRecourseStatus, BillSellStatus, BillStatus, BitcreditBill, BitcreditBillResult,
         },
-        contact::{BillIdentifiedParticipant, BillParticipant, ContactType},
+        contact::{BillIdentParticipant, BillParticipant, ContactType},
         identity::Identity,
         util::BcrKeys,
     };
@@ -46,8 +46,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn empty_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "".to_string(),
@@ -57,8 +57,8 @@ pub mod tests {
         }
     }
 
-    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id,
             name: "".to_string(),
@@ -75,7 +75,7 @@ pub mod tests {
             city_of_issuing: "".to_string(),
             drawee: empty_bill_identified_participant(),
             drawer: empty_bill_identified_participant(),
-            payee: BillParticipant::Identified(bill_identified_participant_only_node_id(
+            payee: BillParticipant::Ident(bill_identified_participant_only_node_id(
                 BcrKeys::new().get_public_key(),
             )),
             endorsee: None,
@@ -96,7 +96,7 @@ pub mod tests {
             participants: BillParticipants {
                 drawee: bill_identified_participant_only_node_id("drawee".to_string()),
                 drawer: bill_identified_participant_only_node_id("drawer".to_string()),
-                payee: BillParticipant::Identified(bill_identified_participant_only_node_id(
+                payee: BillParticipant::Ident(bill_identified_participant_only_node_id(
                     "payee".to_string(),
                 )),
                 endorsee: None,

--- a/crates/bcr-ebill-persistence/src/tests/mod.rs
+++ b/crates/bcr-ebill-persistence/src/tests/mod.rs
@@ -7,8 +7,9 @@ pub mod tests {
             BillAcceptanceStatus, BillData, BillKeys, BillParticipants, BillPaymentStatus,
             BillRecourseStatus, BillSellStatus, BillStatus, BitcreditBill, BitcreditBillResult,
         },
-        contact::{ContactType, IdentityPublicData},
+        contact::{BillIdentifiedParticipant, BillParticipant, ContactType},
         identity::Identity,
+        util::BcrKeys,
     };
 
     pub fn empty_address() -> PostalAddress {
@@ -45,8 +46,8 @@ pub mod tests {
         }
     }
 
-    pub fn empty_identity_public_data() -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "".to_string(),
@@ -56,8 +57,8 @@ pub mod tests {
         }
     }
 
-    pub fn identity_public_data_only_node_id(node_id: String) -> IdentityPublicData {
-        IdentityPublicData {
+    pub fn bill_identified_participant_only_node_id(node_id: String) -> BillIdentifiedParticipant {
+        BillIdentifiedParticipant {
             t: ContactType::Person,
             node_id,
             name: "".to_string(),
@@ -72,9 +73,11 @@ pub mod tests {
             id: "".to_string(),
             country_of_issuing: "".to_string(),
             city_of_issuing: "".to_string(),
-            drawee: empty_identity_public_data(),
-            drawer: empty_identity_public_data(),
-            payee: empty_identity_public_data(),
+            drawee: empty_bill_identified_participant(),
+            drawer: empty_bill_identified_participant(),
+            payee: BillParticipant::Identified(bill_identified_participant_only_node_id(
+                BcrKeys::new().get_public_key(),
+            )),
             endorsee: None,
             currency: "".to_string(),
             sum: 0,
@@ -91,9 +94,11 @@ pub mod tests {
         BitcreditBillResult {
             id,
             participants: BillParticipants {
-                drawee: identity_public_data_only_node_id("drawee".to_string()),
-                drawer: identity_public_data_only_node_id("drawer".to_string()),
-                payee: identity_public_data_only_node_id("payee".to_string()),
+                drawee: bill_identified_participant_only_node_id("drawee".to_string()),
+                drawer: bill_identified_participant_only_node_id("drawer".to_string()),
+                payee: BillParticipant::Identified(bill_identified_participant_only_node_id(
+                    "payee".to_string(),
+                )),
                 endorsee: None,
                 endorsements_count: 5,
                 all_participant_node_ids: vec![],

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-transport"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -446,7 +446,7 @@ mod tests {
         blockchain::bill::block::{
             BillEndorseBlockData, BillIssueBlockData, BillParticipantBlockData, BillRejectBlockData,
         },
-        contact::{BillIdentifiedParticipant, BillParticipant, ContactType},
+        contact::{BillIdentParticipant, BillParticipant, ContactType},
         identity::{Identity, IdentityWithAll},
         notification::ActionType,
         util::BcrKeys,
@@ -472,10 +472,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_creates_new_chain_for_new_chain_event() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let mut payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let mut payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         payee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
-        let drawer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let drawer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, Some(&drawer), None);
         let chain = get_genesis_chain(Some(bill.clone()));
         let keys = get_bill_keys();
@@ -527,10 +527,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_create_new_chain_for_new_chain_event_if_block_validation_fails() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let mut payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let mut payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         payee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
-        let drawer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let drawer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, Some(&drawer), None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let keys = get_bill_keys();
@@ -600,10 +600,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_create_new_chain_for_new_chain_event_if_block_signing_check_fails() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         // drawer has a different key than signer, signing check will fail
-        let mut drawer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let mut drawer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         drawer.node_id = BcrKeys::new().get_public_key();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, Some(&drawer), None);
         let chain = get_genesis_chain(Some(bill.clone()));
@@ -654,10 +654,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_adds_block_for_existing_chain_event() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         let mut endorsee =
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         endorsee.node_id = OTHER_TEST_PUB_KEY_SECP.to_owned();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
@@ -665,10 +665,10 @@ mod tests {
             TEST_BILL_ID.to_string(),
             chain.get_latest_block(),
             &BillEndorseBlockData {
-                endorsee: BillParticipantBlockData::Identified(endorsee.clone().into()),
+                endorsee: BillParticipantBlockData::Ident(endorsee.clone().into()),
                 // endorsed by payee
-                endorser: BillParticipantBlockData::Identified(
-                    BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                endorser: BillParticipantBlockData::Ident(
+                    BillIdentParticipant::new(get_baseline_identity().identity)
                         .unwrap()
                         .into(),
                 ),
@@ -736,8 +736,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_add_block_for_invalid_bill_action() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
 
@@ -806,12 +806,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_add_block_for_invalidly_signed_blocks() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let endorsee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let endorsee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         // endorser is different than block signer - signature won't be able to be validated
         let mut endorser =
-            BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+            BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         endorser.node_id = BcrKeys::new().get_public_key();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
@@ -820,9 +820,9 @@ mod tests {
             TEST_BILL_ID.to_string(),
             chain.get_latest_block(),
             &BillEndorseBlockData {
-                endorsee: BillParticipantBlockData::Identified(endorsee.clone().into()),
+                endorsee: BillParticipantBlockData::Ident(endorsee.clone().into()),
                 // endorsed by payee
-                endorser: BillParticipantBlockData::Identified(endorser.clone().into()),
+                endorser: BillParticipantBlockData::Ident(endorser.clone().into()),
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1000,
                 signing_address: Some(empty_address()),
@@ -882,9 +882,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_add_block_for_unknown_chain() {
-        let payer = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let payee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
-        let endorsee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let endorsee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
 
@@ -892,10 +892,10 @@ mod tests {
             TEST_BILL_ID.to_string(),
             chain.get_latest_block(),
             &BillEndorseBlockData {
-                endorsee: BillParticipantBlockData::Identified(endorsee.clone().into()),
+                endorsee: BillParticipantBlockData::Ident(endorsee.clone().into()),
                 // endorsed by payee
-                endorser: BillParticipantBlockData::Identified(
-                    BillIdentifiedParticipant::new(get_baseline_identity().identity)
+                endorser: BillParticipantBlockData::Ident(
+                    BillIdentParticipant::new(get_baseline_identity().identity)
                         .unwrap()
                         .into(),
                 ),
@@ -1035,19 +1035,19 @@ mod tests {
     }
     pub fn get_test_bitcredit_bill(
         id: &str,
-        payer: &BillIdentifiedParticipant,
-        payee: &BillIdentifiedParticipant,
-        drawer: Option<&BillIdentifiedParticipant>,
-        endorsee: Option<&BillIdentifiedParticipant>,
+        payer: &BillIdentParticipant,
+        payee: &BillIdentParticipant,
+        drawer: Option<&BillIdentParticipant>,
+        endorsee: Option<&BillIdentParticipant>,
     ) -> BitcreditBill {
         let mut bill = empty_bitcredit_bill();
         bill.id = id.to_owned();
-        bill.payee = BillParticipant::Identified(payee.clone());
+        bill.payee = BillParticipant::Ident(payee.clone());
         bill.drawee = payer.clone();
         if let Some(drawer) = drawer {
             bill.drawer = drawer.clone();
         }
-        bill.endorsee = endorsee.map(|e| BillParticipant::Identified(e.to_owned()));
+        bill.endorsee = endorsee.map(|e| BillParticipant::Ident(e.to_owned()));
         bill
     }
     fn get_genesis_chain(bill: Option<BitcreditBill>) -> BillBlockchain {
@@ -1069,8 +1069,8 @@ mod tests {
         let mut payee = empty_bill_identified_participant();
         payee.name = "payee".to_owned();
         payee.node_id = keys.get_public_key();
-        bill.payee = BillParticipant::Identified(payee);
-        bill.drawee = BillIdentifiedParticipant::new(get_baseline_identity().identity).unwrap();
+        bill.payee = BillParticipant::Ident(payee);
+        bill.drawee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
         bill.id = bill_id.to_owned();
         bill
     }
@@ -1081,7 +1081,7 @@ mod tests {
             city_of_issuing: "Vienna".to_string(),
             drawee: empty_bill_identified_participant(),
             drawer: empty_bill_identified_participant(),
-            payee: BillParticipant::Identified(empty_bill_identified_participant()),
+            payee: BillParticipant::Ident(empty_bill_identified_participant()),
             endorsee: None,
             currency: "sat".to_string(),
             sum: 500,
@@ -1114,8 +1114,8 @@ mod tests {
             key_pair: keys,
         }
     }
-    fn empty_bill_identified_participant() -> BillIdentifiedParticipant {
-        BillIdentifiedParticipant {
+    fn empty_bill_identified_participant() -> BillIdentParticipant {
+        BillIdentParticipant {
             t: ContactType::Person,
             node_id: "".to_string(),
             name: "some name".to_string(),

--- a/crates/bcr-ebill-transport/src/notification_service.rs
+++ b/crates/bcr-ebill-transport/src/notification_service.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bcr_ebill_core::ServiceTraitBounds;
 use bcr_ebill_core::{
     bill::BitcreditBill,
-    contact::{BillIdentifiedParticipant, BillParticipant},
+    contact::{BillIdentParticipant, BillParticipant},
     notification::{ActionType, Notification},
 };
 use bcr_ebill_persistence::notification::NotificationFilter;
@@ -66,7 +66,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
     async fn send_bill_recourse_paid_event(
         &self,
         event: &BillChainEvent,
-        recoursee: &BillIdentifiedParticipant,
+        recoursee: &BillIdentParticipant,
     ) -> Result<()>;
 
     /// In case a participant rejects one of the 'request to' actions (e.g. request to accept,
@@ -95,7 +95,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
         bill_id: &str,
         sum: Option<u64>,
         timed_out_action: ActionType,
-        recipients: Vec<BillIdentifiedParticipant>,
+        recipients: Vec<BillIdentParticipant>,
     ) -> Result<()>;
 
     /// In case an action was rejected or timed out a holder can request a recourse action
@@ -110,7 +110,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
         &self,
         event: &BillChainEvent,
         action: ActionType,
-        recoursee: &BillIdentifiedParticipant,
+        recoursee: &BillIdentParticipant,
     ) -> Result<()>;
 
     /// Sent when: A bill is requested to be minted, Sent by: Holder

--- a/crates/bcr-ebill-transport/src/notification_service.rs
+++ b/crates/bcr-ebill-transport/src/notification_service.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bcr_ebill_core::ServiceTraitBounds;
 use bcr_ebill_core::{
     bill::BitcreditBill,
-    contact::IdentityPublicData,
+    contact::{BillIdentifiedParticipant, BillParticipant},
     notification::{ActionType, Notification},
 };
 use bcr_ebill_persistence::notification::NotificationFilter;
@@ -50,7 +50,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
     async fn send_offer_to_sell_event(
         &self,
         event: &BillChainEvent,
-        buyer: &IdentityPublicData,
+        buyer: &BillParticipant,
     ) -> Result<()>;
 
     /// Sent when: A bill is sold by: Seller (old holder)
@@ -58,7 +58,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
     async fn send_bill_is_sold_event(
         &self,
         event: &BillChainEvent,
-        buyer: &IdentityPublicData,
+        buyer: &BillParticipant,
     ) -> Result<()>;
 
     /// Sent when: A bill recourse was paid, by: Recourser (old holder)
@@ -66,7 +66,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
     async fn send_bill_recourse_paid_event(
         &self,
         event: &BillChainEvent,
-        recoursee: &IdentityPublicData,
+        recoursee: &BillIdentifiedParticipant,
     ) -> Result<()>;
 
     /// In case a participant rejects one of the 'request to' actions (e.g. request to accept,
@@ -95,7 +95,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
         bill_id: &str,
         sum: Option<u64>,
         timed_out_action: ActionType,
-        recipients: Vec<IdentityPublicData>,
+        recipients: Vec<BillIdentifiedParticipant>,
     ) -> Result<()>;
 
     /// In case an action was rejected or timed out a holder can request a recourse action
@@ -110,7 +110,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
         &self,
         event: &BillChainEvent,
         action: ActionType,
-        recoursee: &IdentityPublicData,
+        recoursee: &BillIdentifiedParticipant,
     ) -> Result<()>;
 
     /// Sent when: A bill is requested to be minted, Sent by: Holder

--- a/crates/bcr-ebill-transport/src/transport.rs
+++ b/crates/bcr-ebill-transport/src/transport.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
-use bcr_ebill_core::ServiceTraitBounds;
+use bcr_ebill_core::{
+    ServiceTraitBounds, blockchain::bill::block::NodeId, contact::BillParticipant,
+};
 use log::info;
 
 #[cfg(test)]
 use mockall::automock;
 
 use crate::{Result, event::EventEnvelope};
-use bcr_ebill_core::contact::IdentityPublicData;
 
 #[cfg(test)]
 impl ServiceTraitBounds for MockNotificationJsonTransportApi {}
@@ -16,7 +17,7 @@ impl ServiceTraitBounds for MockNotificationJsonTransportApi {}
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait NotificationJsonTransportApi: ServiceTraitBounds {
     fn get_sender_key(&self) -> String;
-    async fn send(&self, recipient: &IdentityPublicData, event: EventEnvelope) -> Result<()>;
+    async fn send(&self, recipient: &BillParticipant, event: EventEnvelope) -> Result<()>;
 }
 
 /// A dummy transport that logs all events that are sent as json.
@@ -30,10 +31,13 @@ impl NotificationJsonTransportApi for LoggingNotificationJsonTransport {
     fn get_sender_key(&self) -> String {
         "log_sender".to_string()
     }
-    async fn send(&self, recipient: &IdentityPublicData, event: EventEnvelope) -> Result<()> {
+    async fn send(&self, recipient: &BillParticipant, event: EventEnvelope) -> Result<()> {
         info!(
             "Sending json event: {:?}({}) with payload: {:?} to peer: {}",
-            event.event_type, event.version, event.data, recipient.node_id
+            event.event_type,
+            event.version,
+            event.data,
+            recipient.node_id()
         );
         Ok(())
     }

--- a/crates/bcr-ebill-wasm/Cargo.toml
+++ b/crates/bcr-ebill-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-wasm"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [lib]

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -4,7 +4,7 @@ use bcr_ebill_api::{
         bill::{
             BillAction, BillIssueData, BillsFilterRole, LightBitcreditBillResult, RecourseReason,
         },
-        contact::{BillIdentifiedParticipant, BillParticipant},
+        contact::{BillIdentParticipant, BillParticipant},
     },
     external,
     service::{Error, bill_service::error::Error as BillServiceError},
@@ -323,7 +323,7 @@ impl Bill {
             .execute_bill_action(
                 &offer_to_sell_payload.bill_id,
                 BillAction::OfferToSell(
-                    BillParticipant::Identified(public_data_buyer.clone()), // TODO: support anon
+                    BillParticipant::Ident(public_data_buyer.clone()), // TODO: support anon
                     sum,
                     offer_to_sell_payload.currency.clone(),
                 ),
@@ -360,7 +360,7 @@ impl Bill {
             .bill_service
             .execute_bill_action(
                 &endorse_bill_payload.bill_id,
-                BillAction::Endorse(BillParticipant::Identified(public_data_endorsee.clone())), // TODO: support anon
+                BillAction::Endorse(BillParticipant::Ident(public_data_endorsee.clone())), // TODO: support anon
                 &signer_public_data,
                 &signer_keys,
                 timestamp,
@@ -489,7 +489,7 @@ impl Bill {
             .execute_bill_action(
                 &mint_bill_payload.bill_id,
                 BillAction::Mint(
-                    BillParticipant::Identified(public_mint_node), // TODO: support anon
+                    BillParticipant::Ident(public_mint_node), // TODO: support anon
                     sum,
                     mint_bill_payload.currency.clone(),
                 ),
@@ -676,13 +676,13 @@ impl Default for Bill {
     }
 }
 
-async fn get_signer_public_data_and_keys() -> Result<(BillIdentifiedParticipant, BcrKeys)> {
+async fn get_signer_public_data_and_keys() -> Result<(BillIdentParticipant, BcrKeys)> {
     let current_identity = get_current_identity().await?;
     let local_node_id = current_identity.personal;
     let (signer_public_data, signer_keys) = match current_identity.company {
         None => {
             let identity = get_ctx().identity_service.get_full_identity().await?;
-            match BillIdentifiedParticipant::new(identity.identity) {
+            match BillIdentParticipant::new(identity.identity) {
                 Some(identity_public_data) => (identity_public_data, identity.key_pair),
                 None => {
                     return Err(Error::Validation(ValidationError::DrawerIsNotBillIssuer).into());
@@ -701,7 +701,7 @@ async fn get_signer_public_data_and_keys() -> Result<(BillIdentifiedParticipant,
                 .into());
             }
             (
-                BillIdentifiedParticipant::from(company),
+                BillIdentParticipant::from(company),
                 BcrKeys::from_private_key(&keys.private_key).map_err(Error::CryptoUtil)?,
             )
         }

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -8,9 +8,9 @@ use bcr_ebill_api::data::{
         PastPaymentResult, PastPaymentStatus,
     },
     contact::{
-        BillAnonymousParticipant, BillIdentifiedParticipant, BillParticipant,
-        LightBillAnonymousParticipant, LightBillIdentifiedParticipant,
-        LightBillIdentifiedParticipantWithAddress, LightBillParticipant,
+        BillAnonParticipant, BillIdentParticipant, BillParticipant,
+        LightBillAnonParticipant, LightBillIdentParticipant,
+        LightBillIdentParticipantWithAddress, LightBillParticipant,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -163,7 +163,7 @@ impl FromWeb<BillsFilterRoleWeb> for BillsFilterRole {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct PastEndorseeWeb {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipantWeb,
+    pub pay_to_the_order_of: LightBillIdentParticipantWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddressWeb>,
@@ -184,7 +184,7 @@ impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
 #[tsify(into_wasm_abi)]
 pub struct LightSignedByWeb {
     pub data: LightBillParticipantWeb,
-    pub signatory: Option<LightBillIdentifiedParticipantWeb>,
+    pub signatory: Option<LightBillIdentParticipantWeb>,
 }
 
 impl IntoWeb<LightSignedByWeb> for LightSignedBy {
@@ -199,7 +199,7 @@ impl IntoWeb<LightSignedByWeb> for LightSignedBy {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct EndorsementWeb {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipantWithAddressWeb,
+    pub pay_to_the_order_of: LightBillIdentParticipantWithAddressWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddressWeb>,
@@ -340,7 +340,7 @@ impl IntoWeb<PastPaymentDataSellWeb> for PastPaymentDataSell {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataPaymentWeb {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipantWeb,
+    pub payer: BillIdentParticipantWeb,
     pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
@@ -371,8 +371,8 @@ impl IntoWeb<PastPaymentDataPaymentWeb> for PastPaymentDataPayment {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataRecourseWeb {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipantWeb,
-    pub recoursee: BillIdentifiedParticipantWeb,
+    pub recourser: BillIdentParticipantWeb,
+    pub recoursee: BillIdentParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -489,7 +489,7 @@ impl IntoWeb<BillWaitingForSellStateWeb> for BillWaitingForSellState {
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForPaymentStateWeb {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipantWeb,
+    pub payer: BillIdentParticipantWeb,
     pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
@@ -517,8 +517,8 @@ impl IntoWeb<BillWaitingForPaymentStateWeb> for BillWaitingForPaymentState {
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForRecourseStateWeb {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipantWeb,
-    pub recoursee: BillIdentifiedParticipantWeb,
+    pub recourser: BillIdentParticipantWeb,
+    pub recoursee: BillIdentParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -691,8 +691,8 @@ impl IntoWeb<BillDataWeb> for BillData {
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub struct BillParticipantsWeb {
-    pub drawee: BillIdentifiedParticipantWeb,
-    pub drawer: BillIdentifiedParticipantWeb,
+    pub drawee: BillIdentParticipantWeb,
+    pub drawer: BillIdentParticipantWeb,
     pub payee: BillParticipantWeb,
     pub endorsee: Option<BillParticipantWeb>,
     pub endorsements_count: u64,
@@ -716,8 +716,8 @@ impl IntoWeb<BillParticipantsWeb> for BillParticipants {
 #[tsify(into_wasm_abi)]
 pub struct LightBitcreditBillWeb {
     pub id: String,
-    pub drawee: LightBillIdentifiedParticipantWeb,
-    pub drawer: LightBillIdentifiedParticipantWeb,
+    pub drawee: LightBillIdentParticipantWeb,
+    pub drawer: LightBillIdentParticipantWeb,
     pub payee: LightBillParticipantWeb,
     pub endorsee: Option<LightBillParticipantWeb>,
     pub active_notification: Option<NotificationWeb>,
@@ -749,30 +749,30 @@ impl IntoWeb<LightBitcreditBillWeb> for LightBitcreditBillResult {
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub enum BillParticipantWeb {
-    Anonymous(BillAnonymousParticipantWeb),
-    Identified(BillIdentifiedParticipantWeb),
+    Anon(BillAnonParticipantWeb),
+    Ident(BillIdentParticipantWeb),
 }
 
 impl IntoWeb<BillParticipantWeb> for BillParticipant {
     fn into_web(self) -> BillParticipantWeb {
         match self {
-            BillParticipant::Identified(data) => BillParticipantWeb::Identified(data.into_web()),
-            BillParticipant::Anonymous(data) => BillParticipantWeb::Anonymous(data.into_web()),
+            BillParticipant::Ident(data) => BillParticipantWeb::Ident(data.into_web()),
+            BillParticipant::Anon(data) => BillParticipantWeb::Anon(data.into_web()),
         }
     }
 }
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct BillAnonymousParticipantWeb {
+pub struct BillAnonParticipantWeb {
     pub node_id: String,
     pub email: Option<String>,
     pub nostr_relay: Option<String>,
 }
 
-impl IntoWeb<BillAnonymousParticipantWeb> for BillAnonymousParticipant {
-    fn into_web(self) -> BillAnonymousParticipantWeb {
-        BillAnonymousParticipantWeb {
+impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
+    fn into_web(self) -> BillAnonParticipantWeb {
+        BillAnonParticipantWeb {
             node_id: self.node_id,
             email: self.email,
             nostr_relay: self.nostr_relay,
@@ -782,7 +782,7 @@ impl IntoWeb<BillAnonymousParticipantWeb> for BillAnonymousParticipant {
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct BillIdentifiedParticipantWeb {
+pub struct BillIdentParticipantWeb {
     pub t: ContactTypeWeb,
     pub node_id: String,
     pub name: String,
@@ -791,9 +791,9 @@ pub struct BillIdentifiedParticipantWeb {
     pub nostr_relay: Option<String>,
 }
 
-impl IntoWeb<BillIdentifiedParticipantWeb> for BillIdentifiedParticipant {
-    fn into_web(self) -> BillIdentifiedParticipantWeb {
-        BillIdentifiedParticipantWeb {
+impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
+    fn into_web(self) -> BillIdentParticipantWeb {
+        BillIdentParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -806,18 +806,18 @@ impl IntoWeb<BillIdentifiedParticipantWeb> for BillIdentifiedParticipant {
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct LightBillIdentifiedParticipantWithAddressWeb {
+pub struct LightBillIdentParticipantWithAddressWeb {
     pub t: ContactTypeWeb,
     pub name: String,
     pub node_id: String,
     pub postal_address: PostalAddressWeb,
 }
 
-impl IntoWeb<LightBillIdentifiedParticipantWithAddressWeb>
-    for LightBillIdentifiedParticipantWithAddress
+impl IntoWeb<LightBillIdentParticipantWithAddressWeb>
+    for LightBillIdentParticipantWithAddress
 {
-    fn into_web(self) -> LightBillIdentifiedParticipantWithAddressWeb {
-        LightBillIdentifiedParticipantWithAddressWeb {
+    fn into_web(self) -> LightBillIdentParticipantWithAddressWeb {
+        LightBillIdentParticipantWithAddressWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -829,18 +829,18 @@ impl IntoWeb<LightBillIdentifiedParticipantWithAddressWeb>
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub enum LightBillParticipantWeb {
-    Anonymous(LightBillAnonymousParticipantWeb),
-    Identified(LightBillIdentifiedParticipantWeb),
+    Anon(LightBillAnonParticipantWeb),
+    Ident(LightBillIdentParticipantWeb),
 }
 
 impl IntoWeb<LightBillParticipantWeb> for LightBillParticipant {
     fn into_web(self) -> LightBillParticipantWeb {
         match self {
-            LightBillParticipant::Identified(data) => {
-                LightBillParticipantWeb::Identified(data.into_web())
+            LightBillParticipant::Ident(data) => {
+                LightBillParticipantWeb::Ident(data.into_web())
             }
-            LightBillParticipant::Anonymous(data) => {
-                LightBillParticipantWeb::Anonymous(data.into_web())
+            LightBillParticipant::Anon(data) => {
+                LightBillParticipantWeb::Anon(data.into_web())
             }
         }
     }
@@ -848,13 +848,13 @@ impl IntoWeb<LightBillParticipantWeb> for LightBillParticipant {
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct LightBillAnonymousParticipantWeb {
+pub struct LightBillAnonParticipantWeb {
     pub node_id: String,
 }
 
-impl IntoWeb<LightBillAnonymousParticipantWeb> for LightBillAnonymousParticipant {
-    fn into_web(self) -> LightBillAnonymousParticipantWeb {
-        LightBillAnonymousParticipantWeb {
+impl IntoWeb<LightBillAnonParticipantWeb> for LightBillAnonParticipant {
+    fn into_web(self) -> LightBillAnonParticipantWeb {
+        LightBillAnonParticipantWeb {
             node_id: self.node_id,
         }
     }
@@ -862,15 +862,15 @@ impl IntoWeb<LightBillAnonymousParticipantWeb> for LightBillAnonymousParticipant
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct LightBillIdentifiedParticipantWeb {
+pub struct LightBillIdentParticipantWeb {
     pub t: ContactTypeWeb,
     pub name: String,
     pub node_id: String,
 }
 
-impl IntoWeb<LightBillIdentifiedParticipantWeb> for LightBillIdentifiedParticipant {
-    fn into_web(self) -> LightBillIdentifiedParticipantWeb {
-        LightBillIdentifiedParticipantWeb {
+impl IntoWeb<LightBillIdentParticipantWeb> for LightBillIdentParticipant {
+    fn into_web(self) -> LightBillIdentParticipantWeb {
+        LightBillIdentParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -7,7 +7,11 @@ use bcr_ebill_api::data::{
         PastEndorsee, PastPaymentDataPayment, PastPaymentDataRecourse, PastPaymentDataSell,
         PastPaymentResult, PastPaymentStatus,
     },
-    contact::{IdentityPublicData, LightIdentityPublicData, LightIdentityPublicDataWithAddress},
+    contact::{
+        BillAnonymousParticipant, BillIdentifiedParticipant, BillParticipant,
+        LightBillAnonymousParticipant, LightBillIdentifiedParticipant,
+        LightBillIdentifiedParticipantWithAddress, LightBillParticipant,
+    },
 };
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
@@ -159,10 +163,10 @@ impl FromWeb<BillsFilterRoleWeb> for BillsFilterRole {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct PastEndorseeWeb {
-    pub pay_to_the_order_of: LightIdentityPublicDataWeb,
+    pub pay_to_the_order_of: LightBillIdentifiedParticipantWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
-    pub signing_address: PostalAddressWeb,
+    pub signing_address: Option<PostalAddressWeb>,
 }
 
 impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
@@ -171,7 +175,7 @@ impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
             pay_to_the_order_of: self.pay_to_the_order_of.into_web(),
             signed: self.signed.into_web(),
             signing_timestamp: self.signing_timestamp,
-            signing_address: self.signing_address.into_web(),
+            signing_address: self.signing_address.map(|s| s.into_web()),
         }
     }
 }
@@ -179,8 +183,8 @@ impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct LightSignedByWeb {
-    pub data: LightIdentityPublicDataWeb,
-    pub signatory: Option<LightIdentityPublicDataWeb>,
+    pub data: LightBillParticipantWeb,
+    pub signatory: Option<LightBillIdentifiedParticipantWeb>,
 }
 
 impl IntoWeb<LightSignedByWeb> for LightSignedBy {
@@ -195,10 +199,10 @@ impl IntoWeb<LightSignedByWeb> for LightSignedBy {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct EndorsementWeb {
-    pub pay_to_the_order_of: LightIdentityPublicDataWithAddressWeb,
+    pub pay_to_the_order_of: LightBillIdentifiedParticipantWithAddressWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
-    pub signing_address: PostalAddressWeb,
+    pub signing_address: Option<PostalAddressWeb>,
 }
 
 impl IntoWeb<EndorsementWeb> for Endorsement {
@@ -207,7 +211,7 @@ impl IntoWeb<EndorsementWeb> for Endorsement {
             pay_to_the_order_of: self.pay_to_the_order_of.into_web(),
             signed: self.signed.into_web(),
             signing_timestamp: self.signing_timestamp,
-            signing_address: self.signing_address.into_web(),
+            signing_address: self.signing_address.map(|s| s.into_web()),
         }
     }
 }
@@ -304,8 +308,8 @@ impl IntoWeb<PastPaymentStatusWeb> for PastPaymentStatus {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataSellWeb {
     pub time_of_request: u64,
-    pub buyer: IdentityPublicDataWeb,
-    pub seller: IdentityPublicDataWeb,
+    pub buyer: BillParticipantWeb,
+    pub seller: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -336,8 +340,8 @@ impl IntoWeb<PastPaymentDataSellWeb> for PastPaymentDataSell {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataPaymentWeb {
     pub time_of_request: u64,
-    pub payer: IdentityPublicDataWeb,
-    pub payee: IdentityPublicDataWeb,
+    pub payer: BillIdentifiedParticipantWeb,
+    pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -367,8 +371,8 @@ impl IntoWeb<PastPaymentDataPaymentWeb> for PastPaymentDataPayment {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataRecourseWeb {
     pub time_of_request: u64,
-    pub recourser: IdentityPublicDataWeb,
-    pub recoursee: IdentityPublicDataWeb,
+    pub recourser: BillIdentifiedParticipantWeb,
+    pub recoursee: BillIdentifiedParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -457,8 +461,8 @@ impl IntoWeb<BillCurrentWaitingStateWeb> for BillCurrentWaitingState {
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForSellStateWeb {
     pub time_of_request: u64,
-    pub buyer: IdentityPublicDataWeb,
-    pub seller: IdentityPublicDataWeb,
+    pub buyer: BillParticipantWeb,
+    pub seller: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -485,8 +489,8 @@ impl IntoWeb<BillWaitingForSellStateWeb> for BillWaitingForSellState {
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForPaymentStateWeb {
     pub time_of_request: u64,
-    pub payer: IdentityPublicDataWeb,
-    pub payee: IdentityPublicDataWeb,
+    pub payer: BillIdentifiedParticipantWeb,
+    pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -513,8 +517,8 @@ impl IntoWeb<BillWaitingForPaymentStateWeb> for BillWaitingForPaymentState {
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForRecourseStateWeb {
     pub time_of_request: u64,
-    pub recourser: IdentityPublicDataWeb,
-    pub recoursee: IdentityPublicDataWeb,
+    pub recourser: BillIdentifiedParticipantWeb,
+    pub recoursee: BillIdentifiedParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -687,10 +691,10 @@ impl IntoWeb<BillDataWeb> for BillData {
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub struct BillParticipantsWeb {
-    pub drawee: IdentityPublicDataWeb,
-    pub drawer: IdentityPublicDataWeb,
-    pub payee: IdentityPublicDataWeb,
-    pub endorsee: Option<IdentityPublicDataWeb>,
+    pub drawee: BillIdentifiedParticipantWeb,
+    pub drawer: BillIdentifiedParticipantWeb,
+    pub payee: BillParticipantWeb,
+    pub endorsee: Option<BillParticipantWeb>,
     pub endorsements_count: u64,
     pub all_participant_node_ids: Vec<String>,
 }
@@ -712,10 +716,10 @@ impl IntoWeb<BillParticipantsWeb> for BillParticipants {
 #[tsify(into_wasm_abi)]
 pub struct LightBitcreditBillWeb {
     pub id: String,
-    pub drawee: LightIdentityPublicDataWeb,
-    pub drawer: LightIdentityPublicDataWeb,
-    pub payee: LightIdentityPublicDataWeb,
-    pub endorsee: Option<LightIdentityPublicDataWeb>,
+    pub drawee: LightBillIdentifiedParticipantWeb,
+    pub drawer: LightBillIdentifiedParticipantWeb,
+    pub payee: LightBillParticipantWeb,
+    pub endorsee: Option<LightBillParticipantWeb>,
     pub active_notification: Option<NotificationWeb>,
     pub sum: String,
     pub currency: String,
@@ -744,7 +748,41 @@ impl IntoWeb<LightBitcreditBillWeb> for LightBitcreditBillResult {
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct IdentityPublicDataWeb {
+pub enum BillParticipantWeb {
+    Anonymous(BillAnonymousParticipantWeb),
+    Identified(BillIdentifiedParticipantWeb),
+}
+
+impl IntoWeb<BillParticipantWeb> for BillParticipant {
+    fn into_web(self) -> BillParticipantWeb {
+        match self {
+            BillParticipant::Identified(data) => BillParticipantWeb::Identified(data.into_web()),
+            BillParticipant::Anonymous(data) => BillParticipantWeb::Anonymous(data.into_web()),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct BillAnonymousParticipantWeb {
+    pub node_id: String,
+    pub email: Option<String>,
+    pub nostr_relay: Option<String>,
+}
+
+impl IntoWeb<BillAnonymousParticipantWeb> for BillAnonymousParticipant {
+    fn into_web(self) -> BillAnonymousParticipantWeb {
+        BillAnonymousParticipantWeb {
+            node_id: self.node_id,
+            email: self.email,
+            nostr_relay: self.nostr_relay,
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct BillIdentifiedParticipantWeb {
     pub t: ContactTypeWeb,
     pub node_id: String,
     pub name: String,
@@ -753,9 +791,9 @@ pub struct IdentityPublicDataWeb {
     pub nostr_relay: Option<String>,
 }
 
-impl IntoWeb<IdentityPublicDataWeb> for IdentityPublicData {
-    fn into_web(self) -> IdentityPublicDataWeb {
-        IdentityPublicDataWeb {
+impl IntoWeb<BillIdentifiedParticipantWeb> for BillIdentifiedParticipant {
+    fn into_web(self) -> BillIdentifiedParticipantWeb {
+        BillIdentifiedParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -768,16 +806,18 @@ impl IntoWeb<IdentityPublicDataWeb> for IdentityPublicData {
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct LightIdentityPublicDataWithAddressWeb {
+pub struct LightBillIdentifiedParticipantWithAddressWeb {
     pub t: ContactTypeWeb,
     pub name: String,
     pub node_id: String,
     pub postal_address: PostalAddressWeb,
 }
 
-impl IntoWeb<LightIdentityPublicDataWithAddressWeb> for LightIdentityPublicDataWithAddress {
-    fn into_web(self) -> LightIdentityPublicDataWithAddressWeb {
-        LightIdentityPublicDataWithAddressWeb {
+impl IntoWeb<LightBillIdentifiedParticipantWithAddressWeb>
+    for LightBillIdentifiedParticipantWithAddress
+{
+    fn into_web(self) -> LightBillIdentifiedParticipantWithAddressWeb {
+        LightBillIdentifiedParticipantWithAddressWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -788,15 +828,49 @@ impl IntoWeb<LightIdentityPublicDataWithAddressWeb> for LightIdentityPublicDataW
 
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
-pub struct LightIdentityPublicDataWeb {
+pub enum LightBillParticipantWeb {
+    Anonymous(LightBillAnonymousParticipantWeb),
+    Identified(LightBillIdentifiedParticipantWeb),
+}
+
+impl IntoWeb<LightBillParticipantWeb> for LightBillParticipant {
+    fn into_web(self) -> LightBillParticipantWeb {
+        match self {
+            LightBillParticipant::Identified(data) => {
+                LightBillParticipantWeb::Identified(data.into_web())
+            }
+            LightBillParticipant::Anonymous(data) => {
+                LightBillParticipantWeb::Anonymous(data.into_web())
+            }
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct LightBillAnonymousParticipantWeb {
+    pub node_id: String,
+}
+
+impl IntoWeb<LightBillAnonymousParticipantWeb> for LightBillAnonymousParticipant {
+    fn into_web(self) -> LightBillAnonymousParticipantWeb {
+        LightBillAnonymousParticipantWeb {
+            node_id: self.node_id,
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct LightBillIdentifiedParticipantWeb {
     pub t: ContactTypeWeb,
     pub name: String,
     pub node_id: String,
 }
 
-impl IntoWeb<LightIdentityPublicDataWeb> for LightIdentityPublicData {
-    fn into_web(self) -> LightIdentityPublicDataWeb {
-        LightIdentityPublicDataWeb {
+impl IntoWeb<LightBillIdentifiedParticipantWeb> for LightBillIdentifiedParticipant {
+    fn into_web(self) -> LightBillIdentifiedParticipantWeb {
+        LightBillIdentifiedParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -45,7 +45,7 @@ enum JsErrorType {
     InvalidContentType,
     InvalidContactType,
     InvalidDate,
-    SignerCantBeAnonymous,
+    SignerCantBeAnon,
     IssueDateAfterMaturityDate,
     MaturityDateInThePast,
     InvalidFileUploadId,
@@ -197,7 +197,7 @@ fn validation_error_data(e: ValidationError) -> JsErrorData {
         ValidationError::InvalidContactType => err_400(e, JsErrorType::InvalidContactType),
         ValidationError::InvalidContentType => err_400(e, JsErrorType::InvalidContentType),
         ValidationError::InvalidDate => err_400(e, JsErrorType::InvalidDate),
-        ValidationError::SignerCantBeAnonymous => err_400(e, JsErrorType::SignerCantBeAnonymous),
+        ValidationError::SignerCantBeAnon => err_400(e, JsErrorType::SignerCantBeAnon),
         ValidationError::MaturityDateInThePast => err_400(e, JsErrorType::MaturityDateInThePast),
         ValidationError::IssueDateAfterMaturityDate => {
             err_400(e, JsErrorType::IssueDateAfterMaturityDate)

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -45,6 +45,7 @@ enum JsErrorType {
     InvalidContentType,
     InvalidContactType,
     InvalidDate,
+    SignerCantBeAnonymous,
     IssueDateAfterMaturityDate,
     MaturityDateInThePast,
     InvalidFileUploadId,
@@ -196,6 +197,7 @@ fn validation_error_data(e: ValidationError) -> JsErrorData {
         ValidationError::InvalidContactType => err_400(e, JsErrorType::InvalidContactType),
         ValidationError::InvalidContentType => err_400(e, JsErrorType::InvalidContentType),
         ValidationError::InvalidDate => err_400(e, JsErrorType::InvalidDate),
+        ValidationError::SignerCantBeAnonymous => err_400(e, JsErrorType::SignerCantBeAnonymous),
         ValidationError::MaturityDateInThePast => err_400(e, JsErrorType::MaturityDateInThePast),
         ValidationError::IssueDateAfterMaturityDate => {
             err_400(e, JsErrorType::IssueDateAfterMaturityDate)

--- a/crates/bcr-ebill-web/Cargo.toml
+++ b/crates/bcr-ebill-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcr-ebill-web"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 
 [dependencies]

--- a/crates/bcr-ebill-web/src/data.rs
+++ b/crates/bcr-ebill-web/src/data.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bcr_ebill_api::data::contact::{
-    BillAnonymousParticipant, BillParticipant, LightBillAnonymousParticipant, LightBillParticipant,
+    BillAnonParticipant, BillParticipant, LightBillAnonParticipant, LightBillParticipant,
 };
 use bcr_ebill_api::service::Error;
 use bcr_ebill_api::util::file::{UploadFileHandler, detect_content_type_for_bytes};
@@ -18,8 +18,8 @@ use bcr_ebill_api::{
         },
         company::Company,
         contact::{
-            BillIdentifiedParticipant, Contact, ContactType, LightBillIdentifiedParticipant,
-            LightBillIdentifiedParticipantWithAddress,
+            BillIdentParticipant, Contact, ContactType, LightBillIdentParticipant,
+            LightBillIdentParticipantWithAddress,
         },
         identity::{Identity, IdentityType},
         notification::{Notification, NotificationType},
@@ -284,7 +284,7 @@ impl FromWeb<BillsFilterRoleWeb> for BillsFilterRole {
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PastEndorseeWeb {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipantWeb,
+    pub pay_to_the_order_of: LightBillIdentParticipantWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddressWeb>,
@@ -305,7 +305,7 @@ impl IntoWeb<PastEndorseeWeb> for PastEndorsee {
 pub struct LightSignedByWeb {
     #[serde(flatten)]
     pub data: LightBillParticipantWeb,
-    pub signatory: Option<LightBillIdentifiedParticipantWeb>,
+    pub signatory: Option<LightBillIdentParticipantWeb>,
 }
 
 impl IntoWeb<LightSignedByWeb> for LightSignedBy {
@@ -319,7 +319,7 @@ impl IntoWeb<LightSignedByWeb> for LightSignedBy {
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct EndorsementWeb {
-    pub pay_to_the_order_of: LightBillIdentifiedParticipantWithAddressWeb,
+    pub pay_to_the_order_of: LightBillIdentParticipantWithAddressWeb,
     pub signed: LightSignedByWeb,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddressWeb>,
@@ -862,7 +862,7 @@ impl IntoWeb<BillWaitingForSellStateWeb> for BillWaitingForSellState {
 #[derive(Debug, Serialize, Clone, ToSchema)]
 pub struct BillWaitingForPaymentStateWeb {
     pub time_of_request: u64,
-    pub payer: BillIdentifiedParticipantWeb,
+    pub payer: BillIdentParticipantWeb,
     pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
@@ -889,8 +889,8 @@ impl IntoWeb<BillWaitingForPaymentStateWeb> for BillWaitingForPaymentState {
 #[derive(Debug, Serialize, Clone, ToSchema)]
 pub struct BillWaitingForRecourseStateWeb {
     pub time_of_request: u64,
-    pub recourser: BillIdentifiedParticipantWeb,
-    pub recoursee: BillIdentifiedParticipantWeb,
+    pub recourser: BillIdentParticipantWeb,
+    pub recoursee: BillIdentParticipantWeb,
     pub currency: String,
     pub sum: String,
     pub link_to_pay: String,
@@ -1056,8 +1056,8 @@ impl IntoWeb<BillDataWeb> for BillData {
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
 pub struct BillParticipantsWeb {
-    pub drawee: BillIdentifiedParticipantWeb,
-    pub drawer: BillIdentifiedParticipantWeb,
+    pub drawee: BillIdentParticipantWeb,
+    pub drawer: BillIdentParticipantWeb,
     pub payee: BillParticipantWeb,
     pub endorsee: Option<BillParticipantWeb>,
     pub endorsements_count: u64,
@@ -1080,8 +1080,8 @@ impl IntoWeb<BillParticipantsWeb> for BillParticipants {
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct LightBitcreditBillWeb {
     pub id: String,
-    pub drawee: LightBillIdentifiedParticipantWeb,
-    pub drawer: LightBillIdentifiedParticipantWeb,
+    pub drawee: LightBillIdentParticipantWeb,
+    pub drawer: LightBillIdentParticipantWeb,
     pub payee: LightBillParticipantWeb,
     pub endorsee: Option<LightBillParticipantWeb>,
     pub active_notification: Option<NotificationWeb>,
@@ -1111,29 +1111,29 @@ impl IntoWeb<LightBitcreditBillWeb> for LightBitcreditBillResult {
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
 pub enum BillParticipantWeb {
-    Anonymous(BillAnonymousParticipantWeb),
-    Identified(BillIdentifiedParticipantWeb),
+    Anon(BillAnonParticipantWeb),
+    Ident(BillIdentParticipantWeb),
 }
 
 impl IntoWeb<BillParticipantWeb> for BillParticipant {
     fn into_web(self) -> BillParticipantWeb {
         match self {
-            BillParticipant::Identified(data) => BillParticipantWeb::Identified(data.into_web()),
-            BillParticipant::Anonymous(data) => BillParticipantWeb::Anonymous(data.into_web()),
+            BillParticipant::Ident(data) => BillParticipantWeb::Ident(data.into_web()),
+            BillParticipant::Anon(data) => BillParticipantWeb::Anon(data.into_web()),
         }
     }
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
-pub struct BillAnonymousParticipantWeb {
+pub struct BillAnonParticipantWeb {
     pub node_id: String,
     pub email: Option<String>,
     pub nostr_relay: Option<String>,
 }
 
-impl IntoWeb<BillAnonymousParticipantWeb> for BillAnonymousParticipant {
-    fn into_web(self) -> BillAnonymousParticipantWeb {
-        BillAnonymousParticipantWeb {
+impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
+    fn into_web(self) -> BillAnonParticipantWeb {
+        BillAnonParticipantWeb {
             node_id: self.node_id,
             email: self.email,
             nostr_relay: self.nostr_relay,
@@ -1142,7 +1142,7 @@ impl IntoWeb<BillAnonymousParticipantWeb> for BillAnonymousParticipant {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct BillIdentifiedParticipantWeb {
+pub struct BillIdentParticipantWeb {
     #[serde(rename = "type")]
     pub t: ContactTypeWeb,
     pub node_id: String,
@@ -1153,9 +1153,9 @@ pub struct BillIdentifiedParticipantWeb {
     pub nostr_relay: Option<String>,
 }
 
-impl IntoWeb<BillIdentifiedParticipantWeb> for BillIdentifiedParticipant {
-    fn into_web(self) -> BillIdentifiedParticipantWeb {
-        BillIdentifiedParticipantWeb {
+impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
+    fn into_web(self) -> BillIdentParticipantWeb {
+        BillIdentParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -1168,47 +1168,47 @@ impl IntoWeb<BillIdentifiedParticipantWeb> for BillIdentifiedParticipant {
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub enum LightBillParticipantWeb {
-    Anonymous(LightBillAnonymousParticipantWeb),
-    Identified(LightBillIdentifiedParticipantWeb),
+    Anon(LightBillAnonParticipantWeb),
+    Ident(LightBillIdentParticipantWeb),
 }
 
 impl IntoWeb<LightBillParticipantWeb> for LightBillParticipant {
     fn into_web(self) -> LightBillParticipantWeb {
         match self {
-            LightBillParticipant::Identified(data) => {
-                LightBillParticipantWeb::Identified(data.into_web())
+            LightBillParticipant::Ident(data) => {
+                LightBillParticipantWeb::Ident(data.into_web())
             }
-            LightBillParticipant::Anonymous(data) => {
-                LightBillParticipantWeb::Anonymous(data.into_web())
+            LightBillParticipant::Anon(data) => {
+                LightBillParticipantWeb::Anon(data.into_web())
             }
         }
     }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct LightBillAnonymousParticipantWeb {
+pub struct LightBillAnonParticipantWeb {
     pub node_id: String,
 }
 
-impl IntoWeb<LightBillAnonymousParticipantWeb> for LightBillAnonymousParticipant {
-    fn into_web(self) -> LightBillAnonymousParticipantWeb {
-        LightBillAnonymousParticipantWeb {
+impl IntoWeb<LightBillAnonParticipantWeb> for LightBillAnonParticipant {
+    fn into_web(self) -> LightBillAnonParticipantWeb {
+        LightBillAnonParticipantWeb {
             node_id: self.node_id,
         }
     }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct LightBillIdentifiedParticipantWeb {
+pub struct LightBillIdentParticipantWeb {
     #[serde(rename = "type")]
     pub t: ContactTypeWeb,
     pub name: String,
     pub node_id: String,
 }
 
-impl IntoWeb<LightBillIdentifiedParticipantWeb> for LightBillIdentifiedParticipant {
-    fn into_web(self) -> LightBillIdentifiedParticipantWeb {
-        LightBillIdentifiedParticipantWeb {
+impl IntoWeb<LightBillIdentParticipantWeb> for LightBillIdentParticipant {
+    fn into_web(self) -> LightBillIdentParticipantWeb {
+        LightBillIdentParticipantWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,
@@ -1217,7 +1217,7 @@ impl IntoWeb<LightBillIdentifiedParticipantWeb> for LightBillIdentifiedParticipa
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
-pub struct LightBillIdentifiedParticipantWithAddressWeb {
+pub struct LightBillIdentParticipantWithAddressWeb {
     #[serde(rename = "type")]
     pub t: ContactTypeWeb,
     pub name: String,
@@ -1226,11 +1226,11 @@ pub struct LightBillIdentifiedParticipantWithAddressWeb {
     pub postal_address: PostalAddressWeb,
 }
 
-impl IntoWeb<LightBillIdentifiedParticipantWithAddressWeb>
-    for LightBillIdentifiedParticipantWithAddress
+impl IntoWeb<LightBillIdentParticipantWithAddressWeb>
+    for LightBillIdentParticipantWithAddress
 {
-    fn into_web(self) -> LightBillIdentifiedParticipantWithAddressWeb {
-        LightBillIdentifiedParticipantWithAddressWeb {
+    fn into_web(self) -> LightBillIdentParticipantWithAddressWeb {
+        LightBillIdentParticipantWithAddressWeb {
             t: self.t.into_web(),
             name: self.name,
             node_id: self.node_id,

--- a/crates/bcr-ebill-web/src/handlers/mod.rs
+++ b/crates/bcr-ebill-web/src/handlers/mod.rs
@@ -309,7 +309,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ValidationError {
                 | bcr_ebill_api::util::ValidationError::InvalidCurrency
                 | bcr_ebill_api::util::ValidationError::InvalidPaymentAddress
                 | bcr_ebill_api::util::ValidationError::InvalidDate
-                | bcr_ebill_api::util::ValidationError::SignerCantBeAnonymous
+                | bcr_ebill_api::util::ValidationError::SignerCantBeAnon
                 | bcr_ebill_api::util::ValidationError::IssueDateAfterMaturityDate
                 | bcr_ebill_api::util::ValidationError::MaturityDateInThePast
                 | bcr_ebill_api::util::ValidationError::InvalidFileUploadId

--- a/crates/bcr-ebill-web/src/handlers/mod.rs
+++ b/crates/bcr-ebill-web/src/handlers/mod.rs
@@ -309,6 +309,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ValidationError {
                 | bcr_ebill_api::util::ValidationError::InvalidCurrency
                 | bcr_ebill_api::util::ValidationError::InvalidPaymentAddress
                 | bcr_ebill_api::util::ValidationError::InvalidDate
+                | bcr_ebill_api::util::ValidationError::SignerCantBeAnonymous
                 | bcr_ebill_api::util::ValidationError::IssueDateAfterMaturityDate
                 | bcr_ebill_api::util::ValidationError::MaturityDateInThePast
                 | bcr_ebill_api::util::ValidationError::InvalidFileUploadId


### PR DESCRIPTION
## 📝 Description

This is the first step of `Anonymous mode`

**Important: It's a lot of code, but the meat is in `bcr-ebill-core`. The rest is mostly refactoring based on the core changes**

The idea is to add the concept of `BillParticipant`, which can be either `Anonymous` or `Identified` and has different data for each variant.

For bill roles, which *have* to be identified (e.g. drawee), we directly use `BillIdentifiedParticipant`, so we have a type-system-level check that we can't have anonymous participants in areas where they're not allowed.

The `signing_address` is now also optional and we'll enforce correct handling via validation

It also includes a big renaming from the `identity public data` concept to `bill participants`, which is clearer.

The name `Bearer` for anon users is not persisted in blocks, but rather added on the frontend, so we can change it, or internationalize it more easily.

Relates to #406 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
