### PR TITLE
Use list of nost relays everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.3.11
 
+* Use a list of Nostr relays everywhere, instead of a single one, including in the config
 * Add Blank Endorse Bill data model implementation
     * Rename `IdentityPublicData` to `BillIdentParticipant`
         * same for `LightIdentityPublicData`

--- a/crates/bcr-ebill-api/src/lib.rs
+++ b/crates/bcr-ebill-api/src/lib.rs
@@ -24,7 +24,7 @@ pub use persistence::notification::NotificationFilter;
 pub struct Config {
     pub bitcoin_network: String,
     pub esplora_base_url: String,
-    pub nostr_relay: String,
+    pub nostr_relays: Vec<String>,
     pub surreal_db_connection: String,
     pub data_dir: String,
 }

--- a/crates/bcr-ebill-api/src/service/contact_service.rs
+++ b/crates/bcr-ebill-api/src/service/contact_service.rs
@@ -382,7 +382,7 @@ impl ContactServiceApi for ContactService {
                     identification_number,
                     avatar_file,
                     proof_document_file,
-                    nostr_relays: vec![get_config().nostr_relay.clone()], // Use the configured relay for now
+                    nostr_relays: get_config().nostr_relays.clone(), // Use the configured relays for now
                 }
             }
             ContactType::Anon => {
@@ -398,7 +398,7 @@ impl ContactServiceApi for ContactService {
                     identification_number: None,
                     avatar_file: None,
                     proof_document_file: None,
-                    nostr_relays: vec![get_config().nostr_relay.clone()], // Use the configured relay for now
+                    nostr_relays: get_config().nostr_relays.clone(), // Use the configured relays for now
                 }
             }
         };
@@ -479,7 +479,7 @@ impl ContactServiceApi for ContactService {
             identification_number,
             avatar_file,
             proof_document_file,
-            nostr_relays: vec![get_config().nostr_relay.clone()], // Use the configured relay for now
+            nostr_relays: get_config().nostr_relays.clone(), // Use the configured relays for now
         };
 
         self.store.update(node_id, contact.clone()).await?;

--- a/crates/bcr-ebill-api/src/service/identity_service.rs
+++ b/crates/bcr-ebill-api/src/service/identity_service.rs
@@ -369,7 +369,7 @@ impl IdentityServiceApi for IdentityService {
                     identification_number,
                     profile_picture_file,
                     identity_document_file,
-                    nostr_relay: Some(get_config().nostr_relay.to_owned()),
+                    nostr_relays: get_config().nostr_relays.to_owned(),
                 }
             }
             IdentityType::Anon => Identity {
@@ -384,7 +384,7 @@ impl IdentityServiceApi for IdentityService {
                 identification_number: None,
                 profile_picture_file: None,
                 identity_document_file: None,
-                nostr_relay: Some(get_config().nostr_relay.to_owned()),
+                nostr_relays: get_config().nostr_relays.to_owned(),
             },
         };
 
@@ -469,7 +469,7 @@ impl IdentityServiceApi for IdentityService {
             identification_number: identification_number.clone(),
             profile_picture_file: profile_picture_file.clone(),
             identity_document_file: identity_document_file.clone(),
-            nostr_relay: Some(get_config().nostr_relay.to_owned()),
+            nostr_relays: get_config().nostr_relays.to_owned(),
         };
 
         let previous_block = self.blockchain_store.get_latest_block().await?;

--- a/crates/bcr-ebill-api/src/service/notification_service/default_service.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/default_service.rs
@@ -28,7 +28,7 @@ pub struct DefaultNotificationService {
     notification_store: Arc<dyn NotificationStoreApi>,
     contact_service: Arc<dyn ContactServiceApi>,
     queued_message_store: Arc<dyn NostrQueuedMessageStoreApi>,
-    nostr_relay: String,
+    nostr_relays: Vec<String>,
 }
 
 impl ServiceTraitBounds for DefaultNotificationService {}
@@ -42,7 +42,7 @@ impl DefaultNotificationService {
         notification_store: Arc<dyn NotificationStoreApi>,
         contact_service: Arc<dyn ContactServiceApi>,
         queued_message_store: Arc<dyn NostrQueuedMessageStoreApi>,
-        nostr_relay: &str,
+        nostr_relays: Vec<String>,
     ) -> Self {
         Self {
             notification_transport: notification_transport
@@ -52,7 +52,7 @@ impl DefaultNotificationService {
             notification_store,
             contact_service,
             queued_message_store,
-            nostr_relay: nostr_relay.to_string(),
+            nostr_relays,
         }
     }
 
@@ -65,7 +65,7 @@ impl DefaultNotificationService {
                 email: None,
                 name: String::new(),
                 postal_address: PostalAddress::default(),
-                nostr_relay: Some(self.nostr_relay.clone()),
+                nostr_relays: self.nostr_relays.clone(),
             }))
         } else {
             None
@@ -566,9 +566,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_request_to_action_rejected_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -658,7 +658,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -684,9 +684,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_request_to_action_rejected_does_not_send_non_rejectable_action() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -744,7 +744,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -756,9 +756,21 @@ mod tests {
     #[tokio::test]
     async fn test_send_request_to_action_timed_out_event() {
         let recipients = vec![
-            BillParticipant::Ident(get_identity_public_data("part1", "part1@example.com", None)),
-            BillParticipant::Ident(get_identity_public_data("part2", "part2@example.com", None)),
-            BillParticipant::Ident(get_identity_public_data("part3", "part3@example.com", None)),
+            BillParticipant::Ident(get_identity_public_data(
+                "part1",
+                "part1@example.com",
+                vec![],
+            )),
+            BillParticipant::Ident(get_identity_public_data(
+                "part2",
+                "part2@example.com",
+                vec![],
+            )),
+            BillParticipant::Ident(get_identity_public_data(
+                "part3",
+                "part3@example.com",
+                vec![],
+            )),
         ];
 
         let mut mock = MockNotificationJsonTransport::new();
@@ -784,7 +796,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -813,9 +825,21 @@ mod tests {
     #[tokio::test]
     async fn test_send_request_to_action_timed_out_does_not_send_non_timeout_action() {
         let recipients = vec![
-            BillParticipant::Ident(get_identity_public_data("part1", "part1@example.com", None)),
-            BillParticipant::Ident(get_identity_public_data("part2", "part2@example.com", None)),
-            BillParticipant::Ident(get_identity_public_data("part3", "part3@example.com", None)),
+            BillParticipant::Ident(get_identity_public_data(
+                "part1",
+                "part1@example.com",
+                vec![],
+            )),
+            BillParticipant::Ident(get_identity_public_data(
+                "part2",
+                "part2@example.com",
+                vec![],
+            )),
+            BillParticipant::Ident(get_identity_public_data(
+                "part3",
+                "part3@example.com",
+                vec![],
+            )),
         ];
 
         let mut mock = MockNotificationJsonTransport::new();
@@ -830,7 +854,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -847,9 +871,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_recourse_action_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -933,7 +957,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -949,9 +973,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_recourse_action_event_does_not_send_non_recurse_action() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1009,7 +1033,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -1021,8 +1045,8 @@ mod tests {
     #[tokio::test]
     async fn test_failed_to_send_is_added_to_retry_queue() {
         // given a payer and payee with a new bill
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
 
@@ -1056,7 +1080,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(queue_mock),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let event = BillChainEvent::new(
@@ -1113,7 +1137,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         (
@@ -1135,8 +1159,8 @@ mod tests {
     #[tokio::test]
     async fn test_send_bill_is_signed_event() {
         // given a payer and payee with a new bill
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
         let (service, event) = setup_chain_expectation(
@@ -1164,8 +1188,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_bill_is_accepted_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1210,8 +1234,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_request_to_accept_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1256,8 +1280,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_request_to_pay_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1303,8 +1327,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_bill_is_paid_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let chain = get_genesis_chain(Some(bill.clone()));
         let (service, event) = setup_chain_expectation(
@@ -1325,9 +1349,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_bill_is_endorsed_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let endorsee = get_identity_public_data("endorsee", "endorsee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let endorsee = get_identity_public_data("endorsee", "endorsee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, Some(&endorsee));
         let chain = get_genesis_chain(Some(bill.clone()));
 
@@ -1354,9 +1378,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_offer_to_sell_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1406,9 +1430,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_bill_is_sold_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let buyer = get_identity_public_data("buyer", "buyer@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let buyer = get_identity_public_data("buyer", "buyer@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1458,9 +1482,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_bill_recourse_paid_event() {
-        let payer = get_identity_public_data("drawee", "drawee@example.com", None);
-        let payee = get_identity_public_data("payee", "payee@example.com", None);
-        let recoursee = get_identity_public_data("recoursee", "recoursee@example.com", None);
+        let payer = get_identity_public_data("drawee", "drawee@example.com", vec![]);
+        let payee = get_identity_public_data("payee", "payee@example.com", vec![]);
+        let recoursee = get_identity_public_data("recoursee", "recoursee@example.com", vec![]);
         let bill = get_test_bitcredit_bill(TEST_BILL_ID, &payer, &payee, None, None);
         let mut chain = get_genesis_chain(Some(bill.clone()));
         let timestamp = now().timestamp() as u64;
@@ -1549,7 +1573,7 @@ mod tests {
             Arc::new(mock_store),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let res = service
@@ -1578,7 +1602,7 @@ mod tests {
             Arc::new(mock_store),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         service
@@ -1610,24 +1634,24 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(MockNostrQueuedMessageStore::new()),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         )
     }
 
     fn get_test_bill() -> BitcreditBill {
         get_test_bitcredit_bill(
             "bill",
-            &get_identity_public_data("drawee", "drawee@example.com", None),
-            &get_identity_public_data("payee", "payee@example.com", None),
+            &get_identity_public_data("drawee", "drawee@example.com", vec![]),
+            &get_identity_public_data("payee", "payee@example.com", vec![]),
             Some(&get_identity_public_data(
                 "drawer",
                 "drawer@example.com",
-                None,
+                vec![],
             )),
             Some(&get_identity_public_data(
                 "endorsee",
                 "endorsee@example.com",
-                None,
+                vec![],
             )),
         )
     }
@@ -1673,7 +1697,7 @@ mod tests {
             payload: payload.clone(),
         };
 
-        let identity = get_identity_public_data(node_id, "test@example.com", None);
+        let identity = get_identity_public_data(node_id, "test@example.com", vec![]);
 
         // Set up mocks
         let mut mock_contact_service = MockContactServiceApi::new();
@@ -1708,7 +1732,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -1735,7 +1759,7 @@ mod tests {
             payload: payload.clone(),
         };
 
-        let identity = get_identity_public_data(node_id, "test@example.com", None);
+        let identity = get_identity_public_data(node_id, "test@example.com", vec![]);
 
         // Set up mocks
         let mut mock_contact_service = MockContactServiceApi::new();
@@ -1773,7 +1797,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -1818,8 +1842,8 @@ mod tests {
             payload: payload2.clone(),
         };
 
-        let identity1 = get_identity_public_data(node_id1, "test1@example.com", None);
-        let identity2 = get_identity_public_data(node_id2, "test2@example.com", None);
+        let identity1 = get_identity_public_data(node_id1, "test1@example.com", vec![]);
+        let identity2 = get_identity_public_data(node_id2, "test2@example.com", vec![]);
 
         // Set up mocks
         let mut mock_contact_service = MockContactServiceApi::new();
@@ -1880,7 +1904,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -1924,7 +1948,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -1951,7 +1975,7 @@ mod tests {
             payload: payload.clone(),
         };
 
-        let identity = get_identity_public_data(node_id, "test@example.com", None);
+        let identity = get_identity_public_data(node_id, "test@example.com", vec![]);
 
         // Set up mocks
         let mut mock_contact_service = MockContactServiceApi::new();
@@ -1994,7 +2018,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -2021,7 +2045,7 @@ mod tests {
             payload: payload.clone(),
         };
 
-        let identity = get_identity_public_data(node_id, "test@example.com", None);
+        let identity = get_identity_public_data(node_id, "test@example.com", vec![]);
 
         // Set up mocks
         let mut mock_contact_service = MockContactServiceApi::new();
@@ -2062,7 +2086,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(mock_contact_service),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;
@@ -2087,7 +2111,7 @@ mod tests {
             Arc::new(MockNotificationStoreApiMock::new()),
             Arc::new(MockContactServiceApi::new()),
             Arc::new(mock_queue),
-            "ws://test.relay",
+            vec!["ws://test.relay".into()],
         );
 
         let result = service.send_retry_messages().await;

--- a/crates/bcr-ebill-api/src/service/notification_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/mod.rs
@@ -46,7 +46,7 @@ pub async fn create_nostr_clients(
     };
     let mut configs: Vec<NostrConfig> = vec![NostrConfig::new(
         keys,
-        vec![config.nostr_relay.clone()],
+        config.nostr_relays.clone(),
         nostr_name,
     )];
 
@@ -63,7 +63,7 @@ pub async fn create_nostr_clients(
         if let Ok(keys) = keys.clone().try_into() {
             configs.push(NostrConfig::new(
                 keys,
-                vec![config.nostr_relay.clone()],
+                config.nostr_relays.clone(),
                 company.name.clone(),
             ));
         }
@@ -88,7 +88,7 @@ pub async fn create_notification_service(
     notification_store: Arc<dyn NotificationStoreApi>,
     contact_service: Arc<dyn ContactServiceApi>,
     queued_message_store: Arc<dyn NostrQueuedMessageStoreApi>,
-    nostr_relay: &str,
+    nostr_relays: Vec<String>,
 ) -> Result<Arc<dyn NotificationServiceApi>> {
     #[allow(clippy::arc_with_non_send_sync)]
     Ok(Arc::new(DefaultNotificationService::new(
@@ -99,7 +99,7 @@ pub async fn create_notification_service(
         notification_store,
         contact_service,
         queued_message_store,
-        nostr_relay,
+        nostr_relays,
     )))
 }
 

--- a/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
@@ -98,11 +98,14 @@ pub fn create_test_event(event_type: &BillEventType) -> Event<TestEventPayload> 
 pub fn get_identity_public_data(
     node_id: &str,
     email: &str,
-    nostr_relay: Option<&str>,
+    nostr_relays: Vec<&str>,
 ) -> BillIdentParticipant {
     let mut identity = bill_identified_participant_only_node_id(node_id.to_owned());
     identity.email = Some(email.to_owned());
-    identity.nostr_relay = nostr_relay.map(|nostr_relay| nostr_relay.to_owned());
+    identity.nostr_relays = nostr_relays
+        .iter()
+        .map(|nostr_relay| String::from(*nostr_relay))
+        .collect();
     identity
 }
 

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -316,7 +316,7 @@ pub mod tests {
                 crate::init(crate::Config {
                     bitcoin_network: "mainnet".to_string(),
                     esplora_base_url: "https://blockstream.info".to_string(),
-                    nostr_relay: "ws://localhost:8080".to_string(),
+                    nostr_relays: vec!["ws://localhost:8080".to_string()],
                     surreal_db_connection: "ws://localhost:8800".to_string(),
                     data_dir: ".".to_string(),
                 })
@@ -354,7 +354,7 @@ pub mod tests {
             country_of_birth: None,
             city_of_birth: None,
             identification_number: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
             profile_picture_file: None,
             identity_document_file: None,
         }
@@ -367,7 +367,7 @@ pub mod tests {
             name: "some@example.com".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 
@@ -378,7 +378,7 @@ pub mod tests {
             name: "some name".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         })
     }
 
@@ -389,7 +389,7 @@ pub mod tests {
             name: "some name".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 

--- a/crates/bcr-ebill-core/src/blockchain/bill/block.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/block.rs
@@ -522,12 +522,12 @@ impl From<BillParticipantBlockData> for BillParticipant {
                 name: data.name,
                 postal_address: data.postal_address,
                 email: None,
-                nostr_relay: None,
+                nostr_relays: vec![],
             }),
             BillParticipantBlockData::Anon(data) => Self::Anon(BillAnonParticipant {
                 node_id: data.node_id,
                 email: None,
-                nostr_relay: None,
+                nostr_relays: vec![],
             }),
         }
     }
@@ -611,7 +611,7 @@ impl From<BillIdentParticipantBlockData> for BillIdentParticipant {
             name: value.name,
             postal_address: value.postal_address,
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 }

--- a/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
@@ -50,7 +50,7 @@ pub struct IdentityCreateBlockData {
     pub city_of_birth: Option<String>,
     pub country_of_birth: Option<String>,
     pub identification_number: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
     pub profile_picture_file: Option<File>,
     pub identity_document_file: Option<File>,
 }
@@ -66,7 +66,7 @@ impl From<Identity> for IdentityCreateBlockData {
             city_of_birth: value.city_of_birth,
             postal_address: value.postal_address,
             identification_number: value.identification_number,
-            nostr_relay: value.nostr_relay,
+            nostr_relays: value.nostr_relays,
             profile_picture_file: value.profile_picture_file,
             identity_document_file: value.identity_document_file,
         }

--- a/crates/bcr-ebill-core/src/contact/mod.rs
+++ b/crates/bcr-ebill-core/src/contact/mod.rs
@@ -85,10 +85,10 @@ impl BillParticipant {
         }
     }
 
-    pub fn nostr_relay(&self) -> Option<String> {
+    pub fn nostr_relays(&self) -> Vec<String> {
         match self {
-            BillParticipant::Ident(data) => data.nostr_relay.to_owned(),
-            BillParticipant::Anon(data) => data.nostr_relay.to_owned(),
+            BillParticipant::Ident(data) => data.nostr_relays.to_owned(),
+            BillParticipant::Anon(data) => data.nostr_relays.to_owned(),
         }
     }
 
@@ -120,7 +120,7 @@ pub struct BillAnonParticipant {
     /// email address of the participant
     pub email: Option<String>,
     /// The preferred Nostr relay to deliver Nostr messages to
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl From<BillIdentParticipant> for BillAnonParticipant {
@@ -128,7 +128,7 @@ impl From<BillIdentParticipant> for BillAnonParticipant {
         Self {
             node_id: value.node_id,
             email: value.email,
-            nostr_relay: value.nostr_relay,
+            nostr_relays: value.nostr_relays,
         }
     }
 }
@@ -159,7 +159,7 @@ pub struct BillIdentParticipant {
     /// email address of the identity
     pub email: Option<String>,
     /// The preferred Nostr relay to deliver Nostr messages to
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
@@ -241,7 +241,7 @@ impl TryFrom<Contact> for BillIdentParticipant {
                     .postal_address
                     .ok_or(ValidationError::InvalidContact(value.node_id.to_owned()))?,
                 email: value.email,
-                nostr_relay: value.nostr_relays.first().cloned(),
+                nostr_relays: value.nostr_relays,
             }),
             ContactType::Anon => Err(ValidationError::ContactIsAnonymous(
                 value.node_id.to_owned(),
@@ -263,13 +263,13 @@ impl TryFrom<Contact> for BillParticipant {
                         .postal_address
                         .ok_or(ValidationError::InvalidContact(value.node_id.to_owned()))?,
                     email: value.email,
-                    nostr_relay: value.nostr_relays.first().cloned(),
+                    nostr_relays: value.nostr_relays,
                 }))
             }
             ContactType::Anon => Ok(BillParticipant::Anon(BillAnonParticipant {
                 node_id: value.node_id.clone(),
                 email: value.email,
-                nostr_relay: value.nostr_relays.first().cloned(),
+                nostr_relays: value.nostr_relays,
             })),
         }
     }
@@ -283,7 +283,7 @@ impl From<Company> for BillIdentParticipant {
             name: value.name,
             postal_address: value.postal_address,
             email: Some(value.email),
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 }
@@ -300,7 +300,7 @@ impl BillIdentParticipant {
                 name: identity.name,
                 postal_address,
                 email: identity.email,
-                nostr_relay: identity.nostr_relay,
+                nostr_relays: identity.nostr_relays,
             }),
             None => Err(ValidationError::IdentityIsNotBillIssuer),
         }
@@ -312,7 +312,7 @@ impl BillAnonParticipant {
         Self {
             node_id: identity.node_id,
             email: identity.email,
-            nostr_relay: identity.nostr_relay,
+            nostr_relays: identity.nostr_relays,
         }
     }
 }

--- a/crates/bcr-ebill-core/src/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/identity/mod.rs
@@ -69,7 +69,7 @@ pub struct Identity {
     pub country_of_birth: Option<String>,
     pub city_of_birth: Option<String>,
     pub identification_number: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
     pub profile_picture_file: Option<File>,
     pub identity_document_file: Option<File>,
 }

--- a/crates/bcr-ebill-core/src/tests/mod.rs
+++ b/crates/bcr-ebill-core/src/tests/mod.rs
@@ -108,7 +108,7 @@ pub mod tests {
             country_of_birth: None,
             city_of_birth: None,
             identification_number: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
             profile_picture_file: None,
             identity_document_file: None,
         }
@@ -121,7 +121,7 @@ pub mod tests {
             name: "Johanna Smith".into(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         })
     }
 
@@ -132,7 +132,7 @@ pub mod tests {
             name: "John Smith".into(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         })
     }
 
@@ -143,7 +143,7 @@ pub mod tests {
             name: "Johanna Smith".into(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 
@@ -154,7 +154,7 @@ pub mod tests {
             name: "John Smith".into(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 
@@ -165,7 +165,7 @@ pub mod tests {
             name: "some name".to_string(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 
@@ -176,7 +176,7 @@ pub mod tests {
             name: "some name".to_string(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         })
     }
 
@@ -187,7 +187,7 @@ pub mod tests {
             name: "some name".to_string(),
             postal_address: valid_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -742,7 +742,7 @@ impl From<BillAnonParticipantDb> for BillAnonParticipant {
         Self {
             node_id: value.node_id,
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 }
@@ -755,7 +755,7 @@ impl From<BillIdentParticipantDb> for BillIdentParticipant {
             name: value.name,
             postal_address: value.postal_address.into(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 }

--- a/crates/bcr-ebill-persistence/src/db/identity.rs
+++ b/crates/bcr-ebill-persistence/src/db/identity.rs
@@ -184,7 +184,7 @@ pub struct IdentityDb {
     pub country_of_birth: Option<String>,
     pub city_of_birth: Option<String>,
     pub identification_number: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
     pub profile_picture_file: Option<FileDb>,
     pub identity_document_file: Option<FileDb>,
 }
@@ -201,7 +201,7 @@ impl From<IdentityDb> for Identity {
             country_of_birth: identity.country_of_birth,
             city_of_birth: identity.city_of_birth,
             identification_number: identity.identification_number,
-            nostr_relay: identity.nostr_relay,
+            nostr_relays: identity.nostr_relays,
             profile_picture_file: identity.profile_picture_file.map(|f| f.into()),
             identity_document_file: identity.identity_document_file.map(|f| f.into()),
         }
@@ -220,7 +220,7 @@ impl From<&Identity> for IdentityDb {
             country_of_birth: identity.country_of_birth.clone(),
             city_of_birth: identity.city_of_birth.clone(),
             identification_number: identity.identification_number.clone(),
-            nostr_relay: identity.nostr_relay.clone(),
+            nostr_relays: identity.nostr_relays.clone(),
             profile_picture_file: identity.profile_picture_file.clone().map(|f| (&f).into()),
             identity_document_file: identity.identity_document_file.clone().map(|f| (&f).into()),
         }

--- a/crates/bcr-ebill-persistence/src/tests/mod.rs
+++ b/crates/bcr-ebill-persistence/src/tests/mod.rs
@@ -41,7 +41,7 @@ pub mod tests {
             country_of_birth: None,
             city_of_birth: None,
             identification_number: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
             profile_picture_file: None,
             identity_document_file: None,
         }
@@ -54,7 +54,7 @@ pub mod tests {
             name: "".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 
@@ -65,7 +65,7 @@ pub mod tests {
             name: "".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
 

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -1116,7 +1116,7 @@ mod tests {
             name: "some name".to_string(),
             postal_address: empty_address(),
             email: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
         }
     }
     fn empty_address() -> PostalAddress {
@@ -1138,7 +1138,7 @@ mod tests {
             country_of_birth: None,
             city_of_birth: None,
             identification_number: None,
-            nostr_relay: None,
+            nostr_relays: vec![],
             profile_picture_file: None,
             identity_document_file: None,
         }

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -39,7 +39,7 @@ async function start() {
     esplora_base_url: "http://localhost:8094", // local reg test via docker-compose
     // bitcoin_network: "testnet",
     // esplora_base_url: "https://blockstream.info",
-    nostr_relay: "wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app",
+    nostr_relays: ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"],
     job_runner_initial_delay_seconds: 1,
     job_runner_check_interval_seconds: 600,
   };

--- a/crates/bcr-ebill-wasm/src/context.rs
+++ b/crates/bcr-ebill-wasm/src/context.rs
@@ -51,7 +51,7 @@ impl Context {
             db.notification_store.clone(),
             contact_service.clone(),
             db.queued_message_store.clone(),
-            &cfg.nostr_relay,
+            cfg.nostr_relays.clone(),
         )
         .await?;
 

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -766,7 +766,7 @@ impl IntoWeb<BillParticipantWeb> for BillParticipant {
 pub struct BillAnonParticipantWeb {
     pub node_id: String,
     pub email: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
@@ -774,7 +774,7 @@ impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
         BillAnonParticipantWeb {
             node_id: self.node_id,
             email: self.email,
-            nostr_relay: self.nostr_relay,
+            nostr_relays: self.nostr_relays,
         }
     }
 }
@@ -787,7 +787,7 @@ pub struct BillIdentParticipantWeb {
     pub name: String,
     pub postal_address: PostalAddressWeb,
     pub email: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
@@ -798,7 +798,7 @@ impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
             node_id: self.node_id,
             postal_address: self.postal_address.into_web(),
             email: self.email,
-            nostr_relay: self.nostr_relay,
+            nostr_relays: self.nostr_relays,
         }
     }
 }

--- a/crates/bcr-ebill-wasm/src/data/identity.rs
+++ b/crates/bcr-ebill-wasm/src/data/identity.rs
@@ -118,7 +118,7 @@ pub struct IdentityWeb {
     pub identification_number: Option<String>,
     pub profile_picture_file: Option<FileWeb>,
     pub identity_document_file: Option<FileWeb>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IdentityWeb {
@@ -137,7 +137,7 @@ impl IdentityWeb {
             identification_number: identity.identification_number,
             profile_picture_file: identity.profile_picture_file.map(|f| f.into_web()),
             identity_document_file: identity.identity_document_file.map(|f| f.into_web()),
-            nostr_relay: identity.nostr_relay,
+            nostr_relays: identity.nostr_relays,
         })
     }
 }

--- a/crates/bcr-ebill-wasm/src/lib.rs
+++ b/crates/bcr-ebill-wasm/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Config {
     pub log_level: Option<String>,
     pub bitcoin_network: String,
     pub esplora_base_url: String,
-    pub nostr_relay: String,
+    pub nostr_relays: Vec<String>,
     pub job_runner_initial_delay_seconds: u32,
     pub job_runner_check_interval_seconds: u32,
 }
@@ -62,7 +62,7 @@ pub async fn initialize_api(
     let api_config = ApiConfig {
         bitcoin_network: config.bitcoin_network,
         esplora_base_url: config.esplora_base_url,
-        nostr_relay: config.nostr_relay,
+        nostr_relays: config.nostr_relays,
         surreal_db_connection: SURREAL_DB_CON_INDXDB_DATA.to_owned(),
         data_dir: "./".to_owned(), // unused in wasm
     };

--- a/crates/bcr-ebill-web/src/config.rs
+++ b/crates/bcr-ebill-web/src/config.rs
@@ -16,8 +16,8 @@ pub struct Config {
     pub surreal_db_connection: String,
     #[arg(default_value_t = String::from("testnet"),  long, env = "BITCOIN_NETWORK")]
     pub bitcoin_network: String,
-    #[arg(default_value_t = String::from("ws://localhost:8080"), long, env = "NOSTR_RELAY")]
-    pub nostr_relay: String,
+    #[arg(default_value = "ws://localhost:8080", value_delimiter = ',', num_args = 1.., long, env = "NOSTR_RELAYS")]
+    pub nostr_relays: Vec<String>,
     #[arg(default_value_t = String::from("https://moksha.minibill.tech"), long, env = "MINT_URL")]
     pub mint_url: String,
     #[arg(default_value_t = 1, long, env = "JOB_RUNNER_INITIAL_DELAY_SECONDS")]

--- a/crates/bcr-ebill-web/src/data.rs
+++ b/crates/bcr-ebill-web/src/data.rs
@@ -607,7 +607,7 @@ pub struct IdentityWeb {
     pub identification_number: Option<String>,
     pub profile_picture_file: Option<FileWeb>,
     pub identity_document_file: Option<FileWeb>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IdentityWeb {
@@ -626,7 +626,7 @@ impl IdentityWeb {
             identification_number: identity.identification_number,
             profile_picture_file: identity.profile_picture_file.map(|f| f.into_web()),
             identity_document_file: identity.identity_document_file.map(|f| f.into_web()),
-            nostr_relay: identity.nostr_relay,
+            nostr_relays: identity.nostr_relays,
         }
     }
 }
@@ -1189,7 +1189,7 @@ impl IntoWeb<BillParticipantWeb> for BillParticipant {
 pub struct BillAnonParticipantWeb {
     pub node_id: String,
     pub email: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
@@ -1197,7 +1197,7 @@ impl IntoWeb<BillAnonParticipantWeb> for BillAnonParticipant {
         BillAnonParticipantWeb {
             node_id: self.node_id,
             email: self.email,
-            nostr_relay: self.nostr_relay,
+            nostr_relays: self.nostr_relays,
         }
     }
 }
@@ -1211,7 +1211,7 @@ pub struct BillIdentParticipantWeb {
     #[serde(flatten)]
     pub postal_address: PostalAddressWeb,
     pub email: Option<String>,
-    pub nostr_relay: Option<String>,
+    pub nostr_relays: Vec<String>,
 }
 
 impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
@@ -1222,7 +1222,7 @@ impl IntoWeb<BillIdentParticipantWeb> for BillIdentParticipant {
             node_id: self.node_id,
             postal_address: self.postal_address.into_web(),
             email: self.email,
-            nostr_relay: self.nostr_relay,
+            nostr_relays: self.nostr_relays,
         }
     }
 }

--- a/crates/bcr-ebill-web/src/main.rs
+++ b/crates/bcr-ebill-web/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     let api_config = bcr_ebill_api::Config {
         bitcoin_network: conf.bitcoin_network.clone(),
         esplora_base_url: conf.esplora_base_url.clone(),
-        nostr_relay: conf.nostr_relay.clone(),
+        nostr_relays: conf.nostr_relays.clone(),
         surreal_db_connection: conf.surreal_db_connection.clone(),
         data_dir: conf.data_dir.clone(),
     };

--- a/crates/bcr-ebill-web/src/service_context.rs
+++ b/crates/bcr-ebill-web/src/service_context.rs
@@ -98,7 +98,7 @@ pub async fn create_service_context(
         db.notification_store.clone(),
         contact_service.clone(),
         db.queued_message_store.clone(),
-        &config.nostr_relay,
+        config.nostr_relays.clone(),
     )
     .await?;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - HTTP_PORT=8001
       - RUST_LOG=info
       - SURREAL_DB_CONNECTION=ws://surrealdb:8000
-      - NOSTR_RELAY=wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app
+      - NOSTR_RELAYS=wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app
     ports:
       - "8001:8001"
       - "1909:1909"

--- a/docs/esplora.md
+++ b/docs/esplora.md
@@ -12,7 +12,7 @@ For this, you also have to set the config to use `regtest` as a bitcoin network 
     log_level: "debug",
     bitcoin_network: "regtest",
     esplora_base_url: "http://localhost:8094",
-    nostr_relay: "wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app",
+    nostr_relays: ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"],
     job_runner_initial_delay_seconds: 1,
     job_runner_check_interval_seconds: 600,
   };

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -55,7 +55,7 @@ import * as wasm from '../pkg/bcr_ebill_wasm.js';
 async function start() {
     let config = {
         bitcoin_network: "testnet",
-        nostr_relay: "wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app",
+        nostr_relays: ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"],
         surreal_db_connection: "indxdb://default",
         data_dir: ".",
         job_runner_initial_delay_seconds: 1,
@@ -269,7 +269,7 @@ import * as wasm from '@bitcredit/bcr-ebill-wasm';
 async function start() {
     let config = {
         bitcoin_network: "testnet",
-        nostr_relay: "wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app",
+        nostr_relays: ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"],
         surreal_db_connection: "indxdb://default",
         data_dir: ".",
         job_runner_initial_delay_seconds: 1,

--- a/docs/wasm_configuration.md
+++ b/docs/wasm_configuration.md
@@ -5,7 +5,7 @@ The application can be configured using the `Config` struct.
 ```rust
 pub struct Config {
     pub bitcoin_network: String,
-    pub nostr_relay: String,
+    pub nostr_relays: Vec<String>,
     pub esplora_base_url: String,
     pub surreal_db_connection: String,
     pub data_dir: String,
@@ -18,7 +18,7 @@ It contains the following options:
 
 * `bitcoin_network` - bitcoin network to use, possible values: `mainnet`, `regtest` and `testnet`
 * `esplora_base_url` - bitcoin explorer base url for payment checks
-* `nostr_relay` - nostr relay endpoint
+* `nostr_relays` - the nostr relay endpoints
 * `surreal_db_connection` - the surreal DB connection
 * `data_dir` - the data directory root - not used on the Web
 * `job_runner_initial_delay_seconds` - initial delay until cron jobs run
@@ -30,7 +30,7 @@ It contains the following options:
     let config = {
         bitcoin_network: "testnet",
         esplora_base_url: "https://blockstream.info",
-        nostr_relay: "wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app",
+        nostr_relays: ["wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app"],
         surreal_db_connection: "indxdb://default",
         data_dir: ".",
         job_runner_initial_delay_seconds: 1,

--- a/docs/web_configuration.md
+++ b/docs/web_configuration.md
@@ -10,7 +10,7 @@ The following options are available:
 * `SURREAL_DB_CONNECTION` - the surreal DB connection (default: "ws://localhost:8800") - set to `rocksdb://data/surreal` for embedded mode
 * `BITCOIN_NETWORK` - bitcoin network to use (default: testnet), possible values: `mainnet`, `regtest` and `testnet`
 * `RUST_LOG` - the log level, e.g.: info, trace, debug, error (default: error)
-* `NOSTR_RELAY` - nostr relay endpoint (default: ws://localhost:8080)
+* `NOSTR_RELAYS` - nostr relay endpoints (default: [ws://localhost:8080])
 * `MINT_URL` - cashu mint endpoint (default: https://moksha.minibill.tech)
 * `JOB_RUNNER_INITIAL_DELAY_SECONDS` - initial delay until cron jobs run (default: 1)
 * `JOB_RUNNER_CHECK_INTERVAL_SECONDS` - interval in which cron jobs run (default: 600)


### PR DESCRIPTION
## 📝 Description

* This changes it so we use a list of nost relays everywhere (config, identities, contacts), since that's the reality of how Nostr works
* I did this in the `anonymous mode` branch, because that already breaks all the identity/contact API and this is just one more break :)

Relates to #486 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. everything should work the same as before

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #486 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
