### PR TITLE
NFC: [bcr-ebill-core]: reduce the dependencies set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ uuid = { version = "1", default-features = false, features = ["v4", "js"] }
 bitcoin = { version = "0.32", default-features = false }
 bip39 = { version = "2.1", features = ["rand"] }
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
+nostr = { version = "0.40"}
 nostr-sdk = { version = "0.40", features = ["nip04", "nip59"] }
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 bitcoin.workspace = true
 bip39.workspace = true
 ecies.workspace = true
-nostr-sdk.workspace = true
+nostr.workspace = true
 secp256k1 = { workspace = true, features = ["global-context"] }
 rust_decimal = { version = "1.36.0", default-features = false }
 

--- a/crates/bcr-ebill-core/src/util/crypto.rs
+++ b/crates/bcr-ebill-core/src/util/crypto.rs
@@ -10,7 +10,7 @@ use bitcoin::{
         self, Keypair, Message, PublicKey, SECP256K1, Scalar, SecretKey, rand, schnorr::Signature,
     },
 };
-use nostr_sdk::ToBech32;
+use nostr::ToBech32;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -19,12 +19,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("Private key error: {0}")]
     PrivateKey(#[from] secp256k1::Error),
-
-    #[error("Nostr key error: {0}")]
-    NostrKey(#[from] nostr_sdk::key::Error),
-
-    #[error("Nostr bech32 key error: {0}")]
-    NostrNip19(#[from] nostr_sdk::nips::nip19::Error),
 
     #[error("Ecies encryption error: {0}")]
     Ecies(String),
@@ -111,8 +105,8 @@ impl BcrKeys {
     }
 
     /// Returns the key pair as a nostr key pair
-    pub fn get_nostr_keys(&self) -> nostr_sdk::Keys {
-        nostr_sdk::Keys::new(self.inner.secret_key().into())
+    pub fn get_nostr_keys(&self) -> nostr::Keys {
+        nostr::Keys::new(self.inner.secret_key().into())
     }
 
     /// Returns the nostr public key as an XOnlyPublicKey hex string
@@ -172,7 +166,7 @@ pub fn is_node_id_nostr_hex_npub(node_id: &str, npub: &str) -> bool {
         Ok(pub_key) => pub_key,
         Err(_) => return false,
     };
-    match nostr_sdk::PublicKey::from_hex(&x_only_pub_key) {
+    match nostr::PublicKey::from_hex(&x_only_pub_key) {
         Ok(npub_from_node_id) => npub == npub_from_node_id.to_hex(),
         Err(_) => false,
     }
@@ -738,14 +732,14 @@ mod tests {
             npub_as_hex.to_string()
         );
         let npub =
-            nostr_sdk::PublicKey::from_hex(&get_nostr_npub_as_hex_from_node_id(node_id).unwrap())
+            nostr::PublicKey::from_hex(&get_nostr_npub_as_hex_from_node_id(node_id).unwrap())
                 .unwrap();
         assert_eq!(npub.to_hex(), npub_as_hex);
         assert_eq!(
             get_nostr_npub_as_hex_from_node_id(TEST_NODE_ID_SECP).unwrap(),
             TEST_NODE_ID_SECP_AS_NPUB_HEX.to_string()
         );
-        let npub = nostr_sdk::PublicKey::from_hex(
+        let npub = nostr::PublicKey::from_hex(
             &get_nostr_npub_as_hex_from_node_id(TEST_NODE_ID_SECP).unwrap(),
         )
         .unwrap();


### PR DESCRIPTION

## 📝 Description

move from nostr-sdk to nostr reduces substantially the cardinality of the dependencies
With this rough test
```
$ cargo tree -p bcr-ebill-core | wc -l
```
The set goes from 407 to 297


---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [ ] My code adheres to the coding guidelines of this project.
- [ ] I have run `cargo fmt`.
- [ ] I have run `cargo clippy`.
- [ ] I have added or updated tests (if applicable).
- [ ] All CI/CD steps were successful.
- [ ] I have updated the documentation (if applicable).
- [ ] I have checked that there are no console errors or warnings.
- [ ] I have verified that the application builds without errors.
- [ ] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made
No functional changes expected.
Reduce the dependencies size by narrowing down from nostr-sdk to nostr


