### PR TITLE
add license to crates

### DIFF
--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-api"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [lib]
 doctest = false

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-core"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [lib]
 doctest = false

--- a/crates/bcr-ebill-persistence/Cargo.toml
+++ b/crates/bcr-ebill-persistence/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-persistence"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [lib]
 doctest = false

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-transport"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [lib]
 doctest = false

--- a/crates/bcr-ebill-wasm/Cargo.toml
+++ b/crates/bcr-ebill-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-wasm"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-Os']

--- a/crates/bcr-ebill-web/Cargo.toml
+++ b/crates/bcr-ebill-web/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcr-ebill-web"
 version = "0.3.10"
 edition = "2024"
+license = "MIT"
 
 [dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
## 📝 Description

* Adds `MIT` license to all crates
* Turns out, only adding a `LICENSE` file doesn't fix the license on npm, it has to be in `package.json` and the way to get it there is by adding it in the crate
* Plus, this is more correct anyway

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
