### PR TITLE
Persist recovery data for minting, Check if proofs are spent

### DIFF
--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -34,8 +34,11 @@ secp256k1.workspace = true
 bcr-wdc-webapi = { git = "https://github.com/BitcreditProtocol/wildcat", rev = "4437c3b809105df69ed459a9698cac8deb8d9210" }
 bcr-wdc-quote-client = { git = "https://github.com/BitcreditProtocol/wildcat", rev = "4437c3b809105df69ed459a9698cac8deb8d9210" }
 bcr-wdc-key-client = { git = "https://github.com/BitcreditProtocol/wildcat", rev = "4437c3b809105df69ed459a9698cac8deb8d9210" }
+bcr-wdc-swap-client = { git = "https://github.com/BitcreditProtocol/wildcat", rev = "4437c3b809105df69ed459a9698cac8deb8d9210" }
 cashu = { version = "0.9", default-features = false }
 rand = { version = "0.8" }
+hex = { version = "0.4" }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -92,6 +92,13 @@ pub mod tests {
                 new_status: &MintRequestStatus,
             ) -> Result<()>;
             async fn add_proofs_to_offer(&self, mint_request_id: &str, proofs: &str) -> Result<()>;
+            async fn add_recovery_data_to_offer(
+                &self,
+                mint_request_id: &str,
+                secrets: &[String],
+                rs: &[String],
+            ) -> Result<()>;
+            async fn set_proofs_to_spent_for_offer(&self, mint_request_id: &str) -> Result<()>;
             async fn add_offer(
                 &self,
                 mint_request_id: &str,

--- a/crates/bcr-ebill-core/src/mint/mod.rs
+++ b/crates/bcr-ebill-core/src/mint/mod.rs
@@ -46,8 +46,22 @@ pub struct MintOffer {
     pub discounted_sum: u64,
     /// The proofs, encoded as a custom Tokenv3
     pub proofs: Option<String>,
+    /// Whether the proofs were spent according to the mint
+    pub proofs_spent: bool,
+    /// The recovery data, if something goes wrong between minting and token generation
+    pub recovery_data: Option<MintOfferRecoveryData>,
 }
 
+/// Mint offer recovery data
+#[derive(Debug, Clone)]
+pub struct MintOfferRecoveryData {
+    /// The secrets of the blinds we used
+    pub secrets: Vec<String>,
+    /// The rs of the blinds we used
+    pub rs: Vec<String>,
+}
+
+/// The state of a mint request
 #[derive(Debug, Clone)]
 pub struct MintRequestState {
     /// There always is a request

--- a/crates/bcr-ebill-persistence/src/constants.rs
+++ b/crates/bcr-ebill-persistence/src/constants.rs
@@ -28,6 +28,8 @@ pub const DB_STATUS_ACCEPTED: &str = "status_accepted";
 pub const DB_MINT_NODE_ID: &str = "mint_node_id";
 pub const DB_MINT_REQUEST_ID: &str = "mint_request_id";
 pub const DB_PROOFS: &str = "proofs";
+pub const DB_RECOVERY_DATA: &str = "recovery_data";
+pub const DB_PROOFS_SPENT: &str = "proofs_spent";
 pub const DB_MINT_REQUESTER_NODE_ID: &str = "requester_node_id";
 pub const DB_SEARCH_TERM: &str = "search_term";
 

--- a/crates/bcr-ebill-persistence/src/lib.rs
+++ b/crates/bcr-ebill-persistence/src/lib.rs
@@ -55,6 +55,12 @@ pub enum Error {
     #[error("The offer for the given request to mint already has proofs set")]
     MintOfferAlreadyHasProofs,
 
+    #[error("The offer for the given request to mint has no proofs set")]
+    MintOfferHasNoProofs,
+
+    #[error("The offer for the given request to mint already has recovery data set")]
+    MintOfferAlreadyHasRecoveryData,
+
     #[error("There is no offer for the given request to mint")]
     MintOfferDoesNotExist,
 

--- a/crates/bcr-ebill-persistence/src/mint.rs
+++ b/crates/bcr-ebill-persistence/src/mint.rs
@@ -45,6 +45,15 @@ pub trait MintStoreApi: ServiceTraitBounds {
     ) -> Result<()>;
     /// Adds proofs for a given offer
     async fn add_proofs_to_offer(&self, mint_request_id: &str, proofs: &str) -> Result<()>;
+    /// Adds recovery data to offer
+    async fn add_recovery_data_to_offer(
+        &self,
+        mint_request_id: &str,
+        secrets: &[String],
+        rs: &[String],
+    ) -> Result<()>;
+    /// Set proofs to spent for offer
+    async fn set_proofs_to_spent_for_offer(&self, mint_request_id: &str) -> Result<()>;
     /// Adds an offer for a request to mint
     async fn add_offer(
         &self,

--- a/crates/bcr-ebill-wasm/src/data/mint.rs
+++ b/crates/bcr-ebill-wasm/src/data/mint.rs
@@ -63,6 +63,7 @@ pub struct MintOfferWeb {
     pub expiration_timestamp: u64,
     pub discounted_sum: u64,
     pub proofs: Option<String>,
+    pub proofs_spent: bool,
 }
 
 impl From<MintOffer> for MintOfferWeb {
@@ -73,6 +74,7 @@ impl From<MintOffer> for MintOfferWeb {
             expiration_timestamp: val.expiration_timestamp,
             discounted_sum: val.discounted_sum,
             proofs: val.proofs.to_owned(),
+            proofs_spent: val.proofs_spent,
         }
     }
 }


### PR DESCRIPTION
## 📝 Description

* Persist recovery data (secrets and rs for blinded messages used for minting)
  * Based on the secrets and rs (and keyset+amount, which we also have) we can recover the blinded messages and either re-call request to mint, or call the recovery endpoint (depending on whether the mint minted, or not, which we can detect using `checkstate`)
  * Created ticket to think about and properly implement recovery for such cases in #531 
* Check if proofs are spent and persist it, if they are

Relates to #517 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. get proofs, spent them, check if the spent check sets them to spent
3. check if the recovery state gets persisted

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #517 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
