### PR TITLE
Fix has mint requests for all identities

### DIFF
--- a/crates/bcr-ebill-persistence/src/db/mint.rs
+++ b/crates/bcr-ebill-persistence/src/db/mint.rs
@@ -45,7 +45,7 @@ impl MintStoreApi for SurrealMintStore {
         match self
             .db
             .query::<Option<BillIdDb>>(
-                "SELECT bill_id FROM type::table($table) WHERE bill_id = $bill_id GROUP BY bill_id",
+                "SELECT bill_id FROM type::table($table) WHERE bill_id = $bill_id AND requester_node_id = $requester_node_id GROUP BY bill_id",
                 bindings,
             )
             .await
@@ -418,6 +418,28 @@ mod tests {
             .await
             .unwrap();
         assert!(store.exists_for_bill("requester", "bill_id").await.unwrap());
+        assert!(
+            !store
+                .exists_for_bill("other_requester", "bill_id")
+                .await
+                .unwrap()
+        );
+        store
+            .add_request(
+                "other_requester",
+                "bill_id",
+                "mint_node_id",
+                "mint_req_id",
+                1731593928,
+            )
+            .await
+            .unwrap();
+        assert!(
+            store
+                .exists_for_bill("other_requester", "bill_id")
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 📝 Description

* Currently, the `has_mint_requests` only checks, if there are mint requests for the whole bill, not checking if there are mint requests for the caller
* This fixes that bug

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. mint a bill, make sure other identities that are part of the bill don't have `has_mint_requests` set

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
