### PR TITLE
Restore from nostr part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ nostr = { version = "0.43" }
 nostr-sdk = { version = "0.43", features = ["nip04", "nip59"] }
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 async-broadcast = "0.7.2"
-rstest = "0.25.0"
+rstest = "0.26"
 secp256k1 = { version = "0.29" }
 reqwest = { version = "0.12", default-features = false }
 miniscript = { version = "12.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ uuid = { version = "1", default-features = false, features = ["v4", "js"] }
 bitcoin = { version = "0.32", default-features = false, features = ["serde"] }
 bip39 = { version = "2.1", features = ["rand"] }
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
-nostr = { version = "0.42" }
-nostr-sdk = { version = "0.42", features = ["nip04", "nip59"] }
+nostr = { version = "0.43" }
+nostr-sdk = { version = "0.43", features = ["nip04", "nip59"] }
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 async-broadcast = "0.7.2"
 rstest = "0.25.0"

--- a/crates/bcr-ebill-api/src/service/company_service.rs
+++ b/crates/bcr-ebill-api/src/service/company_service.rs
@@ -356,6 +356,7 @@ impl CompanyServiceApi for CompanyService {
             &previous_block,
             &IdentityCreateCompanyBlockData {
                 company_id: id.clone(),
+                company_key: company_keys.get_private_key_string(),
                 block_hash: create_company_block.hash.clone(),
             },
             &full_identity.key_pair,

--- a/crates/bcr-ebill-api/src/service/identity_service.rs
+++ b/crates/bcr-ebill-api/src/service/identity_service.rs
@@ -98,6 +98,9 @@ pub trait IdentityServiceApi: ServiceTraitBounds {
 
     /// sets the active identity to the given company node id
     async fn set_current_company_identity(&self, node_id: &NodeId) -> Result<()>;
+
+    /// Returns the local key pair
+    async fn get_keys(&self) -> Result<BcrKeys>;
 }
 
 /// The identity service is responsible for managing the local identity
@@ -668,6 +671,10 @@ impl IdentityServiceApi for IdentityService {
             })
             .await?;
         Ok(())
+    }
+
+    async fn get_keys(&self) -> Result<BcrKeys> {
+        Ok(self.store.get_key_pair().await?)
     }
 }
 

--- a/crates/bcr-ebill-api/src/service/notification_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/mod.rs
@@ -3,6 +3,7 @@ use bcr_ebill_core::util::crypto;
 
 pub mod chain_keys;
 pub mod event;
+pub mod restore;
 mod service;
 pub mod transport;
 

--- a/crates/bcr-ebill-api/src/service/notification_service/restore.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/restore.rs
@@ -1,0 +1,11 @@
+use super::Result;
+use async_trait::async_trait;
+use bcr_ebill_core::ServiceTraitBounds;
+
+#[allow(dead_code)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait RestoreAccountApi: ServiceTraitBounds {
+    /// restores the account and all the associated data
+    async fn restore_account(&self) -> Result<()>;
+}

--- a/crates/bcr-ebill-api/src/service/notification_service/transport.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/transport.rs
@@ -6,7 +6,7 @@ use bcr_ebill_core::{
 #[cfg(test)]
 use mockall::automock;
 
-use nostr::Event;
+use nostr::{Event, Filter};
 
 use super::{NostrContactData, Result, event::EventEnvelope};
 
@@ -48,4 +48,6 @@ pub trait NotificationJsonTransportApi: ServiceTraitBounds {
     ) -> Result<Vec<Event>>;
     /// Adds a new Nostr subscription on the primary client for an added contact
     async fn add_contact_subscription(&self, contact: &NodeId) -> Result<()>;
+    /// Resolves all private messages matching the filter
+    async fn resolve_private_events(&self, filter: Filter) -> Result<Vec<Event>>;
 }

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -11,7 +11,7 @@ pub mod tests {
             BlockchainType,
             bill::{BillBlock, BillBlockchain, BillOpCode},
             company::{CompanyBlock, CompanyBlockchain},
-            identity::IdentityBlock,
+            identity::{IdentityBlock, IdentityBlockchain},
         },
         company::{Company, CompanyKeys},
         contact::{BillIdentParticipant, BillParticipant, Contact, ContactType},
@@ -257,6 +257,7 @@ pub mod tests {
         impl IdentityChainStoreApi for IdentityChainStoreApiMock {
             async fn get_latest_block(&self) -> Result<IdentityBlock>;
             async fn add_block(&self, block: &IdentityBlock) -> Result<()>;
+            async fn get_chain(&self) -> Result<IdentityBlockchain>;
         }
     }
 

--- a/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
@@ -112,6 +112,7 @@ pub struct IdentitySignCompanyBillBlockData {
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
 pub struct IdentityCreateCompanyBlockData {
     pub company_id: NodeId,
+    pub company_key: String,
     pub block_hash: String,
 }
 
@@ -576,6 +577,7 @@ mod tests {
             chain.get_latest_block(),
             &IdentityCreateCompanyBlockData {
                 company_id: node_id_test(),
+                company_key: "some key".to_string(),
                 block_hash: "some hash".to_string(),
             },
             &keys,

--- a/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/identity/mod.rs
@@ -5,7 +5,7 @@ use crate::NodeId;
 use crate::bill::BillId;
 use crate::util::{self, BcrKeys, crypto};
 use crate::{File, OptionalPostalAddress, identity::Identity};
-use borsh::to_vec;
+use borsh::{from_slice, to_vec};
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use log::error;
 use secp256k1::PublicKey;
@@ -79,7 +79,7 @@ impl From<Identity> for IdentityCreateBlockData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Default, Debug, Clone, PartialEq)]
 pub struct IdentityUpdateBlockData {
     pub name: Option<String>,
     pub email: Option<String>,
@@ -129,6 +129,17 @@ pub struct IdentityRemoveSignatoryBlockData {
     pub block_id: u64,
     pub block_hash: String,
     pub signatory: NodeId,
+}
+
+#[derive(Debug)]
+pub enum IdentityBlockPayload {
+    Create(IdentityCreateBlockData),
+    Update(IdentityUpdateBlockData),
+    SignPersonalBill(IdentitySignPersonBillBlockData),
+    SignCompanyBill(IdentitySignCompanyBillBlockData),
+    CreateCompany(IdentityCreateCompanyBlockData),
+    AddSignatory(IdentityAddSignatoryBlockData),
+    RemoveSignatory(IdentityRemoveSignatoryBlockData),
 }
 
 impl Block for IdentityBlock {
@@ -393,6 +404,34 @@ impl IdentityBlock {
         }
         Ok(new_block)
     }
+
+    pub fn get_block_data(&self, keys: &BcrKeys) -> Result<IdentityBlockPayload> {
+        let data = self.get_decrypted_block(keys)?;
+        let result: IdentityBlockPayload = match self.op_code {
+            IdentityOpCode::Create => IdentityBlockPayload::Create(from_slice(&data)?),
+            IdentityOpCode::Update => IdentityBlockPayload::Update(from_slice(&data)?),
+            IdentityOpCode::SignPersonBill => {
+                IdentityBlockPayload::SignPersonalBill(from_slice(&data)?)
+            }
+            IdentityOpCode::SignCompanyBill => {
+                IdentityBlockPayload::SignCompanyBill(from_slice(&data)?)
+            }
+            IdentityOpCode::CreateCompany => {
+                IdentityBlockPayload::CreateCompany(from_slice(&data)?)
+            }
+            IdentityOpCode::AddSignatory => IdentityBlockPayload::AddSignatory(from_slice(&data)?),
+            IdentityOpCode::RemoveSignatory => {
+                IdentityBlockPayload::RemoveSignatory(from_slice(&data)?)
+            }
+        };
+        Ok(result)
+    }
+
+    fn get_decrypted_block(&self, keys: &BcrKeys) -> Result<Vec<u8>> {
+        let bytes = util::base58_decode(&self.data)?;
+        let decrypted_bytes = util::crypto::decrypt_ecies(&bytes, &keys.get_private_key())?;
+        Ok(decrypted_bytes)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -423,6 +462,28 @@ impl IdentityBlockchain {
         Ok(Self {
             blocks: vec![first_block],
         })
+    }
+
+    /// Creates an identity chain from a list of blocks
+    pub fn new_from_blocks(blocks_to_add: Vec<IdentityBlock>) -> Result<Self> {
+        match blocks_to_add.first() {
+            None => Err(super::Error::BlockchainInvalid),
+            Some(first) => {
+                if !first.verify() || !first.validate_hash() {
+                    return Err(super::Error::BlockchainInvalid);
+                }
+
+                let chain = Self {
+                    blocks: blocks_to_add,
+                };
+
+                if !chain.is_chain_valid() {
+                    return Err(super::Error::BlockchainInvalid);
+                }
+
+                Ok(chain)
+            }
+        }
     }
 }
 

--- a/crates/bcr-ebill-core/src/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/identity/mod.rs
@@ -1,5 +1,9 @@
 use super::{File, OptionalPostalAddress};
-use crate::{NodeId, ValidationError, util::BcrKeys};
+use crate::{
+    NodeId, ValidationError,
+    blockchain::identity::{IdentityBlockPayload, IdentityCreateBlockData},
+    util::BcrKeys,
+};
 use serde::{Deserialize, Serialize};
 
 pub mod validation;
@@ -56,6 +60,80 @@ pub struct Identity {
 impl Identity {
     pub fn get_nostr_name(&self) -> String {
         self.name.clone()
+    }
+
+    pub fn from_block_data(data: IdentityCreateBlockData) -> Self {
+        let t = if data.postal_address.is_fully_set() {
+            IdentityType::Ident
+        } else {
+            IdentityType::Anon
+        };
+        Self {
+            t,
+            node_id: data.node_id,
+            name: data.name,
+            email: data.email,
+            postal_address: data.postal_address,
+            date_of_birth: data.date_of_birth,
+            country_of_birth: data.country_of_birth,
+            city_of_birth: data.city_of_birth,
+            identification_number: data.identification_number,
+            nostr_relays: data.nostr_relays,
+            profile_picture_file: data.profile_picture_file,
+            identity_document_file: data.identity_document_file,
+        }
+    }
+
+    pub fn apply_block_data(&mut self, data: &IdentityBlockPayload) {
+        // only the update block does actually mutate the identity
+        if let IdentityBlockPayload::Update(payload) = data {
+            self.name = payload.name.to_owned().unwrap_or(self.name.to_owned());
+            self.email = payload.email.to_owned().or(self.email.to_owned());
+            self.postal_address.country = payload
+                .postal_address
+                .country
+                .to_owned()
+                .or(self.postal_address.country.to_owned());
+            self.postal_address.city = payload
+                .postal_address
+                .city
+                .to_owned()
+                .or(self.postal_address.city.to_owned());
+            self.postal_address.zip = payload
+                .postal_address
+                .zip
+                .to_owned()
+                .or(self.postal_address.zip.to_owned());
+            self.postal_address.address = payload
+                .postal_address
+                .address
+                .to_owned()
+                .or(self.postal_address.address.to_owned());
+            self.date_of_birth = payload
+                .date_of_birth
+                .to_owned()
+                .or(self.date_of_birth.to_owned());
+            self.country_of_birth = payload
+                .country_of_birth
+                .to_owned()
+                .or(self.country_of_birth.to_owned());
+            self.city_of_birth = payload
+                .city_of_birth
+                .to_owned()
+                .or(self.city_of_birth.to_owned());
+            self.identification_number = payload
+                .identification_number
+                .to_owned()
+                .or(self.identification_number.to_owned());
+            self.profile_picture_file = payload
+                .profile_picture_file
+                .to_owned()
+                .or(self.profile_picture_file.to_owned());
+            self.identity_document_file = payload
+                .identity_document_file
+                .to_owned()
+                .or(self.identity_document_file.to_owned());
+        }
     }
 }
 

--- a/crates/bcr-ebill-persistence/src/identity.rs
+++ b/crates/bcr-ebill-persistence/src/identity.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 
 use bcr_ebill_core::{
     ServiceTraitBounds,
-    blockchain::identity::IdentityBlock,
+    blockchain::identity::{IdentityBlock, IdentityBlockchain},
     identity::{ActiveIdentityState, Identity, IdentityWithAll},
     util::crypto::BcrKeys,
 };
@@ -43,4 +43,6 @@ pub trait IdentityChainStoreApi: ServiceTraitBounds {
     async fn get_latest_block(&self) -> Result<IdentityBlock>;
     /// Adds the block to the chain
     async fn add_block(&self, block: &IdentityBlock) -> Result<()>;
+    /// Gets the chain
+    async fn get_chain(&self) -> Result<IdentityBlockchain>;
 }

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -24,6 +24,7 @@ async-broadcast.workspace = true
 bitcoin.workspace = true
 uuid.workspace = true
 tokio_with_wasm.workspace = true
+secp256k1.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -28,7 +28,7 @@ secp256k1.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
-nostr-relay-builder = "0.42"
+nostr-relay-builder = "0.43"
 secp256k1.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
@@ -42,7 +42,7 @@ impl NotificationHandlerApi for BillInviteEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
-        _: Box<nostr::Event>,
+        _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming bill chain invite for {node_id}");
         if let Ok(decoded) = Event::<ChainInvite>::try_from(event.clone()) {
@@ -284,7 +284,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -333,7 +333,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -390,7 +390,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
@@ -31,7 +31,7 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
-        original_event: Box<nostr::Event>,
+        original_event: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming company chain event for {node_id}");
         if let Ok(decoded) = Event::<CompanyBlockEvent>::try_from(event.clone()) {
@@ -47,14 +47,16 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
                     .inspect_err(|e| error!("Received invalid block {e}"))
                     .is_ok();
 
-                self.store_event(
-                    original_event,
-                    decoded.data.block_height,
-                    &decoded.data.block.hash,
-                    &decoded.data.node_id.to_string(),
-                    valid,
-                )
-                .await?;
+                if let Some(original_event) = original_event {
+                    self.store_event(
+                        original_event,
+                        decoded.data.block_height,
+                        &decoded.data.block.hash,
+                        &decoded.data.node_id.to_string(),
+                        valid,
+                    )
+                    .await?;
+                }
             } else {
                 trace!("no keys for incoming company block {node_id}");
             }
@@ -193,7 +195,7 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id, original_event)
+            .handle_event(event.try_into().unwrap(), &node_id, Some(original_event))
             .await
             .expect("failed to handle event");
     }
@@ -238,7 +240,7 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id, original_event)
+            .handle_event(event.try_into().unwrap(), &node_id, Some(original_event))
             .await
             .expect("failed to handle event");
     }

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -22,6 +22,7 @@ use bcr_ebill_api::service::notification_service::{Result, event::EventEnvelope}
 
 use super::{CompanyChainEventProcessorApi, NotificationHandlerApi};
 
+#[derive(Clone)]
 pub struct CompanyInviteEventHandler {
     transport: Arc<dyn NotificationJsonTransportApi>,
     processor: Arc<dyn CompanyChainEventProcessorApi>,

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -1,9 +1,8 @@
-use std::{cmp::Reverse, collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use bcr_ebill_api::service::notification_service::{
-    event::{ChainInvite, ChainKeys},
-    transport::NotificationJsonTransportApi,
+    event::ChainInvite, transport::NotificationJsonTransportApi,
 };
 use bcr_ebill_core::{
     NodeId, ServiceTraitBounds,
@@ -16,15 +15,12 @@ use log::{debug, error, warn};
 
 use crate::{
     EventType,
-    handler::public_chain_helpers::{BlockData, EventContainer},
+    handler::public_chain_helpers::{BlockData, EventContainer, resolve_event_chains},
 };
 use bcr_ebill_api::service::notification_service::event::Event;
 use bcr_ebill_api::service::notification_service::{Result, event::EventEnvelope};
 
-use super::{
-    CompanyChainEventProcessorApi, NotificationHandlerApi,
-    public_chain_helpers::collect_event_chains,
-};
+use super::{CompanyChainEventProcessorApi, NotificationHandlerApi};
 
 pub struct CompanyInviteEventHandler {
     transport: Arc<dyn NotificationJsonTransportApi>,
@@ -43,24 +39,20 @@ impl NotificationHandlerApi for CompanyInviteEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
-        _: Box<nostr::Event>,
+        _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming company chain invite for {node_id}");
         if let Ok(decoded) = Event::<ChainInvite>::try_from(event.clone()) {
-            let events = self
-                .transport
-                .resolve_public_chain(&decoded.data.chain_id, decoded.data.chain_type)
-                .await?;
+            let keys = BcrKeys::from_private_key(&decoded.data.keys.private_key)?;
 
             let mut inserted_chain: Vec<EventContainer> = Vec::new();
-            if let Ok(chain_data) = self
-                .resolve_chain_data(
-                    &decoded.data.keys,
-                    &decoded.data.chain_id,
-                    decoded.data.chain_type,
-                    &events,
-                )
-                .await
+            if let Ok(chain_data) = resolve_event_chains(
+                self.transport.clone(),
+                &decoded.data.chain_id,
+                decoded.data.chain_type,
+                &keys,
+            )
+            .await
             {
                 // We try to add shorter and shorter chains until we have a success
                 for data in chain_data.iter() {
@@ -126,22 +118,6 @@ impl CompanyInviteEventHandler {
             processor,
             chain_event_store,
         }
-    }
-
-    /// Parses chain keys, resolves all Nostr events and builds Nostr chains from it.
-    /// Then decrypts the payloads and parses the block contents. Returns all found chains
-    /// in descending order by chain length.
-    async fn resolve_chain_data(
-        &self,
-        keys: &ChainKeys,
-        chain_id: &str,
-        chain_type: BlockchainType,
-        events: &[nostr_sdk::Event],
-    ) -> Result<Vec<Vec<EventContainer>>> {
-        let keys = BcrKeys::from_private_key(&keys.private_key)?;
-        let mut chains = collect_event_chains(events, chain_id, chain_type, &keys);
-        chains.sort_by_key(|v| Reverse(v.len()));
-        Ok(chains)
     }
 
     async fn store_events(
@@ -298,7 +274,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -350,7 +326,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -410,7 +386,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Box::new(event.clone()))
+            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -11,7 +11,7 @@ use bcr_ebill_core::{
     util::BcrKeys,
 };
 use bcr_ebill_persistence::{NostrChainEventStoreApi, nostr::NostrChainEvent};
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 
 use crate::{
     EventType,
@@ -57,7 +57,7 @@ impl NotificationHandlerApi for CompanyInviteEventHandler {
             {
                 // We try to add shorter and shorter chains until we have a success
                 for data in chain_data.iter() {
-                    debug!("Processing company chain data with block {data:#?}");
+                    trace!("Processing company chain data with block {data:#?}");
                     let blocks: Vec<CompanyBlock> = data
                         .iter()
                         .filter_map(|d| match d.block.clone() {
@@ -65,7 +65,7 @@ impl NotificationHandlerApi for CompanyInviteEventHandler {
                             _ => None,
                         })
                         .collect();
-                    debug!("Processing company chain data with {} blocks", blocks.len());
+                    trace!("Processing company chain data with {} blocks", blocks.len());
                     if !data.is_empty()
                         && self
                             .processor

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
@@ -1,0 +1,260 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bcr_ebill_api::service::notification_service::event::IdentityBlockEvent;
+use bcr_ebill_core::{NodeId, ServiceTraitBounds, blockchain::BlockchainType, util::date::now};
+use bcr_ebill_persistence::identity::IdentityStoreApi;
+use bcr_ebill_persistence::{NostrChainEventStoreApi, nostr::NostrChainEvent};
+use log::{debug, error, trace, warn};
+
+use crate::{EventType, transport::root_and_reply_id};
+use bcr_ebill_api::service::notification_service::event::Event;
+use bcr_ebill_api::service::notification_service::{Result, event::EventEnvelope};
+
+use super::{IdentityChainEventProcessorApi, NotificationHandlerApi};
+
+#[derive(Clone)]
+pub struct IdentityChainEventHandler {
+    identity_store: Arc<dyn IdentityStoreApi>,
+    processor: Arc<dyn IdentityChainEventProcessorApi>,
+    chain_event_store: Arc<dyn NostrChainEventStoreApi>,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl NotificationHandlerApi for IdentityChainEventHandler {
+    fn handles_event(&self, event_type: &EventType) -> bool {
+        event_type == &EventType::IdentityChain
+    }
+
+    async fn handle_event(
+        &self,
+        event: EventEnvelope,
+        node_id: &NodeId,
+        original_event: Box<nostr::Event>,
+    ) -> Result<()> {
+        debug!("incoming identity chain event for {node_id}");
+        if let Ok(decoded) = Event::<IdentityBlockEvent>::try_from(event.clone()) {
+            if let Ok(keys) = self.identity_store.get_key_pair().await {
+                let valid = self
+                    .processor
+                    .process_chain_data(
+                        &decoded.data.node_id,
+                        vec![decoded.data.block.clone()],
+                        Some(keys.clone()),
+                    )
+                    .await
+                    .inspect_err(|e| error!("Received invalid block {e}"))
+                    .is_ok();
+
+                self.store_event(
+                    original_event,
+                    decoded.data.block_height,
+                    &decoded.data.block.hash,
+                    &decoded.data.node_id.to_string(),
+                    valid,
+                )
+                .await?;
+            } else {
+                trace!("no keys for incoming identity block {node_id}");
+            }
+        } else {
+            warn!("Could not decode event to IdentityBlockEvent {event:?}");
+        }
+        Ok(())
+    }
+}
+impl ServiceTraitBounds for IdentityChainEventHandler {}
+
+#[allow(unused)]
+impl IdentityChainEventHandler {
+    pub fn new(
+        identity_store: Arc<dyn IdentityStoreApi>,
+        processor: Arc<dyn IdentityChainEventProcessorApi>,
+        chain_event_store: Arc<dyn NostrChainEventStoreApi>,
+    ) -> Self {
+        Self {
+            identity_store,
+            processor,
+            chain_event_store,
+        }
+    }
+    async fn store_event(
+        &self,
+        event: Box<nostr::Event>,
+        block_height: usize,
+        block_hash: &str,
+        chain_id: &str,
+        valid: bool,
+    ) -> Result<()> {
+        let (root, reply) = root_and_reply_id(&event);
+        if let Err(e) = self
+            .chain_event_store
+            .add_chain_event(NostrChainEvent {
+                event_id: event.id.to_string(),
+                root_id: root
+                    .map(|id| id.to_string())
+                    .unwrap_or(event.id.to_string()),
+                reply_id: reply.map(|id| id.to_string()),
+                author: event.pubkey.to_string(),
+                chain_id: chain_id.to_string(),
+                chain_type: BlockchainType::Identity,
+                block_height,
+                block_hash: block_hash.to_string(),
+                received: now().timestamp() as u64,
+                time: event.created_at.as_u64(),
+                payload: *event.clone(),
+                valid,
+            })
+            .await
+        {
+            error!("Failed to store bill chain nostr event into event store {e}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use bcr_ebill_core::{
+        blockchain::{
+            Blockchain,
+            identity::{IdentityBlock, IdentityBlockchain, IdentityUpdateBlockData},
+        },
+        identity::IdentityWithAll,
+    };
+    use mockall::predicate::always;
+
+    use crate::handler::{
+        MockIdentityChainEventProcessorApi,
+        identity_chain_event_processor::tests::{
+            get_identity_create_block, get_identity_update_block,
+        },
+        test_utils::{
+            MockIdentityStore, MockNostrChainEventStore, get_baseline_identity,
+            get_test_nostr_event, node_id_test,
+        },
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_handle_update_event() {
+        let (mut store, mut processor, mut chain_event_store) = create_mocks();
+        let full = get_baseline_identity();
+        let identity = full.identity.clone();
+        let keys = full.key_pair.clone();
+        let chain = create_identity_chain(full.clone());
+        let data = IdentityUpdateBlockData {
+            name: Some("new_name".to_string()),
+            ..Default::default()
+        };
+        let block = get_identity_update_block(chain.get_latest_block(), &keys, &data);
+        let original_event = Box::new(get_test_nostr_event());
+
+        let event = Event::new_company_chain(IdentityBlockEvent {
+            node_id: node_id_test(),
+            block_height: 1,
+            block: block.clone(),
+        });
+
+        // see if we have chain keys
+        store
+            .expect_get_key_pair()
+            .returning(move || Ok(keys.clone()))
+            .once();
+
+        // should process the chain data
+        processor
+            .expect_process_chain_data()
+            .withf(|node_id, blocks, company_keys| {
+                node_id == &node_id.clone() && !blocks.is_empty() && company_keys.is_some()
+            })
+            .returning(|_, _, _| Ok(()))
+            .once();
+
+        // and store the nostr event
+        chain_event_store
+            .expect_add_chain_event()
+            .with(always())
+            .returning(|_| Ok(()))
+            .once();
+
+        let handler = IdentityChainEventHandler::new(
+            Arc::new(store),
+            Arc::new(processor),
+            Arc::new(chain_event_store),
+        );
+
+        handler
+            .handle_event(event.try_into().unwrap(), &identity.node_id, original_event)
+            .await
+            .expect("failed to handle event");
+    }
+
+    #[tokio::test]
+    async fn test_handle_no_chain_event() {
+        let (mut store, mut processor, chain_event_store) = create_mocks();
+        let full = get_baseline_identity();
+        let identity = full.identity.clone();
+        let keys = full.key_pair.clone();
+        let node_id = identity.node_id.clone();
+        let chain = create_identity_chain(full.clone());
+        let data = IdentityUpdateBlockData {
+            name: Some("new_name".to_string()),
+            ..Default::default()
+        };
+        let block = IdentityBlock::create_block_for_update(
+            chain.get_latest_block(),
+            &data,
+            &keys,
+            1731593928,
+        )
+        .expect("could not create block");
+
+        let original_event = Box::new(get_test_nostr_event());
+
+        let event = Event::new_identity_chain(IdentityBlockEvent {
+            node_id: node_id.clone(),
+            block_height: 1,
+            block: block.clone(),
+        });
+
+        // no chain keys so we should be done here
+        store
+            .expect_get_key_pair()
+            .returning(move || Err(bcr_ebill_persistence::Error::NoIdentity))
+            .once();
+
+        processor.expect_process_chain_data().never();
+
+        let handler = IdentityChainEventHandler::new(
+            Arc::new(store),
+            Arc::new(processor),
+            Arc::new(chain_event_store),
+        );
+
+        handler
+            .handle_event(event.try_into().unwrap(), &node_id, original_event)
+            .await
+            .expect("failed to handle event");
+    }
+
+    fn create_identity_chain(full: IdentityWithAll) -> IdentityBlockchain {
+        let blocks = vec![get_identity_create_block(full.identity, &full.key_pair)];
+        IdentityBlockchain::new_from_blocks(blocks).expect("could not create chain")
+    }
+
+    fn create_mocks() -> (
+        MockIdentityStore,
+        MockIdentityChainEventProcessorApi,
+        MockNostrChainEventStore,
+    ) {
+        (
+            MockIdentityStore::default(),
+            MockIdentityChainEventProcessorApi::default(),
+            MockNostrChainEventStore::default(),
+        )
+    }
+}

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
@@ -1,0 +1,414 @@
+use crate::{Error, Result};
+use async_trait::async_trait;
+use bcr_ebill_api::util::BcrKeys;
+use log::{debug, error, info, warn};
+use std::sync::Arc;
+
+use bcr_ebill_core::{
+    NodeId, ServiceTraitBounds,
+    blockchain::{
+        Block, Blockchain,
+        identity::{IdentityBlock, IdentityBlockPayload, IdentityBlockchain},
+    },
+    identity::Identity,
+};
+use bcr_ebill_persistence::identity::{IdentityChainStoreApi, IdentityStoreApi};
+
+use super::{IdentityChainEventProcessorApi, NostrContactProcessorApi};
+
+#[derive(Clone)]
+pub struct IdentityChainEventProcessor {
+    blockchain_store: Arc<dyn IdentityChainStoreApi>,
+    identity_store: Arc<dyn IdentityStoreApi>,
+    nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+    bitcoin_network: bitcoin::Network,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl IdentityChainEventProcessorApi for IdentityChainEventProcessor {
+    async fn process_chain_data(
+        &self,
+        node_id: &NodeId,
+        blocks: Vec<IdentityBlock>,
+        keys: Option<BcrKeys>,
+    ) -> Result<()> {
+        // check that incoming company blocks are of the same network that we use
+        if node_id.network() != self.bitcoin_network {
+            warn!("Received identity blocks for node {node_id} for a different network");
+            return Err(Error::Blockchain(format!(
+                "Received identity blocks for node {node_id} for a different network"
+            )));
+        }
+
+        if let Ok(mut existing_chain) = self.blockchain_store.get_chain().await {
+            self.add_identity_blocks(node_id, &mut existing_chain, blocks)
+                .await
+        } else {
+            match keys {
+                Some(keys) => self.add_new_chain(blocks, &keys).await,
+                _ => {
+                    error!("Received company blocks for unknown company {node_id}");
+                    Err(Error::Blockchain(
+                        "Received company blocks for unknown company".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    async fn validate_chain_event_and_sender(
+        &self,
+        node_id: &NodeId,
+        sender: nostr::PublicKey,
+    ) -> Result<bool> {
+        Ok(node_id.npub() == sender)
+    }
+}
+
+#[allow(unused)]
+impl IdentityChainEventProcessor {
+    pub fn new(
+        blockchain_store: Arc<dyn IdentityChainStoreApi>,
+        identity_store: Arc<dyn IdentityStoreApi>,
+        nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+        bitcoin_network: bitcoin::Network,
+    ) -> Self {
+        Self {
+            blockchain_store,
+            identity_store,
+            nostr_contact_processor,
+            bitcoin_network,
+        }
+    }
+
+    async fn add_new_chain(&self, blocks: Vec<IdentityBlock>, keys: &BcrKeys) -> Result<()> {
+        let (node_id, identity, chain) = self.get_valid_chain(blocks, keys)?;
+        debug!("updating identity and chain {node_id}");
+        // save the identity
+        self.identity_store.save(&identity).await.map_err(|e| {
+            error!("Failed to save identity {node_id}: {e}");
+            Error::Persistence(e.to_string())
+        })?;
+        // save all blocks
+        for block in chain.blocks().iter() {
+            self.save_block(block).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn add_identity_blocks(
+        &self,
+        node_id: &NodeId,
+        chain: &mut IdentityBlockchain,
+        blocks: Vec<IdentityBlock>,
+    ) -> Result<()> {
+        let keys = self
+            .identity_store
+            .get_key_pair()
+            .await
+            .map_err(|e| Error::Persistence(e.to_string()))?;
+
+        let mut identity = self
+            .identity_store
+            .get()
+            .await
+            .map_err(|e| Error::Persistence(e.to_string()))?;
+
+        let mut block_height = chain.get_latest_block().id;
+        for block in blocks {
+            if block.id <= block_height {
+                info!("Skipping block with id {block_height} for {node_id} as we already have it");
+                continue;
+            }
+
+            let data = block
+                .get_block_data(&keys)
+                .map_err(|e| Error::Blockchain(e.to_string()))?;
+
+            if chain.try_add_block(block.clone()) {
+                block_height = block.id;
+                identity.apply_block_data(&data);
+                self.save_block(&block).await?;
+                self.identity_store
+                    .save(&identity)
+                    .await
+                    .map_err(|e| Error::Persistence(e.to_string()))?;
+
+                if let IdentityBlockPayload::AddSignatory(payload) = data {
+                    self.nostr_contact_processor
+                        .ensure_nostr_contact(&payload.signatory)
+                        .await
+                };
+            }
+        }
+        debug!("Updated identity {node_id} with data from new blocks");
+        Ok(())
+    }
+
+    fn get_valid_chain(
+        &self,
+        blocks: Vec<IdentityBlock>,
+        keys: &BcrKeys,
+    ) -> Result<(NodeId, Identity, IdentityBlockchain)> {
+        match IdentityBlockchain::new_from_blocks(blocks) {
+            Ok(chain) => {
+                let first_block = chain.get_first_block();
+                // create block is where we build up the company from
+                let payload = match first_block
+                    .get_block_data(keys)
+                    .map_err(|e| Error::Blockchain(e.to_string()))?
+                {
+                    IdentityBlockPayload::Create(payload) => payload,
+                    _ => {
+                        error!(
+                            "First block of newly received identity chain is not a Create block"
+                        );
+                        return Err(Error::Blockchain(
+                            "First block of newly received identity chain is not a Create block"
+                                .to_string(),
+                        ));
+                    }
+                };
+
+                // initialize company from payload
+                let mut identity = Identity::from_block_data(payload);
+                let node_id = identity.node_id.clone();
+
+                // now process and validate all the blocks
+                for block in chain.blocks().iter() {
+                    // validate the payloads
+                    if !block.validate_plaintext_hash(&keys.get_private_key()) {
+                        error!("Newly received chain block has invalid plaintext hash");
+                        return Err(Error::Blockchain(
+                            "Newly received chain block has invalid plaintext hash".to_string(),
+                        ));
+                    }
+                    // bulid up the identity from the payloads
+                    let p = block
+                        .get_block_data(keys)
+                        .map_err(|e| Error::Blockchain(e.to_string()))?;
+                    identity.apply_block_data(&p)
+                }
+                Ok((node_id, identity, chain))
+            }
+            _ => {
+                error!("Newly received identity chain is not valid");
+                Err(Error::Blockchain(
+                    "Newly received identity chain is not valid".to_string(),
+                ))
+            }
+        }
+    }
+
+    async fn save_block(&self, block: &IdentityBlock) -> Result<()> {
+        if let Err(e) = self.blockchain_store.add_block(block).await {
+            error!("Failed to add identity block to blockchain store: {e}");
+            return Err(Error::Persistence(
+                "Failed to add identity block to blockchain store".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl ServiceTraitBounds for IdentityChainEventProcessor {}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use bcr_ebill_core::{
+        blockchain::{
+            Blockchain,
+            identity::{IdentityBlock, IdentityBlockchain, IdentityUpdateBlockData},
+        },
+        identity::Identity,
+        util::BcrKeys,
+    };
+    use mockall::predicate::always;
+
+    use crate::handler::{
+        IdentityChainEventProcessorApi, MockNostrContactProcessorApi,
+        identity_chain_event_processor::IdentityChainEventProcessor,
+        test_utils::{
+            MockIdentityChainStore, MockIdentityStore, get_baseline_identity, node_id_test,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_create_event_handler() {
+        let (chain_store, store, contact) = create_mocks();
+        IdentityChainEventProcessor::new(
+            Arc::new(chain_store),
+            Arc::new(store),
+            Arc::new(contact),
+            bitcoin::Network::Testnet,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_chain_event_and_sender_invalid_on_no_keys_or_chain() {
+        let keys = BcrKeys::new().get_nostr_keys();
+        let (chain_store, mut store, contact) = create_mocks();
+
+        store
+            .expect_get()
+            .returning(move || Err(bcr_ebill_persistence::Error::NoIdentityBlock));
+
+        let handler = IdentityChainEventProcessor::new(
+            Arc::new(chain_store),
+            Arc::new(store),
+            Arc::new(contact),
+            bitcoin::Network::Testnet,
+        );
+
+        let valid = handler
+            .validate_chain_event_and_sender(&node_id_test(), keys.public_key())
+            .await
+            .expect("Event should be handled");
+        assert!(!valid);
+    }
+
+    #[tokio::test]
+    async fn test_validate_chain_event_fails_if_not_own_node_id() {
+        let keys = BcrKeys::new();
+        let (chain_store, mut store, contact) = create_mocks();
+        let identity = get_baseline_identity();
+        store
+            .expect_get()
+            .returning(move || Ok(identity.identity.clone()));
+
+        let handler = IdentityChainEventProcessor::new(
+            Arc::new(chain_store),
+            Arc::new(store),
+            Arc::new(contact),
+            bitcoin::Network::Testnet,
+        );
+
+        let valid = handler
+            .validate_chain_event_and_sender(&node_id_test(), keys.get_nostr_keys().public_key())
+            .await
+            .expect("Event should be handled");
+        assert!(!valid);
+    }
+
+    #[tokio::test]
+    async fn test_validate_chain_event() {
+        let (chain_store, mut store, contact) = create_mocks();
+        let full = get_baseline_identity();
+        let mut identity = full.identity.clone();
+        identity.name = "new name".to_string();
+        let keys = full.key_pair.clone();
+
+        store.expect_get().returning(move || Ok(identity.clone()));
+
+        let handler = IdentityChainEventProcessor::new(
+            Arc::new(chain_store),
+            Arc::new(store),
+            Arc::new(contact),
+            bitcoin::Network::Testnet,
+        );
+
+        let valid = handler
+            .validate_chain_event_and_sender(
+                &full.identity.node_id,
+                keys.get_nostr_keys().public_key(),
+            )
+            .await
+            .expect("Event should be handled");
+        assert!(valid);
+    }
+
+    #[tokio::test]
+    async fn test_process_update_identity_data() {
+        let (mut chain_store, mut store, contact) = create_mocks();
+        let full = get_baseline_identity();
+        let identity = full.identity.clone();
+        let keys = full.key_pair.clone();
+        let blocks = vec![get_identity_create_block(full.identity, &full.key_pair)];
+        let chain = IdentityBlockchain::new_from_blocks(blocks).expect("could not create chain");
+        let data = IdentityUpdateBlockData {
+            name: Some("new_name".to_string()),
+            ..Default::default()
+        };
+        let update_block = get_identity_update_block(chain.get_latest_block(), &keys, &data);
+
+        // checks if we already have the chain
+        chain_store
+            .expect_get_chain()
+            .returning(move || Ok(chain.clone()))
+            .once();
+
+        // we have a chain so get the keys
+        store
+            .expect_get_key_pair()
+            .returning(move || Ok(keys.clone()))
+            .once();
+
+        // get the current identity state
+        let expected_identity = identity.clone();
+        store
+            .expect_get()
+            .returning(move || Ok(expected_identity.clone()))
+            .once();
+
+        // apply changes from block and update the identity
+        store
+            .expect_save()
+            .withf(move |n| n.name == "new_name")
+            .returning(|_| Ok(()))
+            .once();
+
+        // inserts the block
+        chain_store
+            .expect_add_block()
+            .with(always())
+            .returning(|_| Ok(()))
+            .once();
+
+        let handler = IdentityChainEventProcessor::new(
+            Arc::new(chain_store),
+            Arc::new(store),
+            Arc::new(contact),
+            bitcoin::Network::Testnet,
+        );
+
+        handler
+            .process_chain_data(&identity.node_id, vec![update_block], None)
+            .await
+            .expect("Process chain data should be handled");
+    }
+
+    pub fn get_identity_create_block(identity: Identity, keys: &BcrKeys) -> IdentityBlock {
+        IdentityBlock::create_block_for_create(
+            "genesis hash".to_string(),
+            &identity.into(),
+            keys,
+            1731593928,
+        )
+        .expect("could not create block")
+    }
+
+    pub fn get_identity_update_block(
+        previous_block: &IdentityBlock,
+        keys: &BcrKeys,
+        data: &IdentityUpdateBlockData,
+    ) -> IdentityBlock {
+        IdentityBlock::create_block_for_update(previous_block, data, keys, 1731594928)
+            .expect("could not create block")
+    }
+
+    fn create_mocks() -> (
+        MockIdentityChainStore,
+        MockIdentityStore,
+        MockNostrContactProcessorApi,
+    ) {
+        (
+            MockIdentityChainStore::new(),
+            MockIdentityStore::new(),
+            MockNostrContactProcessorApi::new(),
+        )
+    }
+}

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
@@ -1,8 +1,12 @@
 use crate::{Error, Result};
 use async_trait::async_trait;
-use bcr_ebill_api::util::BcrKeys;
+use bcr_ebill_api::{
+    service::notification_service::event::{ChainInvite, Event},
+    util::BcrKeys,
+};
 use log::{debug, error, info, warn};
-use std::sync::Arc;
+use secp256k1::SecretKey;
+use std::{str::FromStr, sync::Arc};
 
 use bcr_ebill_core::{
     NodeId, ServiceTraitBounds,
@@ -10,16 +14,18 @@ use bcr_ebill_core::{
         Block, Blockchain,
         identity::{IdentityBlock, IdentityBlockPayload, IdentityBlockchain},
     },
+    company::CompanyKeys,
     identity::Identity,
 };
 use bcr_ebill_persistence::identity::{IdentityChainStoreApi, IdentityStoreApi};
 
-use super::{IdentityChainEventProcessorApi, NostrContactProcessorApi};
+use super::{IdentityChainEventProcessorApi, NostrContactProcessorApi, NotificationHandlerApi};
 
 #[derive(Clone)]
 pub struct IdentityChainEventProcessor {
     blockchain_store: Arc<dyn IdentityChainStoreApi>,
     identity_store: Arc<dyn IdentityStoreApi>,
+    company_invite_handler: Arc<dyn NotificationHandlerApi>,
     nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
     bitcoin_network: bitcoin::Network,
 }
@@ -48,21 +54,17 @@ impl IdentityChainEventProcessorApi for IdentityChainEventProcessor {
             match keys {
                 Some(keys) => self.add_new_chain(blocks, &keys).await,
                 _ => {
-                    error!("Received company blocks for unknown company {node_id}");
+                    error!("Received identity blocks for unknown identity {node_id}");
                     Err(Error::Blockchain(
-                        "Received company blocks for unknown company".to_string(),
+                        "Received identity blocks for unknown identity".to_string(),
                     ))
                 }
             }
         }
     }
 
-    async fn validate_chain_event_and_sender(
-        &self,
-        node_id: &NodeId,
-        sender: nostr::PublicKey,
-    ) -> Result<bool> {
-        Ok(node_id.npub() == sender)
+    fn validate_chain_event_and_sender(&self, node_id: &NodeId, sender: nostr::PublicKey) -> bool {
+        node_id.npub() == sender
     }
 }
 
@@ -71,28 +73,35 @@ impl IdentityChainEventProcessor {
     pub fn new(
         blockchain_store: Arc<dyn IdentityChainStoreApi>,
         identity_store: Arc<dyn IdentityStoreApi>,
+        company_invite_handler: Arc<dyn NotificationHandlerApi>,
         nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
         bitcoin_network: bitcoin::Network,
     ) -> Self {
         Self {
             blockchain_store,
             identity_store,
+            company_invite_handler,
             nostr_contact_processor,
             bitcoin_network,
         }
     }
 
     async fn add_new_chain(&self, blocks: Vec<IdentityBlock>, keys: &BcrKeys) -> Result<()> {
-        let (node_id, identity, chain) = self.get_valid_chain(blocks, keys)?;
-        debug!("updating identity and chain {node_id}");
+        let (node_id, mut identity, mut chain) = self.get_valid_chain(blocks.clone(), keys)?;
+        debug!("updating identity chain for {node_id}");
         // save the identity
         self.identity_store.save(&identity).await.map_err(|e| {
             error!("Failed to save identity {node_id}: {e}");
             Error::Persistence(e.to_string())
         })?;
-        // save all blocks
-        for block in chain.blocks().iter() {
-            self.save_block(block).await?;
+
+        // Save the first block of the chain as it is the create block
+        self.save_block(chain.get_first_block()).await?;
+
+        // process remaining blocks
+        for block in blocks.iter().skip(1) {
+            self.add_identity_block(&node_id, keys, &mut identity, &mut chain, block)
+                .await?;
         }
 
         Ok(())
@@ -119,34 +128,85 @@ impl IdentityChainEventProcessor {
         let mut block_height = chain.get_latest_block().id;
         for block in blocks {
             if block.id <= block_height {
-                info!("Skipping block with id {block_height} for {node_id} as we already have it");
+                info!(
+                    "Skipping identity block with id {block_height} for {node_id} as we already have it"
+                );
                 continue;
             }
-
-            let data = block
-                .get_block_data(&keys)
-                .map_err(|e| Error::Blockchain(e.to_string()))?;
-
-            if chain.try_add_block(block.clone()) {
-                block_height = block.id;
-                identity.apply_block_data(&data);
-                self.save_block(&block).await?;
-                self.identity_store
-                    .save(&identity)
-                    .await
-                    .map_err(|e| Error::Persistence(e.to_string()))?;
-
-                if let IdentityBlockPayload::AddSignatory(payload) = data {
-                    self.nostr_contact_processor
-                        .ensure_nostr_contact(&payload.signatory)
-                        .await
-                };
-            }
+            self.add_identity_block(node_id, &keys, &mut identity, chain, &block)
+                .await?;
         }
         debug!("Updated identity {node_id} with data from new blocks");
         Ok(())
     }
 
+    async fn add_identity_block(
+        &self,
+        node_id: &NodeId,
+        keys: &BcrKeys,
+        identity: &mut Identity,
+        chain: &mut IdentityBlockchain,
+        block: &IdentityBlock,
+    ) -> Result<()> {
+        if chain.try_add_block(block.clone()) {
+            let data = block
+                .get_block_data(keys)
+                .map_err(|e| Error::Blockchain(e.to_string()))?;
+
+            // process effects
+            match data {
+                update @ IdentityBlockPayload::Update(_) => {
+                    info!("Updating identity {node_id} from block data");
+                    identity.apply_block_data(&update);
+                    self.identity_store
+                        .save(identity)
+                        .await
+                        .map_err(|e| Error::Persistence(e.to_string()))?;
+                }
+                IdentityBlockPayload::AddSignatory(payload) => {
+                    info!("Adding signatory to identity {node_id}");
+                    self.nostr_contact_processor
+                        .ensure_nostr_contact(&payload.signatory)
+                        .await
+                }
+                IdentityBlockPayload::CreateCompany(payload) => {
+                    info!("Received company create block. Restoring Company data");
+                    let secret_key = SecretKey::from_str(&payload.company_key)
+                        .map_err(|e| Error::Crypto(e.to_string()))?;
+                    let company_keys = BcrKeys::from_private_key(&secret_key)?;
+                    let invite = ChainInvite::company(
+                        payload.company_id.to_string(),
+                        CompanyKeys {
+                            public_key: company_keys.pub_key(),
+                            private_key: company_keys.get_private_key(),
+                        },
+                    );
+                    let event = Event::new_company_invite(invite);
+                    self.company_invite_handler
+                        .handle_event(event.try_into()?, node_id, None)
+                        .await?;
+                }
+                IdentityBlockPayload::RemoveSignatory(payload) => {}
+                IdentityBlockPayload::SignCompanyBill(payload) => {}
+                IdentityBlockPayload::SignPersonalBill(payload) => {}
+                IdentityBlockPayload::Create(_) => {}
+            }
+
+            // persist data
+            self.save_block(block).await?;
+
+            // return the updated identity and chain
+            Ok(())
+        } else {
+            error!("Received invalid identity block");
+            Err(Error::Blockchain(
+                "Received invalid identity block".to_string(),
+            ))
+        }
+    }
+
+    /// Validates all blocks in the given chain and returns the the chain with create block and the
+    /// created identity and node id. Will return an error if one of the blocks is invalid.
     fn get_valid_chain(
         &self,
         blocks: Vec<IdentityBlock>,
@@ -172,10 +232,6 @@ impl IdentityChainEventProcessor {
                     }
                 };
 
-                // initialize company from payload
-                let mut identity = Identity::from_block_data(payload);
-                let node_id = identity.node_id.clone();
-
                 // now process and validate all the blocks
                 for block in chain.blocks().iter() {
                     // validate the payloads
@@ -185,13 +241,14 @@ impl IdentityChainEventProcessor {
                             "Newly received chain block has invalid plaintext hash".to_string(),
                         ));
                     }
-                    // bulid up the identity from the payloads
-                    let p = block
-                        .get_block_data(keys)
-                        .map_err(|e| Error::Blockchain(e.to_string()))?;
-                    identity.apply_block_data(&p)
                 }
-                Ok((node_id, identity, chain))
+
+                // initialize identity and chain from first block
+                let mut identity = Identity::from_block_data(payload);
+                let node_id = identity.node_id.clone();
+                let return_chain = IdentityBlockchain::new_from_blocks(vec![first_block.clone()])
+                    .map_err(|e| Error::Blockchain(e.to_string()))?;
+                Ok((node_id, identity, return_chain))
             }
             _ => {
                 error!("Newly received identity chain is not valid");
@@ -230,7 +287,7 @@ pub mod tests {
     use mockall::predicate::always;
 
     use crate::handler::{
-        IdentityChainEventProcessorApi, MockNostrContactProcessorApi,
+        IdentityChainEventProcessorApi, MockNostrContactProcessorApi, MockNotificationHandlerApi,
         identity_chain_event_processor::IdentityChainEventProcessor,
         test_utils::{
             MockIdentityChainStore, MockIdentityStore, get_baseline_identity, node_id_test,
@@ -239,10 +296,11 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_create_event_handler() {
-        let (chain_store, store, contact) = create_mocks();
+        let (chain_store, store, contact, company_invite) = create_mocks();
         IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
+            Arc::new(company_invite),
             Arc::new(contact),
             bitcoin::Network::Testnet,
         );
@@ -251,7 +309,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_validate_chain_event_and_sender_invalid_on_no_keys_or_chain() {
         let keys = BcrKeys::new().get_nostr_keys();
-        let (chain_store, mut store, contact) = create_mocks();
+        let (chain_store, mut store, contact, company_invite) = create_mocks();
 
         store
             .expect_get()
@@ -260,21 +318,19 @@ pub mod tests {
         let handler = IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
+            Arc::new(company_invite),
             Arc::new(contact),
             bitcoin::Network::Testnet,
         );
 
-        let valid = handler
-            .validate_chain_event_and_sender(&node_id_test(), keys.public_key())
-            .await
-            .expect("Event should be handled");
+        let valid = handler.validate_chain_event_and_sender(&node_id_test(), keys.public_key());
         assert!(!valid);
     }
 
     #[tokio::test]
     async fn test_validate_chain_event_fails_if_not_own_node_id() {
         let keys = BcrKeys::new();
-        let (chain_store, mut store, contact) = create_mocks();
+        let (chain_store, mut store, contact, company_invite) = create_mocks();
         let identity = get_baseline_identity();
         store
             .expect_get()
@@ -283,20 +339,19 @@ pub mod tests {
         let handler = IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
+            Arc::new(company_invite),
             Arc::new(contact),
             bitcoin::Network::Testnet,
         );
 
         let valid = handler
-            .validate_chain_event_and_sender(&node_id_test(), keys.get_nostr_keys().public_key())
-            .await
-            .expect("Event should be handled");
+            .validate_chain_event_and_sender(&node_id_test(), keys.get_nostr_keys().public_key());
         assert!(!valid);
     }
 
     #[tokio::test]
     async fn test_validate_chain_event() {
-        let (chain_store, mut store, contact) = create_mocks();
+        let (chain_store, mut store, contact, company_invite) = create_mocks();
         let full = get_baseline_identity();
         let mut identity = full.identity.clone();
         identity.name = "new name".to_string();
@@ -307,23 +362,21 @@ pub mod tests {
         let handler = IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
+            Arc::new(company_invite),
             Arc::new(contact),
             bitcoin::Network::Testnet,
         );
 
-        let valid = handler
-            .validate_chain_event_and_sender(
-                &full.identity.node_id,
-                keys.get_nostr_keys().public_key(),
-            )
-            .await
-            .expect("Event should be handled");
+        let valid = handler.validate_chain_event_and_sender(
+            &full.identity.node_id,
+            keys.get_nostr_keys().public_key(),
+        );
         assert!(valid);
     }
 
     #[tokio::test]
     async fn test_process_update_identity_data() {
-        let (mut chain_store, mut store, contact) = create_mocks();
+        let (mut chain_store, mut store, contact, company_invite) = create_mocks();
         let full = get_baseline_identity();
         let identity = full.identity.clone();
         let keys = full.key_pair.clone();
@@ -371,6 +424,7 @@ pub mod tests {
         let handler = IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
+            Arc::new(company_invite),
             Arc::new(contact),
             bitcoin::Network::Testnet,
         );
@@ -404,11 +458,13 @@ pub mod tests {
         MockIdentityChainStore,
         MockIdentityStore,
         MockNostrContactProcessorApi,
+        MockNotificationHandlerApi,
     ) {
         (
             MockIdentityChainStore::new(),
             MockIdentityStore::new(),
             MockNostrContactProcessorApi::new(),
+            MockNotificationHandlerApi::new(),
         )
     }
 }

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -32,6 +32,7 @@ pub use bill_invite_handler::BillInviteEventHandler;
 pub use company_chain_event_handler::CompanyChainEventHandler;
 pub use company_chain_event_processor::CompanyChainEventProcessor;
 pub use company_invite_handler::CompanyInviteEventHandler;
+pub use identity_chain_event_handler::IdentityChainEventHandler;
 pub use identity_chain_event_processor::IdentityChainEventProcessor;
 pub use nostr_contact_processor::NostrContactProcessor;
 pub use public_chain_helpers::{BlockData, EventContainer, resolve_event_chains};

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -1,10 +1,10 @@
 use crate::Result;
 use async_trait::async_trait;
-use bcr_ebill_api::service::notification_service::event::EventEnvelope;
+use bcr_ebill_api::{service::notification_service::event::EventEnvelope, util::BcrKeys};
 use bcr_ebill_core::{
     NodeId, ServiceTraitBounds,
     bill::{BillId, BillKeys},
-    blockchain::{bill::BillBlock, company::CompanyBlock},
+    blockchain::{bill::BillBlock, company::CompanyBlock, identity::IdentityBlock},
     company::CompanyKeys,
 };
 use log::trace;
@@ -20,6 +20,8 @@ mod bill_invite_handler;
 mod company_chain_event_handler;
 mod company_chain_event_processor;
 mod company_invite_handler;
+mod identity_chain_event_handler;
+mod identity_chain_event_processor;
 mod nostr_contact_processor;
 mod public_chain_helpers;
 
@@ -107,6 +109,32 @@ pub trait CompanyChainEventProcessorApi: ServiceTraitBounds {
 
 #[cfg(test)]
 impl ServiceTraitBounds for MockCompanyChainEventProcessorApi {}
+
+/// Generalizes the handling and validation of a bill block event.
+#[cfg_attr(test, automock)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait IdentityChainEventProcessorApi: ServiceTraitBounds {
+    /// Processes the chain data for given bill id, some blocks and an optional key that will be
+    /// present when we are joining a new chain.
+    async fn process_chain_data(
+        &self,
+        node_id: &NodeId,
+        blocks: Vec<IdentityBlock>,
+        keys: Option<BcrKeys>,
+    ) -> Result<()>;
+
+    /// Validates that a given bill id is relevant for us, and if so also checks that the sender
+    /// of the event is part of the chain this event is for.
+    async fn validate_chain_event_and_sender(
+        &self,
+        node_id: &NodeId,
+        sender: nostr::PublicKey,
+    ) -> Result<bool>;
+}
+
+#[cfg(test)]
+impl ServiceTraitBounds for MockIdentityChainEventProcessorApi {}
 
 /// Generalizes the handling of other Nostr identities.
 #[cfg_attr(test, automock)]
@@ -281,6 +309,7 @@ mod test_utils {
         NostrChainEventStoreApi, NotificationStoreApi, Result,
         bill::{BillChainStoreApi, BillStoreApi},
         company::{CompanyChainStoreApi, CompanyStoreApi},
+        identity::{IdentityChainStoreApi, IdentityStoreApi},
         nostr::NostrContactStoreApi,
         notification::NotificationFilter,
     };
@@ -402,6 +431,40 @@ mod test_utils {
             async fn set_trust_level(&self, node_id: &NodeId, trust_level: bcr_ebill_core::nostr_contact::TrustLevel) -> Result<()>;
             async fn get_npubs(&self, levels: Vec<bcr_ebill_core::nostr_contact::TrustLevel>) -> Result<Vec<NostrPublicKey>>;
 
+        }
+    }
+
+    mock! {
+        pub IdentityStore {}
+
+        impl ServiceTraitBounds for IdentityStore {}
+
+        #[async_trait]
+        impl IdentityStoreApi for IdentityStore {
+            async fn exists(&self) -> bool;
+            async fn save(&self, identity: &Identity) -> Result<()>;
+            async fn get(&self) -> Result<Identity>;
+            async fn get_full(&self) -> Result<IdentityWithAll>;
+            async fn save_key_pair(&self, key_pair: &BcrKeys, seed: &str) -> Result<()>;
+            async fn get_key_pair(&self) -> Result<BcrKeys>;
+            async fn get_or_create_key_pair(&self) -> Result<BcrKeys>;
+            async fn get_seedphrase(&self) -> Result<String>;
+            async fn get_current_identity(&self) -> Result<bcr_ebill_core::identity::ActiveIdentityState>;
+            async fn set_current_identity(&self, identity_state: &bcr_ebill_core::identity::ActiveIdentityState) -> Result<()>;
+            async fn set_or_check_network(&self, configured_network: bitcoin::Network) -> Result<()>;
+        }
+    }
+
+    mock! {
+        pub IdentityChainStore {}
+
+        impl ServiceTraitBounds for IdentityChainStore {}
+
+        #[async_trait]
+        impl IdentityChainStoreApi for IdentityChainStore {
+            async fn get_latest_block(&self) -> Result<bcr_ebill_core::blockchain::identity::IdentityBlock>;
+            async fn add_block(&self, block: &bcr_ebill_core::blockchain::identity::IdentityBlock) -> Result<()>;
+            async fn get_chain(&self) -> Result<bcr_ebill_core::blockchain::identity::IdentityBlockchain>;
         }
     }
 

--- a/crates/bcr-ebill-transport/src/lib.rs
+++ b/crates/bcr-ebill-transport/src/lib.rs
@@ -39,6 +39,7 @@ pub use async_broadcast::Receiver;
 pub use nostr::{NostrClient, NostrConsumer};
 use notification_service::NotificationService;
 pub use push_notification::{PushApi, PushService};
+pub use restore::RestoreAccountService;
 pub use transport::bcr_nostr_tag;
 
 /// Creates a new nostr client configured with the current identity user.

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -11,8 +11,9 @@ use bcr_ebill_core::{NodeId, blockchain::BlockchainType, contact::BillParticipan
 use log::{debug, error, info, trace, warn};
 use nostr::signer::NostrSigner;
 use nostr_sdk::{
-    Alphabet, Client, Event, EventBuilder, EventId, Filter, Kind, Metadata, Options, PublicKey,
-    RelayPoolNotification, RelayUrl, SingleLetterTag, TagKind, TagStandard, Timestamp, ToBech32,
+    Alphabet, Client, ClientOptions, Event, EventBuilder, EventId, Filter, Kind, Metadata,
+    PublicKey, RelayPoolNotification, RelayUrl, SingleLetterTag, TagKind, TagStandard, Timestamp,
+    ToBech32,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -73,7 +74,7 @@ impl NostrClient {
     /// Creates a new nostr client with the given config.
     pub async fn default(config: &NostrConfig) -> Result<Self> {
         let keys = config.keys.clone();
-        let options = Options::new();
+        let options = ClientOptions::new();
         let client = Client::builder()
             .signer(keys.get_nostr_keys().clone())
             .opts(options)

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -691,7 +691,7 @@ async fn handle_event(
     for handler in handlers.iter() {
         if handler.handles_event(event_type) {
             match handler
-                .handle_event(event.to_owned(), node_id, original_event.clone())
+                .handle_event(event.to_owned(), node_id, Some(original_event.clone()))
                 .await
             {
                 Ok(_) => times += 1,

--- a/crates/bcr-ebill-transport/src/restore/mod.rs
+++ b/crates/bcr-ebill-transport/src/restore/mod.rs
@@ -1,11 +1,83 @@
-use crate::Result;
 use async_trait::async_trait;
-use bcr_ebill_core::{ServiceTraitBounds, util::BcrKeys};
+use bcr_ebill_api::service::notification_service::{
+    Result, restore::RestoreAccountApi, transport::NotificationJsonTransportApi,
+};
+use bcr_ebill_core::{ServiceTraitBounds, blockchain::BlockchainType};
+use log::info;
+use nostr::{filter::Filter, types::Timestamp};
 
 #[allow(dead_code)]
+pub struct RestoreAccountService {
+    nostr: Box<dyn NotificationJsonTransportApi>,
+}
+
+#[allow(dead_code)]
+impl RestoreAccountService {
+    pub async fn new(nostr: Box<dyn NotificationJsonTransportApi>) -> Self {
+        Self { nostr }
+    }
+
+    async fn restore_primary_account(&self) -> Result<()> {
+        let blocks = self
+            .nostr
+            .resolve_public_chain(
+                &self.nostr.get_sender_node_id().to_string(),
+                BlockchainType::Identity,
+            )
+            .await?;
+        info!("found identity blocks {blocks :#?} blocks for primary account");
+
+        let dms = self
+            .nostr
+            .resolve_private_events(Filter::new().since(Timestamp::zero()))
+            .await?;
+        info!("found private dms {dms :#?} dms for primary account");
+        Ok(())
+    }
+}
+
+impl ServiceTraitBounds for RestoreAccountService {}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait RestoreAccountApi: ServiceTraitBounds {
-    /// Given a set of keys and relays, restores the account and all the associated data
-    fn restore_account(&self, keys: BcrKeys, relays: Vec<String>) -> Result<()>;
+impl RestoreAccountApi for RestoreAccountService {
+    async fn restore_account(&self) -> Result<()> {
+        info!("restoring primary account");
+        self.restore_primary_account().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::{MockNotificationJsonTransport, node_id_test};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_service() {
+        let mut nostr = MockNotificationJsonTransport::new();
+
+        nostr
+            .expect_get_sender_node_id()
+            .returning(node_id_test)
+            .once();
+
+        nostr
+            .expect_resolve_public_chain()
+            .returning(|_, _| Ok(vec![]))
+            .once();
+
+        nostr
+            .expect_resolve_private_events()
+            .returning(|_| Ok(vec![]))
+            .once();
+
+        let service = RestoreAccountService::new(Box::new(nostr)).await;
+
+        service
+            .restore_account()
+            .await
+            .expect("could not restore account");
+    }
 }

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -90,7 +90,7 @@ impl NotificationHandlerApi for TestEventHandler<TestEventPayload> {
         &self,
         event: EventEnvelope,
         _: &NodeId,
-        _: Box<nostr::Event>,
+        _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         *self.called.lock().await = true;
         let event: Event<TestEventPayload> = event.try_into()?;
@@ -430,7 +430,7 @@ mockall::mock! {
     impl ServiceTraitBounds for NotificationHandler {}
     #[async_trait]
     impl NotificationHandlerApi for NotificationHandler {
-        async fn handle_event(&self, event: EventEnvelope, identity: &NodeId, original_event: Box<nostr::Event>) -> Result<()>;
+        async fn handle_event(&self, event: EventEnvelope, identity: &NodeId, original_event: Option<Box<nostr::Event>>) -> Result<()>;
         fn handles_event(&self, event_type: &EventType) -> bool;
     }
 }

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -421,6 +421,7 @@ mockall::mock! {
         async fn resolve_contact(&self, node_id: &NodeId) -> Result<Option<NostrContactData>>;
         async fn resolve_public_chain(&self, id: &str, chain_type: BlockchainType) -> Result<Vec<nostr::event::Event>>;
         async fn add_contact_subscription(&self, contact: &NodeId) -> Result<()>;
+        async fn resolve_private_events(&self, filter: nostr::Filter) -> Result<Vec<nostr::event::Event>>;
     }
 }
 

--- a/crates/bcr-ebill-transport/src/transport.rs
+++ b/crates/bcr-ebill-transport/src/transport.rs
@@ -23,7 +23,7 @@ use nostr::{
 
 // A bit abitrary. This is to protect our client from beeing overwhelmed by spam. The downside is
 // that we will not be able to extract a chain even if there are valid blocks on the relay.
-const CHAIN_EVENT_LIMIT: usize = 1000;
+const CHAIN_EVENT_LIMIT: usize = 10000;
 
 pub async fn unwrap_direct_message<T: NostrSigner>(
     event: Box<Event>,

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -40,6 +40,14 @@
         <button type="button" id="switch_identity">Switch to identity</button>
     </div>
     <div>
+        <h2>Identity backup restore</h2>
+        <div></div><button type="button" id="get_seed_phrase">Backup Seed Phrase</button> Seed Phrase: <span id="current_seed"></span></div>
+        <div>
+          <input type="text" id="restore_seed_phrase"/>
+          <button type="button" id="restore_account">Restore Account</button>
+        </div>
+    </div>
+    <div>
         <h2>Company Testing</h2>
         <div>Company Id: <span id="companies"></span></div>
         <button type="button" id="company_create">Create Company</button>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -199,7 +199,7 @@ async function start(create_identity) {
   return { companyApi, generalApi, identityApi, billApi, contactApi, notificationApi };
 }
 
-let apis = await start(false);
+let apis = await start(generateIdentity());
 let contactApi = apis.contactApi;
 let companyApi = apis.companyApi;
 let generalApi = apis.generalApi;
@@ -652,3 +652,16 @@ async function getActiveNotif() {
   await measured();
 }
 
+// disables auto identity creation via query param identity=false
+function generateIdentity() {
+  let param = getQueryParam("identity");
+  if (param && param.toLowerCase() === "false") {
+    return false;
+  }
+  return true;
+}
+
+function getQueryParam(paramName) {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(paramName);
+}

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -48,6 +48,10 @@ document.getElementById("company_create").addEventListener("click", createCompan
 document.getElementById("company_update").addEventListener("click", updateCompany);
 document.getElementById("company_add_signatory").addEventListener("click", addSignatory);
 
+// restore account, backup seed phrase
+document.getElementById("get_seed_phrase").addEventListener("click", getSeedPhrase);
+document.getElementById("restore_account").addEventListener("click", restoreFromSeedPhrase);
+
 
 let config = {
   log_level: "debug",
@@ -217,6 +221,16 @@ async function uploadFile(event) {
   } catch (err) {
     console.log("upload error: ", err);
   }
+}
+
+async function getSeedPhrase() {
+  let seed_phrase = await identityApi.seed_backup();
+  document.getElementById("current_seed").innerHTML = seed_phrase.seed_phrase;
+}
+
+async function restoreFromSeedPhrase() {
+  let seed_phrase = document.getElementById("restore_seed_phrase").value;
+  await identityApi.seed_recover({ seed_phrase });
 }
 
 async function createCompany() {

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -71,7 +71,7 @@ let config = {
   default_mint_node_id: "bitcrt03cbb9254a24df6bad6243227cadf257c25eb10c2177c1ee85bfaefde3bf532ab6", // dev mint
 };
 
-async function start() {
+async function start(create_identity) {
   await wasm.default();
   await wasm.initialize_api(config);
 
@@ -83,92 +83,98 @@ async function start() {
   let generalApi = wasm.Api.general();
 
   let identity;
+  let current_identity;
   // Identity
   try {
     identity = await identityApi.detail();
     console.log("local identity:", identity);
   } catch (err) {
-    console.log("No local identity found - creating anon identity..");
-    await identityApi.create({
-      t: 1,
-      name: "Cypherpunk",
-      email: "cypher@example.com",
-      postal_address: {},
-    });
+    if (create_identity) {
 
-    identity = await identityApi.detail();
+      console.log("No local identity found - creating anon identity..");
+      await identityApi.create({
+        t: 1,
+        name: "Cypherpunk",
+        email: "cypher@example.com",
+        postal_address: {},
+      });
 
-    console.log("Deanonymizing identity..");
-    await identityApi.deanonymize({
-      t: 0,
-      name: "Johanna Smith",
-      email: "jsmith@example.com",
-      postal_address: {
-        country: "AT",
-        city: "Vienna",
-        zip: "1020",
-        address: "street 1",
-      }
-    });
+      identity = await identityApi.detail();
 
-    // add self to contacts
-    await contactApi.create({
-      t: 0,
-      node_id: identity.node_id,
-      name: "Self Contact",
-      email: "selfcont@example.com",
-      postal_address: {
-        country: "AT",
-        city: "Vienna",
-        zip: "1020",
-        address: "street 1",
-      },
-    });
+      console.log("Deanonymizing identity..");
+      await identityApi.deanonymize({
+        t: 0,
+        name: "Johanna Smith",
+        email: "jsmith@example.com",
+        postal_address: {
+          country: "AT",
+          city: "Vienna",
+          zip: "1020",
+          address: "street 1",
+        }
+      });
+
+      // add self to contacts
+      await contactApi.create({
+        t: 0,
+        node_id: identity.node_id,
+        name: "Self Contact",
+        email: "selfcont@example.com",
+        postal_address: {
+          country: "AT",
+          city: "Vienna",
+          zip: "1020",
+          address: "street 1",
+        },
+      });
+    }
   }
-  document.getElementById("identity").innerHTML = identity.node_id;
 
+  if (identity) {
+    document.getElementById("identity").innerHTML = identity.node_id;
 
-  await notificationApi.subscribe((evt) => {
-    console.log("Received event in JS: ", evt);
-  });
-
-  let current_identity = await identityApi.active();
-  console.log(current_identity);
-  document.getElementById("current_identity").innerHTML = current_identity.node_id;
-
-  // Company
-  let companies = await companyApi.list();
-  console.log("companies:", companies.companies.length, companies);
-  if (companies.companies.length == 0) {
-    let company = await companyApi.create({
-      name: "hayek Ltd",
-      email: "test@example.com",
-      postal_address: {
-        country: "AT",
-        city: "Vienna",
-        zip: "1020",
-        address: "street 1",
-      }
+    await notificationApi.subscribe((evt) => {
+      console.log("Received event in JS: ", evt);
     });
-    console.log("company: ", company);
-    await companyApi.edit({ id: company.id, email: "different@example.com", postal_address: {} });
-    let detail = await companyApi.detail(company.id);
-    console.log("company detail: ", detail);
-    // add company to contacts
-    await contactApi.create({
-      t: 1,
-      node_id: detail.id,
-      name: "Company Contact",
-      email: "comcont@example.com",
-      postal_address: {
-        country: "AT",
-        city: "Vienna",
-        zip: "1020",
-        address: "street 1",
-      },
-    });
-  } else {
-    document.getElementById("companies").innerHTML = "node_id: " + companies.companies[0].id;
+
+    current_identity = await identityApi.active();
+    console.log(current_identity);
+    document.getElementById("current_identity").innerHTML = current_identity.node_id;
+
+    // Company
+    let companies = await companyApi.list();
+    console.log("companies:", companies.companies.length, companies);
+    if (companies.companies.length == 0 && create_identity) {
+      let company = await companyApi.create({
+        name: "hayek Ltd",
+        email: "test@example.com",
+        postal_address: {
+          country: "AT",
+          city: "Vienna",
+          zip: "1020",
+          address: "street 1",
+        }
+      });
+      console.log("company: ", company);
+      await companyApi.edit({ id: company.id, email: "different@example.com", postal_address: {} });
+      let detail = await companyApi.detail(company.id);
+      console.log("company detail: ", detail);
+      // add company to contacts
+      await contactApi.create({
+        t: 1,
+        node_id: detail.id,
+        name: "Company Contact",
+        email: "comcont@example.com",
+        postal_address: {
+          country: "AT",
+          city: "Vienna",
+          zip: "1020",
+          address: "street 1",
+        },
+      });
+    } else if (companies.companies.length > 0) {
+      document.getElementById("companies").innerHTML = "node_id: " + companies.companies[0].id;
+    }
   }
 
   // General
@@ -178,17 +184,22 @@ async function start() {
   let status = await generalApi.status();
   console.log("status: ", status);
 
-  let search = await generalApi.search({ filter: { search_term: "Test", currency: "sat", item_types: ["Contact"] } });
-  console.log("search: ", search);
+  if (identity) {
+    let search = await generalApi.search({ filter: { search_term: "Test", currency: "sat", item_types: ["Contact"] } });
+    console.log("search: ", search);
+  }
 
   // Notifications
-  let filter = current_identity ? { node_ids: [current_identity.node_id] } : null;
-  let notifications = await notificationApi.list(filter);
-  console.log("notifications: ", notifications);
+  if (current_identity) {
+    let filter = current_identity ? { node_ids: [current_identity.node_id] } : null;
+    let notifications = await notificationApi.list(filter);
+    console.log("notifications: ", notifications);
+  }
+  console.log("Returning apis..");
   return { companyApi, generalApi, identityApi, billApi, contactApi, notificationApi };
 }
 
-let apis = await start();
+let apis = await start(false);
 let contactApi = apis.contactApi;
 let companyApi = apis.companyApi;
 let generalApi = apis.generalApi;
@@ -198,6 +209,8 @@ window.billApi = billApi;
 window.identityApi = identityApi;
 window.generalApi = generalApi;
 let notificationTriggerApi = apis.notificationApi;
+console.log("Apis initialized..");
+
 
 async function uploadFile(event) {
   const file = event.target.files[0];

--- a/crates/bcr-ebill-wasm/src/context.rs
+++ b/crates/bcr-ebill-wasm/src/context.rs
@@ -101,6 +101,7 @@ impl Context {
         let chain_key_service = Arc::new(ChainKeyService::new(
             db.bill_store.clone(),
             db.company_store.clone(),
+            db.identity_store.clone(),
         ));
 
         let nostr_consumer = create_nostr_consumer(


### PR DESCRIPTION
## 📝 Description

Restore personal identity and all companies. Also sync personal identity and company changes between two active accounts on different devices. Test env now allows to be started without identity.

Relates to #409 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Restore identity and companies into empty account

- **Other Changes:**
  - Allow booting test env without active account

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Launch normal account in test ui
2. Lauch test ui with query param ?identity=false in a private tab
3. Backup seed phrase in first test ui
4. Restore from seed phrase in private tab
5. Reload private tab a see that identity and companies from other account are present
6. Change company in restored account
7. See that changes are applied on original account

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #409

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
