### PR TITLE
Small fix in payment logic

### DIFF
--- a/crates/bcr-ebill-api/src/external/bitcoin.rs
+++ b/crates/bcr-ebill-api/src/external/bitcoin.rs
@@ -257,7 +257,9 @@ fn payment_state_from_transactions(
     for tx in txs.iter().rev() {
         for vout in tx.vout.iter() {
             // sum up outputs towards the address to check
-            if vout.scriptpubkey_address == *address {
+            if let Some(ref addr) = vout.scriptpubkey_address
+                && addr == address
+            {
                 total += vout.value;
             }
         }
@@ -349,7 +351,7 @@ pub struct Tx {
 #[derive(Deserialize, Debug, Clone)]
 pub struct Vout {
     pub value: u64,
-    pub scriptpubkey_address: String,
+    pub scriptpubkey_address: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -388,7 +390,7 @@ pub mod tests {
             },
             vout: vec![Vout {
                 value: 500,
-                scriptpubkey_address: test_addr.to_owned(),
+                scriptpubkey_address: Some(test_addr.to_owned()),
             }],
         };
 


### PR DESCRIPTION
## 📝 Description

While prepping for Demo and testing payment with the regtest setup locally, I noticed that the `scriptpubkey_address` field can be null in some edge cases (which isn't mentioned in the docs).

Plus, I added error logging for when the payment check fails.

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Test with regtest setup and strange transactions, payment should work and if not, it should be logged why

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
