### PR TITLE
Disable companies we are no longer singatory in

### DIFF
--- a/crates/bcr-ebill-api/src/service/company_service.rs
+++ b/crates/bcr-ebill-api/src/service/company_service.rs
@@ -340,6 +340,7 @@ impl CompanyServiceApi for CompanyService {
             proof_of_registration_file,
             logo_file,
             signatories: vec![full_identity.identity.node_id.clone()], // add caller as signatory
+            active: true,
         };
         self.store.insert(&company).await?;
 
@@ -935,6 +936,7 @@ pub mod tests {
                     proof_of_registration_file: None,
                     logo_file: None,
                     signatories: vec![node_id_test()],
+                    active: true,
                 },
                 CompanyKeys {
                     private_key: private_key_test(),

--- a/crates/bcr-ebill-core/src/blockchain/company/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/company/mod.rs
@@ -585,6 +585,7 @@ mod tests {
                     proof_of_registration_file: None,
                     logo_file: None,
                     signatories: vec![node_id_test()],
+                    active: true,
                 },
                 CompanyKeys {
                     private_key: private_key_test(),

--- a/crates/bcr-ebill-core/src/company.rs
+++ b/crates/bcr-ebill-core/src/company.rs
@@ -93,6 +93,9 @@ impl Company {
             CompanyBlockPayload::AddSignatory(payload) => {
                 if !self.signatories.contains(&payload.signatory) {
                     self.signatories.push(payload.signatory.to_owned());
+                    if &payload.signatory == our_node_id {
+                        self.active = true;
+                    }
                 }
             }
             CompanyBlockPayload::RemoveSignatory(payload) => {

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -36,6 +36,7 @@ fn network_char(network: &bitcoin::Network) -> char {
         bitcoin::Network::Testnet4 => NETWORK_TESTNET4,
         bitcoin::Network::Signet => unreachable!(),
         bitcoin::Network::Regtest => NETWORK_REGTEST,
+        _ => unreachable!(),
     }
 }
 

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -36,7 +36,6 @@ fn network_char(network: &bitcoin::Network) -> char {
         bitcoin::Network::Testnet4 => NETWORK_TESTNET4,
         bitcoin::Network::Signet => unreachable!(),
         bitcoin::Network::Regtest => NETWORK_REGTEST,
-        _ => unreachable!(),
     }
 }
 

--- a/crates/bcr-ebill-persistence/src/db/company.rs
+++ b/crates/bcr-ebill-persistence/src/db/company.rs
@@ -145,6 +145,13 @@ pub struct CompanyDb {
     pub proof_of_registration_file: Option<FileDb>,
     pub logo_file: Option<FileDb>,
     pub signatories: Vec<NodeId>,
+    #[serde(default = "active_default")]
+    pub active: bool,
+}
+
+// needed to migrate existing companies
+fn active_default() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -170,6 +177,7 @@ impl TryFrom<CompanyDb> for Company {
             proof_of_registration_file: value.proof_of_registration_file.map(|f| f.into()),
             logo_file: value.logo_file.map(|f| f.into()),
             signatories: value.signatories,
+            active: value.active,
         })
     }
 }
@@ -195,6 +203,7 @@ impl From<&Company> for CompanyDb {
                 .map(|f| (&f).into()),
             logo_file: value.logo_file.clone().map(|f| (&f).into()),
             signatories: value.signatories.clone(),
+            active: value.active,
         }
     }
 }
@@ -249,6 +258,7 @@ mod tests {
             proof_of_registration_file: None,
             logo_file: None,
             signatories: vec![node_id_test()],
+            active: true,
         }
     }
 

--- a/crates/bcr-ebill-persistence/src/db/company_chain.rs
+++ b/crates/bcr-ebill-persistence/src/db/company_chain.rs
@@ -283,6 +283,7 @@ mod tests {
                 proof_of_registration_file: None,
                 logo_file: None,
                 signatories: vec![node_id_test()],
+                active: true,
             }
             .into(),
             &BcrKeys::new(),
@@ -338,6 +339,7 @@ mod tests {
                 proof_of_registration_file: None,
                 logo_file: None,
                 signatories: vec![node_id_test()],
+                active: true,
             }
             .into(),
             &BcrKeys::new(),

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -711,6 +711,7 @@ mod test_utils {
                     proof_of_registration_file: None,
                     logo_file: None,
                     signatories: vec![node_id_test()],
+                    active: true,
                 },
                 CompanyKeys {
                     private_key: private_key_test(),

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -58,6 +58,7 @@
         <button type="button" id="company_update">Update Company name</button>
         <button type="button" id="company_add_signatory">Add Signatory</button>
         <button type="button" id="company_remove_signatory">Remove Signatory</button>
+        <button type="button" id="company_list">List Companies</button>
     </div>
     <div>
         <h2>Contact Testing</h2>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -49,6 +49,7 @@ document.getElementById("company_create").addEventListener("click", createCompan
 document.getElementById("company_update").addEventListener("click", updateCompany);
 document.getElementById("company_add_signatory").addEventListener("click", addSignatory);
 document.getElementById("company_remove_signatory").addEventListener("click", removeSignatory);
+document.getElementById("company_list").addEventListener("click", listCompanies);
 
 // restore account, backup seed phrase
 document.getElementById("get_seed_phrase").addEventListener("click", getSeedPhrase);
@@ -292,6 +293,11 @@ async function removeSignatory() {
     signatory_node_id: signatory_node_id,
   });
   console.log("removed signatory to company: ", signatory_node_id, company_id);
+}
+
+async function listCompanies() {
+  let companies = await companyApi.list();
+  console.log("companies:", companies.companies.length, companies);
 }
 
 async function triggerContact() {
@@ -667,7 +673,7 @@ async function getActiveNotif() {
 
 async function getNotifList() {
   let measured = measure(async () => {
-      return await notificationTriggerApi.list({});
+    return await notificationTriggerApi.list({});
   });
   await measured();
 }


### PR DESCRIPTION
## 📝 Description

Companies now have an active flag which is maintained via block processing (add/remove signatory). Company list queries and search will only return the active companies. Exists and direct id queries still give access to the underlying data.

Relates to #348 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Cascade remove signatory

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Add some identity to your company as a signatory
2. Remove the identity from the company
3. Other account should first list the company and after remove no longer show it
4. Re-adding the signatory will sync newer blocks and show the company again

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
