### PR TITLE
Use Proxy for Identity Proof URL Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.9
+
+* Identity Proof now requests URLs via nostr-relay HTTP proxy
+
 # 0.4.8
 
 * Fix reject block propagation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 license = "MIT"
 

--- a/crates/bcr-ebill-api/src/external/identity_proof.rs
+++ b/crates/bcr-ebill-api/src/external/identity_proof.rs
@@ -3,14 +3,19 @@ use bcr_ebill_core::{
     ServiceTraitBounds,
     identity_proof::{IdentityProofStamp, IdentityProofStatus},
 };
+use borsh_derive::BorshSerialize;
 use log::error;
+use nostr::hashes::Hash;
+use nostr::{hashes::sha256, nips::nip19::ToBech32};
+use secp256k1::{Keypair, Message, SECP256K1};
+use serde::Serialize;
 use thiserror::Error;
 use url::Url;
 
 #[cfg(test)]
 use mockall::automock;
 
-use crate::util;
+use crate::{external::file_storage::to_url, util};
 
 /// Generic result type
 pub type Result<T> = std::result::Result<T, super::Error>;
@@ -30,6 +35,12 @@ pub enum Error {
     /// all errors originating from interacting with base58
     #[error("External Identity Proof Validation error: {0}")]
     Validation(#[from] util::ValidationError),
+    /// all nostr key  errors
+    #[error("External Identity Proof Nostr Key Error")]
+    NostrKey,
+    /// all borsh errors
+    #[error("External Identity Proof Borsh Error")]
+    Borsh(#[from] borsh::io::Error),
 }
 
 #[cfg_attr(test, automock)]
@@ -37,9 +48,12 @@ pub enum Error {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait IdentityProofApi: ServiceTraitBounds {
     /// Checks if the given identity proof somewhere in the (successful) response of calling the given URL
+    /// The request is proxied through the given relay and signed by the caller's private key
     async fn check_url(
         &self,
+        relay_url: &str,
         identity_proof_stamp: &IdentityProofStamp,
+        private_key: &nostr::SecretKey,
         url: &Url,
     ) -> IdentityProofStatus;
 }
@@ -62,47 +76,63 @@ impl ServiceTraitBounds for IdentityProofClient {}
 #[cfg(test)]
 impl ServiceTraitBounds for MockIdentityProofApi {}
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProxyReq {
+    pub payload: ProxyReqPayload,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, BorshSerialize)]
+pub struct ProxyReqPayload {
+    pub npub: String,
+    pub url: String,
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl IdentityProofApi for IdentityProofClient {
     async fn check_url(
         &self,
+        relay_url: &str,
         identity_proof: &IdentityProofStamp,
+        private_key: &nostr::SecretKey,
         url: &Url,
     ) -> IdentityProofStatus {
-        // Make an unauthenticated request to the given URL and retrieve its body
-        match self.cl.get(url.to_owned()).send().await {
+        let (proxy_url, proxy_req) = match create_proxy_req(relay_url, private_key, url) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Error creating proxy request for {url}: {e}");
+                return IdentityProofStatus::FailureClient;
+            }
+        };
+        // Call the Nostr relay's proxy function with a signed payload
+        match self.cl.post(proxy_url).json(&proxy_req).send().await {
             Ok(res) => {
-                match res.error_for_status() {
-                    Ok(resp) => {
-                        match resp.text().await {
-                            Ok(body) => {
-                                // Check if the identity proof is contained in the response
-                                if identity_proof.is_contained_in(&body) {
-                                    IdentityProofStatus::Success
-                                } else {
-                                    IdentityProofStatus::NotFound
-                                }
-                            }
-                            Err(body_err) => {
-                                error!("Error checking url: {url} for identity proof: {body_err}");
-                                IdentityProofStatus::FailureClient
-                            }
+                let status = res.status();
+                match res.text().await {
+                    Ok(body) => {
+                        if status.is_client_error() {
+                            error!(
+                                "Error checking url: {url} for identity proof: {status}, {body}"
+                            );
+                            return IdentityProofStatus::FailureClient;
+                        } else if status.is_server_error() {
+                            error!(
+                                "Error checking url: {url} for identity proof: {status}, {body}"
+                            );
+                            return IdentityProofStatus::FailureServer;
+                        }
+
+                        // Check if the identity proof is contained in the response
+                        if identity_proof.is_contained_in(&body) {
+                            IdentityProofStatus::Success
+                        } else {
+                            IdentityProofStatus::NotFound
                         }
                     }
-                    Err(e) => {
-                        error!("Error checking url: {url} for identity proof: {e}");
-                        if let Some(status) = e.status() {
-                            if status.is_client_error() {
-                                IdentityProofStatus::FailureClient
-                            } else if status.is_server_error() {
-                                IdentityProofStatus::FailureServer
-                            } else {
-                                IdentityProofStatus::FailureConnect
-                            }
-                        } else {
-                            IdentityProofStatus::FailureConnect
-                        }
+                    Err(body_err) => {
+                        error!("Error checking url: {url} for identity proof: {body_err}");
+                        IdentityProofStatus::FailureClient
                     }
                 }
             }
@@ -114,13 +144,78 @@ impl IdentityProofApi for IdentityProofClient {
     }
 }
 
+// Returns the relay URL to call and the request
+fn create_proxy_req(
+    relay_url: &str,
+    private_key: &nostr::SecretKey,
+    url: &Url,
+) -> Result<(Url, ProxyReq)> {
+    let npub = nostr::Keys::new(private_key.clone())
+        .public_key()
+        .to_bech32()
+        .map_err(|_| Error::NostrKey)?;
+
+    let payload = ProxyReqPayload {
+        npub,
+        url: url.to_string(),
+    };
+    let key_pair = Keypair::from_secret_key(SECP256K1, private_key);
+    let serialized = borsh::to_vec(&payload).map_err(Error::Borsh)?;
+    let hash: sha256::Hash = sha256::Hash::hash(&serialized);
+    let msg = Message::from_digest(*hash.as_ref());
+
+    let signature = SECP256K1.sign_schnorr(&msg, &key_pair).to_string();
+    Ok((
+        to_url(relay_url, "proxy/v1/req")?,
+        ProxyReq { signature, payload },
+    ))
+}
+
 #[cfg(test)]
 pub mod tests {
     use std::str::FromStr;
 
-    use crate::tests::tests::node_id_test;
+    use bcr_ebill_core::util::BcrKeys;
+    use bitcoin::XOnlyPublicKey;
+    use nostr::key::SecretKey;
+    use secp256k1::schnorr::Signature;
+
+    use crate::tests::tests::{node_id_test, private_key_test};
 
     use super::*;
+    pub fn verify_request<Req>(req: &Req, signature: &str, key: &XOnlyPublicKey) -> bool
+    where
+        Req: borsh::BorshSerialize,
+    {
+        let serialized = borsh::to_vec(&req).unwrap();
+        let hash = sha256::Hash::hash(&serialized);
+        let msg = Message::from_digest(*hash.as_ref());
+        let decoded_signature = Signature::from_str(signature).unwrap();
+
+        SECP256K1
+            .verify_schnorr(&decoded_signature, &msg, key)
+            .is_ok()
+    }
+
+    #[test]
+    fn sig_req_proxy_test() {
+        let relay_url = "wss://bcr-relay-dev.minibill.tech";
+        let secret_key =
+            SecretKey::from_str("8863c82829480536893fc49c4b30e244f97261e989433373d73c648c1a656a79")
+                .unwrap();
+        let x_only_pub = secret_key.public_key(SECP256K1).x_only_public_key().0;
+        let (proxy_url, proxy_req) = create_proxy_req(relay_url, &secret_key, &Url::parse("https://primal.net/e/nevent1qqs24kk3m0rc8e7a6f8k8daddqes0a2n74jszdszppu84e6y5q8ss3cy2rxs4").unwrap()).expect("creating proxy req works");
+
+        assert_eq!(
+            proxy_url,
+            Url::parse("https://bcr-relay-dev.minibill.tech/proxy/v1/req").unwrap()
+        );
+        assert!(verify_request(
+            &proxy_req.payload,
+            &proxy_req.signature,
+            &x_only_pub
+        ));
+    }
 
     #[tokio::test]
     #[ignore]
@@ -128,6 +223,12 @@ pub mod tests {
     // networks interact with the check_url() call.
     async fn test_check_url() {
         let node_id = node_id_test();
+        let relay_url = "wss://bcr-relay-dev.minibill.tech";
+        let private_key = BcrKeys::from_private_key(&private_key_test())
+            .unwrap()
+            .get_nostr_keys()
+            .secret_key()
+            .to_owned();
 
         let identity_proof_client = IdentityProofClient::new();
 
@@ -137,19 +238,19 @@ pub mod tests {
 
         let valid_url = Url::parse("https://primal.net/e/nevent1qqs24kk3m0rc8e7a6f8k8daddqes0a2n74jszdszppu84e6y5q8ss3cy2rxs4").unwrap();
         let check_url_res = identity_proof_client
-            .check_url(&identity_proof, &valid_url)
+            .check_url(relay_url, &identity_proof, &private_key, &valid_url)
             .await;
         assert!(matches!(check_url_res, IdentityProofStatus::Success));
 
         let not_found_url = Url::parse("https://primal.net/e/nevent1qqsv64erdk323pkpuzqspyk3e842egaeuu8v6js970tvnyjlkjakzqc0whefs").unwrap();
         let check_url_res = identity_proof_client
-            .check_url(&identity_proof, &not_found_url)
+            .check_url(relay_url, &identity_proof, &private_key, &not_found_url)
             .await;
         assert!(matches!(check_url_res, IdentityProofStatus::NotFound));
 
         let invalid_url = Url::parse("https://www.bit.cr/does-not-exist-ever").unwrap();
         let check_url_res = identity_proof_client
-            .check_url(&identity_proof, &invalid_url)
+            .check_url(relay_url, &identity_proof, &private_key, &invalid_url)
             .await;
         assert!(matches!(check_url_res, IdentityProofStatus::FailureClient));
     }

--- a/crates/bcr-ebill-wasm/src/api/identity_proof.rs
+++ b/crates/bcr-ebill-wasm/src/api/identity_proof.rs
@@ -52,13 +52,18 @@ impl IdentityProof {
     /// Add identity proof for the currently selected identity
     #[wasm_bindgen(unchecked_return_type = "IdentityProofWeb")]
     pub async fn add(&self, url: &str, stamp: &str) -> Result<JsValue> {
-        let (signer_public_data, _) = get_signer_public_data_and_keys().await?;
+        let (signer_public_data, signer_keys) = get_signer_public_data_and_keys().await?;
         let parsed_url =
             Url::parse(url).map_err(|_| Error::Validation(ValidationError::InvalidUrl))?;
         let parsed_stamp = IdentityProofStamp::from_str(stamp)?;
         let identity_proof: IdentityProofWeb = get_ctx()
             .identity_proof_service
-            .add(&signer_public_data.node_id(), &parsed_url, &parsed_stamp)
+            .add(
+                &signer_public_data,
+                &signer_keys,
+                &parsed_url,
+                &parsed_stamp,
+            )
             .await?
             .into();
         let res = serde_wasm_bindgen::to_value(&identity_proof)?;
@@ -80,10 +85,10 @@ impl IdentityProof {
     /// returning the new result
     #[wasm_bindgen(unchecked_return_type = "IdentityProofWeb")]
     pub async fn re_check(&self, id: &str) -> Result<JsValue> {
-        let (signer_public_data, _) = get_signer_public_data_and_keys().await?;
+        let (signer_public_data, signer_keys) = get_signer_public_data_and_keys().await?;
         let identity_proof: IdentityProofWeb = get_ctx()
             .identity_proof_service
-            .re_check(&signer_public_data.node_id(), id)
+            .re_check(&signer_public_data, &signer_keys, id)
             .await?
             .into();
         let res = serde_wasm_bindgen::to_value(&identity_proof)?;


### PR DESCRIPTION
### **User description**
## 📝 Description

* URL-checks from identity proofs now go via the new HTTP proxy route on the default nostr relay to work around CORS issues in the browser/PWA.

Relates to #514 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. Create some identity proofs - the URL checks should work from the browser/PWA and go via the nostr relay

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #514 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Enhancement


___

### **Description**
- Route identity proof URL checks through nostr relay proxy

- Add cryptographic signing for proxy requests using Schnorr signatures

- Update service methods to require signer keys and participant data

- Implement CORS workaround for browser/PWA compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Identity Proof Check"] --> B["Create Signed Proxy Request"]
  B --> C["POST to Relay Proxy Endpoint"]
  C --> D["Relay Fetches URL"]
  D --> E["Return Response Body"]
  E --> F["Verify Identity Proof in Content"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>identity_proof.rs</strong><dd><code>Implement signed proxy requests for identity proof checks</code></dd></summary>
<hr>

crates/bcr-ebill-api/src/external/identity_proof.rs

<ul><li>Replace direct HTTP requests with signed proxy requests to nostr relay<br> <li> Add <code>ProxyReq</code> and <code>ProxyReqPayload</code> structures for request signing<br> <li> Implement Schnorr signature creation and verification for proxy <br>authentication<br> <li> Update <code>check_url</code> method to accept relay URL and private key parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/643/files#diff-3fe7d2e41b5bf18cba3d6b73b8ae56d4ea8b4a204ca270e1d669f77ea429601b">+135/-34</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity_proof_service.rs</strong><dd><code>Update service to use participant data and keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-api/src/service/identity_proof_service.rs

<ul><li>Update service methods to accept <code>BillParticipant</code> and <code>BcrKeys</code> instead <br>of just <code>NodeId</code><br> <li> Extract nostr relay URL from participant data for proxy requests<br> <li> Pass signer's private key to identity proof client for request signing<br> <li> Update all method signatures for <code>add</code> and <code>re_check</code> operations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/643/files#diff-0eda62458d664700b26289dd9e6ad3fc7ef435b2b8543592e4d1cb38339a0acc">+95/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity_proof.rs</strong><dd><code>Update WASM bindings for new service interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-wasm/src/api/identity_proof.rs

<ul><li>Update WASM API calls to pass both signer public data and keys<br> <li> Modify <code>add</code> and <code>re_check</code> methods to use new service signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/643/files#diff-90fa806151d07cb9e26f9e4058f25064dfab2aad4042e33c00baebd140a002f2">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document proxy feature in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add entry for version 0.4.8 documenting proxy functionality


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/643/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Version bump to 0.4.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Bump workspace version from 0.4.7 to 0.4.8


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/643/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

