### PR TITLE
Recourser can be Anon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `default_court_url` to config and add API to share a bill with a court
 * Add API to share company and identity details with an external party
 * Removed the concept of an `Authorized Signer`
+* Fix it so that Anon holders of a bill can do recourse (breaking DB and API change)
+    * `recourser` went from `BillIdentParticipant` to `BillParticipant`
 
 # 0.4.8
 

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -474,7 +474,7 @@ impl BillService {
                     }
 
                     let recourser = self
-                        .extend_bill_chain_identity_data_from_contacts_or_identity(
+                        .extend_bill_chain_participant_data_from_contacts_or_identity(
                             payment_info.recourser.clone(),
                             local_identity,
                             &contacts,
@@ -490,7 +490,7 @@ impl BillService {
 
                     let address_to_pay = self.bitcoin_client.get_address_to_pay(
                         &bill_keys.public_key,
-                        &payment_info.recourser.node_id.pub_key(),
+                        &payment_info.recourser.node_id().pub_key(),
                     )?;
 
                     let link_to_pay = self.bitcoin_client.generate_link_to_pay(
@@ -768,7 +768,7 @@ impl BillService {
             }
             Some(BillCurrentWaitingState::Recourse(state)) => {
                 state.recourser = self
-                    .extend_bill_chain_identity_data_from_contacts_or_identity(
+                    .extend_bill_chain_participant_data_from_contacts_or_identity(
                         state.recourser.clone().into(),
                         identity,
                         contacts,

--- a/crates/bcr-ebill-api/src/service/bill_service/payment.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/payment.rs
@@ -128,7 +128,7 @@ impl BillService {
             // calculate payment address
             let payment_address = self.bitcoin_client.get_address_to_pay(
                 &bill_keys.public_key,
-                &payment_info.recourser.node_id.pub_key(),
+                &payment_info.recourser.node_id().pub_key(),
             )?;
             // check if paid
             if let Ok(payment_state) = self
@@ -164,7 +164,7 @@ impl BillService {
                         "bill {bill_id} is recourse-paid - creating recourse block if we're recourser"
                     );
                     // If we are the recourser and a bill issuer and it's paid, we add a Recourse block
-                    if payment_info.recourser.node_id == identity.identity.node_id {
+                    if payment_info.recourser.node_id() == identity.identity.node_id {
                         if let Ok(signer_identity) =
                             BillIdentParticipant::new(identity.identity.clone())
                         {
@@ -207,7 +207,7 @@ impl BillService {
                         self.company_store.get_all().await?;
                     // If a local company is the recourser, create the recourse block as that company
                     if let Some(recourser_company) =
-                        local_companies.get(&payment_info.recourser.node_id)
+                        local_companies.get(&payment_info.recourser.node_id())
                         && recourser_company
                             .0
                             .signatories

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -1394,7 +1394,7 @@ impl BillServiceApi for BillService {
         for past_sell_payment in past_recourse_payments {
             let address_to_pay = self.bitcoin_client.get_address_to_pay(
                 &bill_keys.public_key,
-                &past_sell_payment.0.recourser.node_id.pub_key(),
+                &past_sell_payment.0.recourser.node_id().pub_key(),
             )?;
             let link_to_pay = self.bitcoin_client.generate_link_to_pay(
                 &address_to_pay,

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -331,14 +331,17 @@ pub fn request_to_recourse_block(
         id.to_owned(),
         first_block,
         &BillRequestRecourseBlockData {
-            recourser: bill_identified_participant_only_node_id(node_id_test()).into(),
+            recourser: BillParticipant::Ident(bill_identified_participant_only_node_id(
+                node_id_test(),
+            ))
+            .into(),
             recoursee: recoursee.to_owned().into(),
             sum: 15000,
             currency: "sat".to_string(),
             recourse_reason: BillRecourseReasonBlockData::Pay,
             signatory: None,
             signing_timestamp: timestamp,
-            signing_address: empty_address(),
+            signing_address: Some(empty_address()),
         },
         &BcrKeys::from_private_key(&private_key_test()).unwrap(),
         None,

--- a/crates/bcr-ebill-core/src/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/bill/mod.rs
@@ -260,7 +260,7 @@ pub struct BillWaitingForPaymentState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillWaitingForRecourseState {
-    pub recourser: BillIdentParticipant,
+    pub recourser: BillParticipant,
     pub recoursee: BillIdentParticipant,
     pub payment_data: BillWaitingStatePaymentData,
 }
@@ -598,7 +598,7 @@ pub struct PastPaymentDataPayment {
 #[derive(Debug, Clone)]
 pub struct PastPaymentDataRecourse {
     pub time_of_request: u64,
-    pub recourser: BillIdentParticipant,
+    pub recourser: BillParticipant,
     pub recoursee: BillIdentParticipant,
     pub currency: String,
     pub sum: String,

--- a/crates/bcr-ebill-core/src/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/bill/validation.rs
@@ -250,7 +250,7 @@ impl Validate for BillValidateActionData {
                     if payment_info.sum != *sum
                         || payment_info.currency != *currency
                         || payment_info.recoursee.node_id != recoursee.node_id
-                        || payment_info.recourser.node_id != self.signer_node_id
+                        || payment_info.recourser.node_id() != self.signer_node_id
                         || payment_info.reason != recourse_reason
                     {
                         return Err(ValidationError::BillRecourseDataInvalid);
@@ -767,14 +767,14 @@ mod tests {
             bill_id_test(),
             chain.get_latest_block(),
             &BillRequestRecourseBlockData {
-                recourser: valid_bill_identified_participant().into(),
+                recourser: BillParticipant::Ident(valid_bill_identified_participant()).into(),
                 recoursee: valid_other_bill_identified_participant().into(),
                 sum: 500,
                 currency: "sat".into(),
                 recourse_reason: BillRecourseReasonBlockData::Accept,
                 signatory: None,
                 signing_timestamp: chain.get_latest_block().timestamp + 1,
-                signing_address: valid_address(),
+                signing_address: Some(valid_address()),
             },
             &keys(),
             None,

--- a/crates/bcr-ebill-core/src/blockchain/bill/chain.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/chain.rs
@@ -514,7 +514,7 @@ impl BillBlockchain {
             let block_data_decrypted: BillRequestRecourseBlockData =
                 request_to_recourse_block.get_decrypted_block(bill_keys)?;
 
-            if *node_id != block_data_decrypted.recourser.node_id {
+            if *node_id != block_data_decrypted.recourser.node_id() {
                 // node id is not beneficiary - skip
                 continue;
             }

--- a/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/blockchain/bill/mod.rs
@@ -12,7 +12,7 @@ pub use chain::BillBlockchain;
 use crate::{
     PublicKey, SecretKey,
     bill::{BillId, BillKeys},
-    blockchain::Result,
+    blockchain::{Result, bill::block::BillParticipantBlockData},
     contact::BillParticipant,
     util::{self, BcrKeys},
 };
@@ -61,7 +61,7 @@ pub struct PaymentInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoursePaymentInfo {
-    pub recourser: BillIdentParticipantBlockData, // recourser has to be identified
+    pub recourser: BillParticipantBlockData, // recourser can be anon
     pub recoursee: BillIdentParticipantBlockData, // recoursee has to be identified
     pub sum: u64,
     pub currency: String,

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -539,7 +539,7 @@ impl From<&BillWaitingForPaymentState> for BillWaitingForPaymentStateDb {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillWaitingForRecourseStateDb {
-    pub recourser: BillIdentParticipantDb,
+    pub recourser: BillParticipantDb,
     pub recoursee: BillIdentParticipantDb,
     pub payment_data: BillWaitingStatePaymentDataDb,
 }
@@ -1861,7 +1861,9 @@ pub mod tests {
             bill_id_test(),
             &first_block,
             &BillRequestRecourseBlockData {
-                recourser: bill_identified_participant_only_node_id(node_id_test()).into(),
+                recourser: BillParticipantBlockData::Ident(
+                    bill_identified_participant_only_node_id(node_id_test()).into(),
+                ),
                 recoursee: bill_identified_participant_only_node_id(NodeId::new(
                     BcrKeys::new().pub_key(),
                     bitcoin::Network::Testnet,
@@ -1872,7 +1874,7 @@ pub mod tests {
                 recourse_reason: BillRecourseReasonBlockData::Pay,
                 signatory: None,
                 signing_timestamp: now,
-                signing_address: empty_address(),
+                signing_address: Some(empty_address()),
             },
             &BcrKeys::from_private_key(&private_key_test()).unwrap(),
             None,
@@ -1951,7 +1953,9 @@ pub mod tests {
             bill_id_test(),
             &first_block,
             &BillRequestRecourseBlockData {
-                recourser: bill_identified_participant_only_node_id(node_id_test()).into(),
+                recourser: BillParticipantBlockData::Ident(
+                    bill_identified_participant_only_node_id(node_id_test()).into(),
+                ),
                 recoursee: bill_identified_participant_only_node_id(NodeId::new(
                     BcrKeys::new().pub_key(),
                     bitcoin::Network::Testnet,
@@ -1962,7 +1966,7 @@ pub mod tests {
                 sum: 15000,
                 signatory: None,
                 signing_timestamp: now_minus_one_month,
-                signing_address: empty_address(),
+                signing_address: Some(empty_address()),
             },
             &BcrKeys::from_private_key(&private_key_test()).unwrap(),
             None,

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -114,7 +114,8 @@
             <button type="button" id="accept_bill">Accept</button>
             <button type="button" id="req_to_pay_bill">Request to Pay</button>
             <button type="button" id="offer_to_sell_bill">Offer To Sell</button>
-            <button type="button" id="req_to_recourse_bill">Request to Recourse</button>
+            <button type="button" id="req_to_recourse_bill">Request to Recourse (Accept)</button>
+            <button type="button" id="req_to_recourse_bill_payment">Request to Recourse (Payment)</button>
             <br />
             <button type="button" id="reject_accept">Reject Acceptance</button>
             <button type="button" id="reject_pay">Reject Payment</button>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -46,6 +46,7 @@ document.getElementById("accept_bill").addEventListener("click", acceptBill);
 document.getElementById("req_to_pay_bill").addEventListener("click", requestToPayBill);
 document.getElementById("offer_to_sell_bill").addEventListener("click", offerToSellBill);
 document.getElementById("req_to_recourse_bill").addEventListener("click", requestToRecourseBill);
+document.getElementById("req_to_recourse_bill_payment").addEventListener("click", requestToRecourseBillPayment);
 document.getElementById("reject_accept").addEventListener("click", rejectAcceptBill);
 document.getElementById("reject_pay").addEventListener("click", rejectPayBill);
 document.getElementById("reject_buying").addEventListener("click", rejectBuyingBill);
@@ -539,6 +540,15 @@ async function requestToRecourseBill() {
   let endorsee = document.getElementById("endorsee_id").value;
   let measured = measure(async () => {
     return await billApi.request_to_recourse_bill_acceptance({ bill_id, recoursee: endorsee });
+  });
+  await measured();
+}
+
+async function requestToRecourseBillPayment() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let endorsee = document.getElementById("endorsee_id").value;
+  let measured = measure(async () => {
+    return await billApi.request_to_recourse_bill_payment({ bill_id, recoursee: endorsee, currency: "sat", sum: "1500" });
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -379,7 +379,7 @@ impl From<PastPaymentDataPayment> for PastPaymentDataPaymentWeb {
 #[tsify(into_wasm_abi)]
 pub struct PastPaymentDataRecourseWeb {
     pub time_of_request: u64,
-    pub recourser: BillIdentParticipantWeb,
+    pub recourser: BillParticipantWeb,
     pub recoursee: BillIdentParticipantWeb,
     pub currency: String,
     pub sum: String,
@@ -521,7 +521,7 @@ impl From<BillWaitingForPaymentState> for BillWaitingForPaymentStateWeb {
 #[derive(Tsify, Debug, Serialize, Clone)]
 #[tsify(into_wasm_abi)]
 pub struct BillWaitingForRecourseStateWeb {
-    pub recourser: BillIdentParticipantWeb,
+    pub recourser: BillParticipantWeb,
     pub recoursee: BillIdentParticipantWeb,
     pub payment_data: BillWaitingStatePaymentDataWeb,
 }


### PR DESCRIPTION
## 📝 Description

* Anonymous holders can recourse now

Relates to #630 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. Create bills where the holder at the end is anon, make them recourseable and recourse them

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #630 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
