### PR TITLE
Recourse has to work with Recoursees that are not in the contact book

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold=14
+too-many-arguments-threshold=200

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -5617,7 +5617,7 @@ pub mod tests {
         ctx.bill_blockchain_store
             .expect_get_chain()
             .returning(move |_| {
-                let now = util::date::now().timestamp() as u64;
+                let now = util::date::now().timestamp() as u64 - 10; // to avoid race with called code
                 let mut chain = get_genesis_chain(Some(bill.clone()));
                 let req_to_recourse = BillBlock::create_block_for_request_recourse(
                     bill_id_test(),
@@ -5649,10 +5649,8 @@ pub mod tests {
             .expect_send_bill_recourse_paid_event()
             .returning(|_, _| Ok(()));
 
-        // TODO (future): this fixes the flakyness of the test, but we have to investigate why at some point
-        ctx.notification_service
-            .expect_send_identity_chain_events()
-            .returning(|_| Ok(()));
+        // Populate identity block
+        expect_populates_identity_block(&mut ctx);
 
         let service = get_service(ctx);
 

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -5649,8 +5649,10 @@ pub mod tests {
             .expect_send_bill_recourse_paid_event()
             .returning(|_, _| Ok(()));
 
-        // Populate identity block
-        expect_populates_identity_block(&mut ctx);
+        // TODO (future): this fixes the flakyness of the test, but we have to investigate why at some point
+        ctx.notification_service
+            .expect_send_identity_chain_events()
+            .returning(|_| Ok(()));
 
         let service = get_service(ctx);
 

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -54,6 +54,7 @@ use bcr_ebill_core::notification::ActionType;
 use bcr_ebill_core::util::currency;
 use bcr_ebill_core::{File, ServiceTraitBounds, Validate, ValidationError};
 use bcr_ebill_persistence::mint::MintStoreApi;
+use bcr_ebill_persistence::nostr::NostrContactStoreApi;
 use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -76,6 +77,7 @@ pub struct BillService {
     pub mint_store: Arc<dyn MintStoreApi>,
     pub mint_client: Arc<dyn MintClientApi>,
     pub court_client: Arc<dyn CourtClientApi>,
+    pub nostr_contact_store: Arc<dyn NostrContactStoreApi>,
 }
 impl ServiceTraitBounds for BillService {}
 
@@ -95,6 +97,7 @@ impl BillService {
         mint_store: Arc<dyn MintStoreApi>,
         mint_client: Arc<dyn MintClientApi>,
         court_client: Arc<dyn CourtClientApi>,
+        nostr_contact_store: Arc<dyn NostrContactStoreApi>,
     ) -> Self {
         Self {
             store,
@@ -111,6 +114,7 @@ impl BillService {
             mint_store,
             mint_client,
             court_client,
+            nostr_contact_store,
         }
     }
 
@@ -212,6 +216,10 @@ impl BillService {
                     } else {
                         (None, vec![])
                     }
+                } else if let Ok(Some(nostr_contact)) =
+                    self.nostr_contact_store.by_node_id(node_id).await
+                {
+                    (None, nostr_contact.relays)
                 } else {
                     (None, vec![])
                 }

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -11,10 +11,10 @@ use crate::{
         MockBillChainStoreApiMock, MockBillStoreApiMock, MockCompanyChainStoreApiMock,
         MockCompanyStoreApiMock, MockContactStoreApiMock, MockFileUploadStoreApiMock,
         MockIdentityChainStoreApiMock, MockIdentityStoreApiMock, MockMintStore,
-        VALID_PAYMENT_ADDRESS_TESTNET, bill_id_test, bill_identified_participant_only_node_id,
-        bill_participant_only_node_id, empty_address, empty_bill_identified_participant,
-        empty_bitcredit_bill, empty_identity, init_test_cfg, node_id_test, node_id_test_other,
-        node_id_test_other2, private_key_test,
+        MockNostrContactStore, VALID_PAYMENT_ADDRESS_TESTNET, bill_id_test,
+        bill_identified_participant_only_node_id, bill_participant_only_node_id, empty_address,
+        empty_bill_identified_participant, empty_bitcredit_bill, empty_identity, init_test_cfg,
+        node_id_test, node_id_test_other, node_id_test_other2, private_key_test,
     },
     util,
 };
@@ -58,6 +58,7 @@ pub struct MockBillContext {
     pub mint_store: MockMintStore,
     pub mint_client: MockMintClientApi,
     pub court_client: MockCourtClientApi,
+    pub nostr_contact_store: MockNostrContactStore,
 }
 
 pub fn get_baseline_identity() -> IdentityWithAll {
@@ -206,6 +207,9 @@ pub fn get_service(mut ctx: MockBillContext) -> BillService {
             )
         });
     bitcoin_client.expect_generate_link_to_pay().returning(|_,_,_| String::from("bitcoin:1Jfn2nZcJ4T7bhE8FdMRz8T3P3YV4LsWn2?amount=0.01&message=Payment in relation to bill some bill"));
+    ctx.nostr_contact_store
+        .expect_by_node_id()
+        .returning(|_| Ok(None));
     ctx.contact_store.expect_get().returning(|node_id| {
         let mut contact = get_baseline_contact();
         contact.node_id = node_id.to_owned();
@@ -300,6 +304,7 @@ pub fn get_service(mut ctx: MockBillContext) -> BillService {
         Arc::new(ctx.mint_store),
         Arc::new(ctx.mint_client),
         Arc::new(ctx.court_client),
+        Arc::new(ctx.nostr_contact_store),
     )
 }
 
@@ -318,6 +323,7 @@ pub fn get_ctx() -> MockBillContext {
         mint_store: MockMintStore::new(),
         mint_client: MockMintClientApi::new(),
         court_client: MockCourtClientApi::new(),
+        nostr_contact_store: MockNostrContactStore::new(),
     }
 }
 

--- a/crates/bcr-ebill-core/src/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/bill/mod.rs
@@ -422,7 +422,7 @@ pub enum BillsFilterRole {
 
 #[derive(Clone, Debug)]
 pub struct PastEndorsee {
-    pub pay_to_the_order_of: LightBillIdentParticipant,
+    pub pay_to_the_order_of: BillIdentParticipant,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
     pub signing_address: Option<PostalAddress>,

--- a/crates/bcr-ebill-wasm/src/context.rs
+++ b/crates/bcr-ebill-wasm/src/context.rs
@@ -86,6 +86,7 @@ impl Context {
             db.mint_store.clone(),
             mint_client,
             court_client,
+            db.nostr_contact_store.clone(),
         ));
 
         let identity_service = IdentityService::new(

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -894,6 +894,16 @@ impl From<LightBillIdentParticipant> for LightBillIdentParticipantWeb {
     }
 }
 
+impl From<BillIdentParticipant> for LightBillIdentParticipantWeb {
+    fn from(val: BillIdentParticipant) -> Self {
+        LightBillIdentParticipantWeb {
+            t: val.t.into(),
+            name: val.name,
+            node_id: val.node_id,
+        }
+    }
+}
+
 #[derive(Tsify, Debug, Clone, Deserialize)]
 #[tsify(from_wasm_abi)]
 pub struct ShareBillWithCourtPayload {


### PR DESCRIPTION
### **User description**
## 📝 Description

* Recoursees don't have to be in the contact book anymore
* Disable useless number-of-arguments clippy rule
* Fix flaky test (the issue was with two `now` calls and a non-failing call on the function under test

Relates to #422 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. do recourse against a recoursee that's not in the contact book - it needs to work

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #422 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Enhancement


___

### **Description**
- Enable recourse functionality for recoursees not in contact book

- Add NostrContactStore integration to BillService

- Update recourse validation to use past endorsees

- Fix type conversion for PastEndorsee structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NostrContactStore"] --> B["BillService"]
  B --> C["Recourse Request"]
  C --> D["Past Endorsees Validation"]
  D --> E["Nostr Contact Lookup"]
  E --> F["Recourse Execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.rs</strong><dd><code>Add NostrContactStore integration to BillService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-api/src/service/bill_service/service.rs

<ul><li>Add <code>NostrContactStoreApi</code> dependency to BillService<br> <li> Update constructor to accept nostr contact store parameter<br> <li> Integrate nostr contact lookup in notification logic</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-0f8be59aa77d801377c9444e9dde7f12cb28c51f3633221d9af168a148d1cb20">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bill.rs</strong><dd><code>Update recourse request validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-wasm/src/api/bill.rs

<ul><li>Replace contact service lookup with nostr contact lookup<br> <li> Add past endorsees validation for recoursee verification<br> <li> Update public data creation using past endorsees and nostr contacts</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-d835c8a130eb5a342fa96ad7286fe1db5d45d3529134fd456826070cf39ff226">+24/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bill.rs</strong><dd><code>Add type conversion for BillIdentParticipant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-wasm/src/data/bill.rs

<ul><li>Add From trait implementation for BillIdentParticipant to <br>LightBillIdentParticipantWeb conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-153b142d936b823b4d34484d619f8f89dddc46279063f9c2ceb20bce2d5c0fc0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_utils.rs</strong><dd><code>Update test utilities for NostrContactStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-api/src/service/bill_service/test_utils.rs

<ul><li>Add MockNostrContactStore to test context<br> <li> Update service constructor calls with nostr contact store<br> <li> Configure mock expectations for nostr contact lookups</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-e42588ae9356552a47933a4f68b1838e6acef2ecc2b6684b3b554c97777424b4">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update test mock expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-api/src/service/bill_service/mod.rs

<ul><li>Replace identity block population expectation with identity chain <br>events expectation in test</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-a521209a8e2658a63c386b488777762373cedca3fb0a3001892aa2fc0f8c8a31">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Fix PastEndorsee participant type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-core/src/bill/mod.rs

<ul><li>Change PastEndorsee field type from LightBillIdentParticipant to <br>BillIdentParticipant</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-6cbb416d7b1076fc9289cdab3728adb2e9e7c7d3e67bff7e0f8aa53e44ae9457">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context.rs</strong><dd><code>Update context with NostrContactStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-wasm/src/context.rs

<ul><li>Update BillService constructor call to include nostr_contact_store <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-4aab47a7683b01dc13d3bd22573728e6f581df241ee8a3e6eb19d12521bd635f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clippy.toml</strong><dd><code>Increase clippy arguments threshold</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clippy.toml

- Increase too-many-arguments-threshold from 14 to 200


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/672/files#diff-f3dbfb2563c3490394f44c26b51837018e79a79e75fd31e89b19e943a38317ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

