### PR TITLE
Fix publish contact in async Nostr init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.4.11
 
 * Fix a bug where it was possible to reject recourse, even though it was already rejected
+* Fixed an issue where it could happen that identity and company contacts weren't propagated to Nostr, leading to block propagation inconsistencies
 
 # 0.4.10
 


### PR DESCRIPTION
### **User description**
## 📝 Description

* If the identity and company creation happens before the Nostr transport is connected (mostly only possible in the test harness), the Nostr Metadata wasn't published for these identities and contacts
* This lead to NostrContacts not being able to be created, which in turn could lead to block propagation issues, since we subscribe to Nostr contacts of bill participants to get bill updates
* This fix makes sure, on startup, that if there is no metadata published, we publish it once for each company and personal identity

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. nostr contacts are initialized and nostr contacts are created on bill propagation

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Bug fix


___

### **Description**
- Ensure Nostr metadata is published for identities and companies on startup

- Fix contact propagation issues when identity/company creation precedes Nostr connection

- Add `publish_contact` methods to identity and company service APIs

- Verify and publish missing metadata after Nostr transport connection established


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Startup"] --> B["Connect to Nostr"]
  B --> C["Check Identity Metadata"]
  C --> D{"Metadata Exists?"}
  D -- "No" --> E["Publish Identity Contact"]
  D -- "Yes" --> F["Check Companies"]
  E --> F
  F --> G{"For Each Company"}
  G --> H{"Metadata Exists?"}
  H -- "No" --> I["Publish Company Contact"]
  H -- "Yes" --> J["Continue"]
  I --> J
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>company_service.rs</strong><dd><code>Extract company contact publishing into dedicated API method</code></dd></summary>
<hr>

crates/bcr-ebill-api/src/service/company_service.rs

<ul><li>Added <code>publish_contact</code> method to <code>CompanyServiceApi</code> trait<br> <li> Extracted contact publishing logic into reusable <code>publish_contact</code> <br>method<br> <li> Refactored <code>on_company_contact_change</code> to call new <code>publish_contact</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/686/files#diff-82623d6c0c34558ad98aa31a2678068b0e3dcdc939ce669b1b2c56d158054768">+17/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity_service.rs</strong><dd><code>Extract identity contact publishing into dedicated API method</code></dd></summary>
<hr>

crates/bcr-ebill-api/src/service/identity_service.rs

<ul><li>Added <code>publish_contact</code> method to <code>IdentityServiceApi</code> trait<br> <li> Extracted contact publishing logic into reusable <code>publish_contact</code> <br>method<br> <li> Refactored <code>on_identity_contact_change</code> to call new <code>publish_contact</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/686/files#diff-7c5d736ff3951f5cf6bb117b708df266f6897995da9999fca1cd944f02e7aece">+16/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Ensure Nostr metadata published on initialization for all entities</code></dd></summary>
<hr>

crates/bcr-ebill-wasm/src/lib.rs

<ul><li>Added Nostr connection and metadata verification on startup<br> <li> Check and publish missing identity metadata after transport connection<br> <li> Check and publish missing company metadata for all active companies<br> <li> Added warning logs for metadata resolution and publishing failures</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/686/files#diff-78b085a893e1faee301d123867503a432b3a173b3a527612442ed79927ceb308">+48/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document fix for Nostr contact propagation issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Added entry for version 0.4.11 documenting the bug fix


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/686/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

