### PR TITLE
Fix reject recourse validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.4.11
 
+* Fix a bug where it was possible to reject recourse, even though it was already rejected
+
 # 0.4.10
 
 * Recoursee in a request to recourse does not have to be in the contact book anymore

--- a/crates/bcr-ebill-core/src/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/bill/validation.rs
@@ -375,7 +375,11 @@ impl Validate for BillValidateActionData {
                 self.bill_waiting_for_offer_to_sell()?;
                 // not waiting for req to pay
                 self.bill_waiting_for_req_to_pay()?;
-                // if the op was already rejected, can't reject again - checked above
+                // if the op was already rejected, can't reject again
+                if BillOpCode::RejectToPayRecourse == *self.blockchain.get_latest_block().op_code()
+                {
+                    return Err(ValidationError::RequestAlreadyRejected);
+                }
                 // there has to be a request to recourse that is not expired
                 if let RecourseWaitingForPayment::Yes(payment_info) = self
                     .blockchain


### PR DESCRIPTION
### **User description**
## 📝 Description

* Fixes an issue where it was possible to reject recourse several times, even though it was already rejected (this was introduced, because in a previous version of the validation rules, rejecting a recourse blocked the whole bill, which is no longer the case)

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. recourse a bill, reject it - it shouldn't be able to reject again

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Bug fix


___

### **Description**
- Added validation to prevent rejecting recourse multiple times

- Checks if latest block operation is already a recourse rejection

- Updated changelog to document the bug fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RejectPaymentForRecourse action"] --> B["Check latest block op_code"]
  B --> C{"Is RejectToPayRecourse?"}
  C -- "Yes" --> D["Return RequestAlreadyRejected error"]
  C -- "No" --> E["Continue validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validation.rs</strong><dd><code>Add duplicate recourse rejection validation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-core/src/bill/validation.rs

<ul><li>Added explicit check for duplicate recourse rejection<br> <li> Validates if latest blockchain block is already <code>RejectToPayRecourse</code><br> <li> Returns <code>RequestAlreadyRejected</code> error when rejection already exists</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/687/files#diff-aa872d5828caf12fbe2935a587bdf21e98fb0e4d224eb901150bd3d6111e5ae4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document recourse rejection bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Added entry for version 0.4.11 documenting the bug fix


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/687/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

