### PR TITLE
Fix Harness and connect new Company Transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix a bug where it was possible to reject recourse, even though it was already rejected
 * Fixed an issue where it could happen that identity and company contacts weren't propagated to Nostr, leading to block propagation inconsistencies
+* Fail with an error, if we have to connect to Nostr, but the client is not connected
 
 # 0.4.10
 

--- a/crates/bcr-ebill-transport/src/notification_service.rs
+++ b/crates/bcr-ebill-transport/src/notification_service.rs
@@ -193,7 +193,8 @@ impl NotificationService {
         );
 
         if let Ok(client) = NostrClient::new(&nostr_config).await {
-            debug!("added nostr client for {}", &nostr_config.get_npub());
+            debug!("adding nostr client for {}", &nostr_config.get_npub());
+            client.connect().await?;
             transports.insert(node_id, Arc::new(client));
         }
         Ok(())

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -96,9 +96,9 @@ let config = {
   // nostr_relays: ["ws://localhost:8080"],
   // if set to true we will drop DMs from nostr that we don't have in contacts
   nostr_only_known_contacts: false,
-  job_runner_initial_delay_seconds: 1,
+  job_runner_initial_delay_seconds: 5,
   job_runner_check_interval_seconds: 600,
-  transport_initial_subscription_delay_seconds: 2,
+  transport_initial_subscription_delay_seconds: 1,
   // default_mint_url: "http://localhost:4343",
   default_mint_url: "https://wildcat-dev-docker.minibill.tech",
   // default_mint_node_id: "bitcrt038d1bd3e2e3a01f20c861f18eb456cc33f869c9aaa5dec685f7f7d8c40ea3b3c7",
@@ -129,6 +129,7 @@ async function start(create_identity) {
     console.log("local identity:", identity);
   } catch (err) {
     if (create_identity) {
+      await sleep(2000); // sleep to let Nostr connect before first setup
       console.log("No local identity found - creating anon identity..");
       await identityApi.create({
         t: 1,
@@ -894,3 +895,6 @@ function getDeadlineDate() {
   return nDaysLater.toISOString().split('T')[0]
 }
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
### **User description**
## 📝 Description

* Added a delay to our test harness, because otherwise it attempts to create identity/company before Nostr is loaded
* Fixed an issue, where creating new companies failed, because we didn't `.connect()` their newly created Nostr transports

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Bug fix


___

### **Description**
- Added connection call for newly created Nostr transports in companies

- Increased test harness initial delay to allow Nostr initialization

- Added 2-second sleep before identity creation in test setup

- Adjusted transport subscription delay timing configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Harness"] -- "delay 2s" --> B["Identity Creation"]
  C["Company Creation"] -- "connect()" --> D["Nostr Transport"]
  E["Job Runner"] -- "delay 5s" --> F["Initialization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notification_service.rs</strong><dd><code>Connect Nostr client after creation for companies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-transport/src/notification_service.rs

<ul><li>Added <code>connect()</code> call after creating new <code>NostrClient</code> instance<br> <li> Ensures Nostr transport is connected before being added to transports <br>map</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/689/files#diff-3d0a1f93baac17cad711250480de3ed125953511c77cb770e2b5ba81274e18f1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Adjust timing delays and add sleep utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-ebill-wasm/main.js

<ul><li>Increased <code>job_runner_initial_delay_seconds</code> from 1 to 5 seconds<br> <li> Decreased <code>transport_initial_subscription_delay_seconds</code> from 2 to 1 <br>second<br> <li> Added 2-second sleep before identity creation in <code>start()</code> function<br> <li> Added new <code>sleep()</code> utility function for async delays</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/689/files#diff-5449a9dc93fe2b9863a8982603f38309c34386d64c218f0b42e699bd01c16320">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Nostr connection error handling fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting error handling for unconnected Nostr clients</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Bitcredit-Core/pull/689/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

