### PR TITLE
Fix URL ts types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added `actions` to `BitcreditBillResult`, with `bill_actions`, that are calculated based on which bill actions the caller is currently allowed to do (breaking DB and API change)
 * Fix an edge case for request to recourse if the payer == holder - they should not have past endorsees and if the payer is a contingent holder, they should not show up in past endorsees
+* Fix TS types for urls
 
 # 0.4.11
 

--- a/crates/bcr-ebill-core/src/lib.rs
+++ b/crates/bcr-ebill-core/src/lib.rs
@@ -170,8 +170,8 @@ pub enum GeneralSearchFilterItemType {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct File {
     pub name: String,
-    pub hash: String,
-    pub nostr_hash: String,
+    pub hash: String,       // the hash over the unencrypted file
+    pub nostr_hash: String, // the identification hash on Nostr for the encrypted file
 }
 
 #[derive(Debug)]

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -915,6 +915,7 @@ pub struct BillAnonParticipantWeb {
     pub node_id: NodeId,
     #[tsify(type = "string | undefined")]
     pub email: Option<Email>,
+    #[tsify(type = "string[]")]
     pub nostr_relays: Vec<url::Url>,
 }
 
@@ -939,6 +940,7 @@ pub struct BillIdentParticipantWeb {
     pub postal_address: PostalAddressWeb,
     #[tsify(type = "string | undefined")]
     pub email: Option<Email>,
+    #[tsify(type = "string[]")]
     pub nostr_relays: Vec<url::Url>,
 }
 

--- a/crates/bcr-ebill-wasm/src/data/contact.rs
+++ b/crates/bcr-ebill-wasm/src/data/contact.rs
@@ -128,6 +128,7 @@ pub struct ContactWeb {
     pub identification_number: Option<Identification>,
     pub avatar_file: Option<FileWeb>,
     pub proof_document_file: Option<FileWeb>,
+    #[tsify(type = "string[]")]
     pub nostr_relays: Vec<url::Url>,
     pub is_logical: bool,
 }

--- a/crates/bcr-ebill-wasm/src/data/identity.rs
+++ b/crates/bcr-ebill-wasm/src/data/identity.rs
@@ -139,6 +139,7 @@ pub struct IdentityWeb {
     pub identification_number: Option<Identification>,
     pub profile_picture_file: Option<FileWeb>,
     pub identity_document_file: Option<FileWeb>,
+    #[tsify(type = "string[]")]
     pub nostr_relays: Vec<url::Url>,
 }
 


### PR DESCRIPTION
## 📝 Description

* Just fix TS types for `Vec<Url>` to be `Vec<String>`
* Add an explanation comment to the `File` hashes
