### PR TITLE
Fix recover from seed because of unconnected nostr client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added `actions` to `BitcreditBillResult`, with `bill_actions`, that are calculated based on which bill actions the caller is currently allowed to do (breaking DB and API change)
 * Fix an edge case for request to recourse if the payer == holder - they should not have past endorsees and if the payer is a contingent holder, they should not show up in past endorsees
 * Fix TS types for urls
+* Fix `restore from seed` where the Nostr client wasn't connected properly
 
 # 0.4.11
 

--- a/crates/bcr-ebill-transport/src/lib.rs
+++ b/crates/bcr-ebill-transport/src/lib.rs
@@ -296,6 +296,7 @@ pub async fn create_restore_account_service(
     );
 
     let nostr_client = Arc::new(NostrClient::default(&nostr_config).await?);
+    nostr_client.connect().await?;
     let nostr_contact_processor = Arc::new(NostrContactProcessor::new(
         nostr_client.clone(),
         db_context.nostr_contact_store.clone(),


### PR DESCRIPTION
## 📝 Description

* Nostr client didn't call `connect` in the RestoreAccount path, which lead to seed recovery to fail
* @tompro I checked and didn't find any other places where this could be an issue. In the future, this should be fixed by our "retry"-logic when a request to Nostr is made before it's connected :+1: 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. test seed recovery

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
