### PR TITLE
Fixes spam filter on NIP17 sender check

### DIFF
--- a/crates/bcr-ebill-transport/src/handler/bill_action_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_action_event_handler.rs
@@ -131,7 +131,8 @@ impl NotificationHandlerApi for BillActionEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
-        evt: Option<Box<nostr::Event>>,
+        sender: Option<nostr::PublicKey>,
+        _evt: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming bill chain event for {node_id} in action event handler");
         if let Ok(decoded) = Event::<BillChainEventPayload>::try_from(event.clone()) {
@@ -139,10 +140,9 @@ impl NotificationHandlerApi for BillActionEventHandler {
                 .create_notification(
                     &decoded.data,
                     node_id,
-                    evt.ok_or(Error::Network(
+                    sender.ok_or(Error::Network(
                         "No original event for notification handler".to_string(),
-                    ))?
-                    .pubkey,
+                    ))?,
                 )
                 .await
             {
@@ -246,6 +246,7 @@ mod tests {
             .handle_event(
                 event.try_into().expect("Envelope from event"),
                 &node_id_test(),
+                Some(get_test_nostr_event().pubkey),
                 Some(Box::new(get_test_nostr_event())),
             )
             .await
@@ -284,6 +285,7 @@ mod tests {
             .handle_event(
                 event.try_into().expect("Envelope from event"),
                 &node_id_test(),
+                Some(get_test_nostr_event().pubkey),
                 Some(Box::new(get_test_nostr_event())),
             )
             .await
@@ -339,6 +341,7 @@ mod tests {
             .handle_event(
                 event.try_into().expect("Envelope from event"),
                 &node_id_test(),
+                Some(get_test_nostr_event().pubkey),
                 Some(Box::new(get_test_nostr_event())),
             )
             .await

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -53,6 +53,7 @@ impl NotificationHandlerApi for BillChainEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         original_event: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming bill chain event for {node_id} in chain event handler");
@@ -237,6 +238,7 @@ mod tests {
             .handle_event(
                 event.try_into().expect("Envelope from event"),
                 &node_id_test(),
+                None,
                 Some(Box::new(nostr_event)),
             )
             .await
@@ -310,6 +312,7 @@ mod tests {
             .handle_event(
                 event.try_into().expect("Envelope from event"),
                 &node_id_test(),
+                None,
                 Some(Box::new(get_test_nostr_event())),
             )
             .await

--- a/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
@@ -39,6 +39,7 @@ impl NotificationHandlerApi for BillInviteEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming bill chain invite for {node_id}");
@@ -255,7 +256,7 @@ mod tests {
 
         let handler = BillInviteEventHandler::new(Arc::new(processor), Arc::new(chain_event_store));
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -306,7 +307,7 @@ mod tests {
 
         let handler = BillInviteEventHandler::new(Arc::new(processor), Arc::new(chain_event_store));
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -365,7 +366,7 @@ mod tests {
 
         let handler = BillInviteEventHandler::new(Arc::new(processor), Arc::new(chain_event_store));
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
@@ -33,6 +33,7 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         original_event: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming company chain event for {node_id}");
@@ -198,7 +199,12 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id, Some(original_event))
+            .handle_event(
+                event.try_into().unwrap(),
+                &node_id,
+                None,
+                Some(original_event),
+            )
             .await
             .expect("failed to handle event");
     }
@@ -248,7 +254,12 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id, Some(original_event))
+            .handle_event(
+                event.try_into().unwrap(),
+                &node_id,
+                None,
+                Some(original_event),
+            )
             .await
             .expect("failed to handle event");
     }

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
@@ -364,7 +364,12 @@ impl CompanyChainEventProcessor {
                         // the bills.
                         if let Err(e) = self
                             .bill_invite_handler
-                            .handle_event(Event::new_bill(invite).try_into()?, &company.id, None)
+                            .handle_event(
+                                Event::new_bill(invite).try_into()?,
+                                &company.id,
+                                None,
+                                None,
+                            )
                             .await
                         {
                             error!(

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -42,6 +42,7 @@ impl NotificationHandlerApi for CompanyInviteEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming company chain invite for {node_id}");
@@ -273,7 +274,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -322,7 +323,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }
@@ -379,7 +380,7 @@ mod tests {
             Arc::new(chain_event_store),
         );
         handler
-            .handle_event(invite, &node_id, Some(Box::new(event.clone())))
+            .handle_event(invite, &node_id, None, Some(Box::new(event.clone())))
             .await
             .expect("failed to process chain invite event");
     }

--- a/crates/bcr-ebill-transport/src/handler/contact_share_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/contact_share_handler.rs
@@ -40,6 +40,7 @@ impl NotificationHandlerApi for ContactShareEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming contact share for {node_id}");
@@ -171,7 +172,7 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id_test(), None)
+            .handle_event(event.try_into().unwrap(), &node_id_test(), None, None)
             .await
             .expect("Event successfully handled");
     }

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
@@ -33,6 +33,7 @@ impl NotificationHandlerApi for IdentityChainEventHandler {
         &self,
         event: EventEnvelope,
         node_id: &NodeId,
+        _sender: Option<nostr::PublicKey>,
         original_event: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         debug!("incoming identity chain event for {node_id}");
@@ -195,6 +196,7 @@ mod tests {
             .handle_event(
                 event.try_into().unwrap(),
                 &identity.node_id,
+                None,
                 Some(original_event),
             )
             .await
@@ -249,7 +251,12 @@ mod tests {
         );
 
         handler
-            .handle_event(event.try_into().unwrap(), &node_id, Some(original_event))
+            .handle_event(
+                event.try_into().unwrap(),
+                &node_id,
+                None,
+                Some(original_event),
+            )
             .await
             .expect("failed to handle event");
     }

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
@@ -274,7 +274,7 @@ impl IdentityChainEventProcessor {
                     );
                     let event = Event::new_company_invite(invite);
                     self.company_invite_handler
-                        .handle_event(event.try_into()?, node_id, None)
+                        .handle_event(event.try_into()?, node_id, None, None)
                         .await?;
                 }
                 IdentityBlockPayload::SignPersonalBill(payload) => {
@@ -292,7 +292,7 @@ impl IdentityChainEventProcessor {
                             BcrKeys::from_private_key(&bill_keys.get_private_key()),
                         );
                         self.bill_invite_handler
-                            .handle_event(Event::new_bill(invite).try_into()?, node_id, None)
+                            .handle_event(Event::new_bill(invite).try_into()?, node_id, None, None)
                             .await?;
                     }
                 }

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -62,6 +62,7 @@ pub trait NotificationHandlerApi: ServiceTraitBounds {
         &self,
         event: bcr_ebill_core::protocol::event::EventEnvelope,
         node_id: &NodeId,
+        sender: Option<nostr::PublicKey>,
         original_event: Option<Box<nostr::Event>>,
     ) -> Result<()>;
 }
@@ -204,6 +205,7 @@ impl NotificationHandlerApi for LoggingEventHandler {
         &self,
         event: EventEnvelope,
         identity: &NodeId,
+        _: Option<nostr::PublicKey>,
         _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         trace!("Received event: {event:?} for identity: {identity}");
@@ -247,6 +249,7 @@ mod tests {
                     "bitcrt02295fb5f4eeb2f21e01eaf3a2d9a3be10f39db870d28f02146130317973a40ac0",
                 )
                 .unwrap(),
+                None,
                 Some(nostr_event),
             )
             .await
@@ -302,6 +305,7 @@ mod tests {
             &self,
             event: EventEnvelope,
             _: &NodeId,
+            _: Option<nostr::PublicKey>,
             _: Option<Box<nostr::Event>>,
         ) -> Result<()> {
             *self.called.lock().await = true;

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -173,6 +173,7 @@ impl NotificationHandlerApi for TestEventHandler<TestEventPayload> {
         &self,
         event: EventEnvelope,
         _: &NodeId,
+        _: Option<nostr::PublicKey>,
         _: Option<Box<nostr::Event>>,
     ) -> Result<()> {
         *self.called.lock().await = true;
@@ -561,7 +562,7 @@ mockall::mock! {
     impl ServiceTraitBounds for NotificationHandler {}
     #[async_trait]
     impl NotificationHandlerApi for NotificationHandler {
-        async fn handle_event(&self, event: EventEnvelope, identity: &NodeId, original_event: Option<Box<nostr::Event>>) -> Result<()>;
+        async fn handle_event(&self, event: EventEnvelope, identity: &NodeId, sender: Option<nostr::PublicKey>, original_event: Option<Box<nostr::Event>>) -> Result<()>;
         fn handles_event(&self, event_type: &EventType) -> bool;
     }
 }


### PR DESCRIPTION
## 📝 Description

Spam filter prevented all action notifications when using NIP-17 transport for DMs. This PR fixes the issue and ensures that the spam filter works with both NIP-04 and NIP-17. All message handlers have direct access to the original sender public key from now on.

Relates to #735 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **Bug Fixes:**
  - Fix spam filter for action notifications

---


## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
