### PR TITLE
Fix waiting for minting status enabled and recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0-2 (Hotfix)
+
+* Wait for Minting Status to be enabled before attempting to Mint
+    * Don't fail on setting recovery data again
+
 # 0.5.0-1 (Hotfix)
 
 * Fix validation for deleting the last signatory of a company

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.0-1"
+version = "0.5.0-2"
 edition = "2024"
 license = "MIT"
 
@@ -20,6 +20,11 @@ codegen-units = 1 # Reduces binary size at the cost of compile time
 
 [profile.dev]
 opt-level = 1 # Avoid surrealdb index out of bounds issue in dev build
+
+
+# Temporary fix, overriding this in surrealdb, because there's a break in 7.2.0 with the errno crate
+[patch.crates-io]
+async-graphql = { git = "https://github.com/async-graphql/async-graphql", rev = "dba4342a1d6c644e1bb69db46eb98fe64f88665d" } # 7.0.17
 
 [workspace.dependencies]
 sha2 = { version = "0.10", default-features = false }
@@ -62,7 +67,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", tag = "v0.6.0" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "f44d20494c060fdb7c5f763a699cbb16b3ac785b" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-persistence/Cargo.toml
+++ b/crates/bcr-ebill-persistence/Cargo.toml
@@ -35,5 +35,5 @@ surrealdb = { workspace = true, default-features = false, features = ["kv-indxdb
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 surrealdb = { workspace = true, default-features = false, features = ["protocol-ws"] }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 surrealdb = { workspace = true, default-features = false, features = ["kv-mem"] }

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -115,10 +115,10 @@ let config = {
   job_runner_initial_delay_seconds: 5,
   job_runner_check_interval_seconds: 600,
   transport_initial_subscription_delay_seconds: 1,
-  default_mint_url: "http://localhost:4343",
-  // default_mint_url: "https://wildcat-dev-docker.minibill.tech",
-  default_mint_node_id: "bitcrt02c18f94838c95754478c14a7c90db417d7a1dd0099add2002b31b4513480b3e99",
-  // default_mint_node_id: "bitcrt02a2e6ecd9dfee6f88e6a0eb8ebdcfa4dae9905158889586fc18bbcccbd9fac5e7", // dev mint
+  // default_mint_url: "http://localhost:4343",
+  default_mint_url: "https://wildcat-dev-docker.minibill.tech",
+  // default_mint_node_id: "bitcrt02c18f94838c95754478c14a7c90db417d7a1dd0099add2002b31b4513480b3e99",
+  default_mint_node_id: "bitcrt02a2e6ecd9dfee6f88e6a0eb8ebdcfa4dae9905158889586fc18bbcccbd9fac5e7", // dev mint
   num_confirmations_for_payment: 1,
   dev_mode: true,
   disable_mandatory_email_confirmations: true,
@@ -218,7 +218,7 @@ async function start(create_identity) {
 
   // Notifications
   if (current_identity) {
-    let filter = current_identity ? { node_ids: [current_identity.node_id] } : null;
+    let filter = { node_ids: [current_identity.node_id] };
     let notifications = success_or_fail(await window.notifApi.list(filter));
     console.log("notifications: ", notifications);
   }


### PR DESCRIPTION
## 📝 Description

(Still have to test a full minting flow before merging - which currently fails on Wildcat side.)

* Update bcr-common to a version where we have the minting status that's still compatible
* Wait for Minting Status to be enabled before attempting to Mint
    * Don't fail on setting recovery data again
* Also, had to pin async-graphql to a specific version, because it's not pinned in surrealdb and auto-updating leads to a compile error with the `errno` package.
* Also only use dev deps for non-wasm builds

Relates to #797 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Test minting flow, before and after enable_minting in dashboard

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #797

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
