### PR TITLE
Prevent event overflooding after id create

### DIFF
--- a/crates/bcr-ebill-transport/src/handler/direct_message_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/direct_message_event_processor.rs
@@ -53,6 +53,7 @@ impl DirectMessageEventProcessorApi for DirectMessageEventProcessor {
             &local_node_ids,
             &self.contact_service,
             &self.offset_store,
+            None,
         )
         .await
         {


### PR DESCRIPTION
## 📝 Description

I found the reason for having a lot of unrelated bill block messages right after account creation. This stems from a default contact (the wildcat) that is subscribed automatically. There is a second issue with the Nostr subscriptions not precisely cutting off from the last offset (since date) so I added an in app filter before event processing to skip older messages. I can not say 100% whether this improves account creation but at least most of those wildcat events will no longer be processed and should not add load on the database.

Relates to and closes #808

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Additional timestamp filter before processing events

- **Bug Fixes:**
  - Improved Nostr init performance

- **Refactoring:**
  - Having a fresh account starts subscription at now instead of 0

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
