### PR TITLE
bcr-common #42 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Add Esplora URL fallback support with automatic retry on errors
 * Serialize `Sum` amounts as strings to prevent precision loss in JavaScript (breaking change for UI)
 * Remove `numbers_to_words` endpoint
+* Upgrade to newest bcr_common with breaking changes for minting endpoints
+    * Add `MintingEnabled` state to `MintRequestStatusWeb` and `QuoteStatusReply` (breaking DB and API change)
 
 # 0.5.0-2 (Hotfix)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", tag = "v0.7.0" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "6b904cca832f00df5997a9d1e241b5139c2859b5" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-api/src/external/mint.rs
+++ b/crates/bcr-ebill-api/src/external/mint.rs
@@ -5,7 +5,7 @@ use bcr_common::cashu::{self, ProofsMethods, State, nut01 as cdk01, nut02 as cdk
 use bcr_common::client::keys::Client as KeysClient;
 use bcr_common::client::quote::Client as QuoteClient;
 use bcr_common::client::swap::Client as SwapClient;
-use bcr_common::wire::quotes::{MintingStatus, ResolveOffer, StatusReply};
+use bcr_common::wire::quotes::{ResolveOffer, StatusReply};
 use bcr_ebill_core::protocol::Sum;
 use bcr_ebill_core::{
     application::ServiceTraitBounds, protocol::DateTimeUtc, protocol::SecretKey,
@@ -414,7 +414,10 @@ pub enum QuoteStatusReply {
     },
     Accepted {
         keyset_id: cdk02::Id,
-        minting_status: QuoteMintingStatus,
+    },
+    MintingEnabled {
+        keyset_id: cdk02::Id,
+        minted_amount: cashu::Amount,
     },
     Rejected {
         tstamp: DateTimeUtc,
@@ -425,21 +428,6 @@ pub enum QuoteStatusReply {
     Expired {
         tstamp: DateTimeUtc,
     },
-}
-
-#[derive(Debug, Clone)]
-pub enum QuoteMintingStatus {
-    Disabled,
-    Enabled { minted: cashu::Amount },
-}
-
-impl From<MintingStatus> for QuoteMintingStatus {
-    fn from(value: MintingStatus) -> Self {
-        match value {
-            MintingStatus::Disabled => QuoteMintingStatus::Disabled,
-            MintingStatus::Enabled { minted } => QuoteMintingStatus::Enabled { minted },
-        }
-    }
 }
 
 impl From<StatusReply> for QuoteStatusReply {
@@ -457,17 +445,18 @@ impl From<StatusReply> for QuoteStatusReply {
                 expiration_date,
                 discounted,
             },
-            StatusReply::Accepted {
-                keyset_id,
-                minting_status,
-                ..
-            } => QuoteStatusReply::Accepted {
-                keyset_id,
-                minting_status: minting_status.into(),
-            },
+            StatusReply::Accepted { keyset_id, .. } => QuoteStatusReply::Accepted { keyset_id },
             StatusReply::Rejected { tstamp, .. } => QuoteStatusReply::Rejected { tstamp },
             StatusReply::Canceled { tstamp } => QuoteStatusReply::Cancelled { tstamp },
             StatusReply::OfferExpired { tstamp, .. } => QuoteStatusReply::Expired { tstamp },
+            StatusReply::MintingEnabled {
+                keyset_id,
+                minted_amount,
+                ..
+            } => QuoteStatusReply::MintingEnabled {
+                keyset_id,
+                minted_amount,
+            },
         }
     }
 }

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -4,9 +4,7 @@ use crate::external;
 use crate::external::bitcoin::BitcoinClientApi;
 use crate::external::court::CourtClientApi;
 use crate::external::file_storage::{self, FileStorageClientApi};
-use crate::external::mint::{
-    MintClientApi, QuoteMintingStatus, QuoteStatusReply, ResolveMintOffer,
-};
+use crate::external::mint::{MintClientApi, QuoteStatusReply, ResolveMintOffer};
 use crate::get_config;
 use crate::service::file_upload_service::UploadFileType;
 use crate::service::transport_service::TransportServiceApi;
@@ -363,8 +361,8 @@ impl BillService {
         }
 
         match mint_request.status {
-            // If it's accepted, get the offer and, if it's not finished (i.e. has no proofs), attempt to get keyset and mint
-            MintRequestStatus::Accepted => {
+            // If it's minting enabled, get the offer and, if it's not finished (i.e. has no proofs), attempt to get keyset and mint
+            MintRequestStatus::MintingEnabled => {
                 if let Ok(Some(offer)) = self
                     .mint_store
                     .get_offer(&mint_request.mint_request_id)
@@ -386,13 +384,7 @@ impl BillService {
                             )
                             .await?;
 
-                        if matches!(
-                            updated_status,
-                            QuoteStatusReply::Accepted {
-                                minting_status: QuoteMintingStatus::Disabled,
-                                ..
-                            }
-                        ) {
+                        if matches!(updated_status, QuoteStatusReply::Accepted { .. }) {
                             info!(
                                 "Quote {} is accepted, but minting not enabled - skipping",
                                 mint_request.mint_request_id
@@ -538,7 +530,9 @@ impl BillService {
                     }
                 }
             }
-            MintRequestStatus::Pending | MintRequestStatus::Offered => {
+            MintRequestStatus::Pending
+            | MintRequestStatus::Offered
+            | MintRequestStatus::Accepted => {
                 let updated_status = self
                     .mint_client
                     .lookup_quote_for_mint(
@@ -549,14 +543,14 @@ impl BillService {
                 // only update, if changed
                 match updated_status {
                     QuoteStatusReply::Pending => {
-                        // it's already pending, or offered and can't go from Offered to Pending - nothing to do
+                        // it's already pending, or offered, or accepted and can't go from Accepted to Offered to Pending - nothing to do
                     }
                     QuoteStatusReply::Offered {
                         keyset_id,
                         expiration_date,
                         discounted,
                     } => {
-                        // if it's not already offered, set to offered
+                        // if it's not already offered, set to offered and store the offer
                         if !matches!(mint_request.status, MintRequestStatus::Offered) {
                             // Update the request
                             self.mint_store
@@ -572,6 +566,18 @@ impl BillService {
                                     &keyset_id.to_string(),
                                     Timestamp::from(expiration_date),
                                     discounted.into(),
+                                )
+                                .await?;
+                        }
+                    }
+                    QuoteStatusReply::Accepted { .. } => {
+                        // if it's not already accepted, set to accepted
+                        if !matches!(mint_request.status, MintRequestStatus::Accepted) {
+                            // Update the request
+                            self.mint_store
+                                .update_request(
+                                    &mint_request.mint_request_id,
+                                    &MintRequestStatus::Accepted,
                                 )
                                 .await?;
                         }
@@ -620,12 +626,12 @@ impl BillService {
                             )
                             .await?;
                     }
-                    QuoteStatusReply::Accepted { .. } => {
-                        // checked above, that it's not accepted
+                    QuoteStatusReply::MintingEnabled { .. } => {
+                        // checked above, that it's not minting enabled
                         self.mint_store
                             .update_request(
                                 &mint_request.mint_request_id,
-                                &MintRequestStatus::Accepted,
+                                &MintRequestStatus::MintingEnabled,
                             )
                             .await?;
                     }

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    external::mint::{QuoteMintingStatus, QuoteStatusReply},
+    external::mint::QuoteStatusReply,
     service::{
         bill_service::test_utils::{MockBillContext, safe_deadline_ts},
         company_service::tests::{
@@ -6732,9 +6732,6 @@ async fn check_mint_state_pending_accepted() {
         .returning(|_, _| {
             Ok(QuoteStatusReply::Accepted {
                 keyset_id: cdk02::Id::try_from("00c7b45973e5f0fc".to_owned()).unwrap(),
-                minting_status: QuoteMintingStatus::Enabled {
-                    minted: bcr_common::cashu::Amount::from(1500),
-                },
             })
         });
     let req_node_id = identity.identity.node_id.clone();
@@ -6804,7 +6801,44 @@ async fn check_mint_state_pending_offered() {
 }
 
 #[tokio::test]
-async fn check_mint_state_accepted_proofs() {
+async fn check_mint_state_offered_accepted() {
+    init_test_cfg();
+    let mut ctx = get_ctx();
+    let identity = get_baseline_identity();
+
+    ctx.mint_client
+        .expect_lookup_quote_for_mint()
+        .returning(|_, _| {
+            Ok(QuoteStatusReply::Accepted {
+                keyset_id: cdk02::Id::try_from("00c7b45973e5f0fc".to_owned()).unwrap(),
+            })
+        });
+    let req_node_id = identity.identity.node_id.clone();
+    ctx.mint_store
+        .expect_get_requests_for_bill()
+        .returning(move |_, _| {
+            Ok(vec![MintRequest {
+                requester_node_id: req_node_id.clone(),
+                bill_id: bill_id_test(),
+                mint_node_id: node_id_test(),
+                mint_request_id: get_uuid_v4(),
+                timestamp: test_ts(),
+                status: MintRequestStatus::Offered,
+            }])
+        });
+    ctx.mint_store
+        .expect_update_request()
+        .returning(|_, _| Ok(()));
+
+    let service = get_service(ctx);
+    let res = service
+        .check_mint_state(&bill_id_test(), &identity.identity.node_id)
+        .await;
+    assert!(res.is_ok());
+}
+
+#[tokio::test]
+async fn check_mint_state_minting_enabled_proofs() {
     init_test_cfg();
     let mut ctx = get_ctx();
     let identity = get_baseline_identity();
@@ -6824,10 +6858,8 @@ async fn check_mint_state_accepted_proofs() {
     ctx.mint_client
         .expect_lookup_quote_for_mint()
         .returning(|_, _| {
-            Ok(QuoteStatusReply::Accepted {
-                minting_status: QuoteMintingStatus::Enabled {
-                    minted: bcr_common::cashu::Amount::ZERO,
-                },
+            Ok(QuoteStatusReply::MintingEnabled {
+                minted_amount: bcr_common::cashu::Amount::ZERO,
                 keyset_id: cdk02::Id::try_from("00c7b45973e5f0fc".to_owned()).unwrap(),
             })
         });
@@ -6846,7 +6878,7 @@ async fn check_mint_state_accepted_proofs() {
                 mint_node_id: node_id_test(),
                 mint_request_id: get_uuid_v4(),
                 timestamp: test_ts(),
-                status: MintRequestStatus::Accepted,
+                status: MintRequestStatus::MintingEnabled,
             }])
         });
     ctx.mint_store.expect_get_offer().returning(|_| {
@@ -6869,7 +6901,7 @@ async fn check_mint_state_accepted_proofs() {
 }
 
 #[tokio::test]
-async fn check_mint_state_accepted_check_spent() {
+async fn check_mint_state_minting_enabled_check_spent() {
     init_test_cfg();
     let mut ctx = get_ctx();
     let identity = get_baseline_identity();
@@ -6898,7 +6930,7 @@ async fn check_mint_state_accepted_check_spent() {
                 mint_node_id: node_id_test(),
                 mint_request_id: get_uuid_v4(),
                 timestamp: test_ts(),
-                status: MintRequestStatus::Accepted,
+                status: MintRequestStatus::MintingEnabled,
             }])
         });
     ctx.mint_store.expect_get_offer().returning(|_| {

--- a/crates/bcr-ebill-core/src/protocol/mint/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/mint/mod.rs
@@ -29,6 +29,8 @@ pub enum MintRequestStatus {
     Offered,
     /// Offer was accepted
     Accepted,
+    /// Offer was enabled to mint
+    MintingEnabled,
     /// The offer was rejected by the requester
     Rejected { timestamp: Timestamp },
     /// The request was cancelled by the requester

--- a/crates/bcr-ebill-persistence/src/db/mint.rs
+++ b/crates/bcr-ebill-persistence/src/db/mint.rs
@@ -363,6 +363,7 @@ pub enum MintRequestStatusDb {
     Denied { timestamp: Timestamp },
     Offered,
     Accepted,
+    MintingEnabled,
     Rejected { timestamp: Timestamp },
     Cancelled { timestamp: Timestamp },
     Expired { timestamp: Timestamp },
@@ -375,6 +376,7 @@ impl From<MintRequestStatusDb> for MintRequestStatus {
             MintRequestStatusDb::Denied { timestamp } => MintRequestStatus::Denied { timestamp },
             MintRequestStatusDb::Offered => MintRequestStatus::Offered,
             MintRequestStatusDb::Accepted => MintRequestStatus::Accepted,
+            MintRequestStatusDb::MintingEnabled => MintRequestStatus::MintingEnabled,
             MintRequestStatusDb::Rejected { timestamp } => {
                 MintRequestStatus::Rejected { timestamp }
             }
@@ -393,6 +395,7 @@ impl From<MintRequestStatus> for MintRequestStatusDb {
             MintRequestStatus::Denied { timestamp } => MintRequestStatusDb::Denied { timestamp },
             MintRequestStatus::Offered => MintRequestStatusDb::Offered,
             MintRequestStatus::Accepted => MintRequestStatusDb::Accepted,
+            MintRequestStatus::MintingEnabled => MintRequestStatusDb::MintingEnabled,
             MintRequestStatus::Rejected { timestamp } => {
                 MintRequestStatusDb::Rejected { timestamp }
             }

--- a/crates/bcr-ebill-wasm/src/data/mint.rs
+++ b/crates/bcr-ebill-wasm/src/data/mint.rs
@@ -43,6 +43,7 @@ pub enum MintRequestStatusWeb {
     Denied { timestamp: u64 },
     Offered,
     Accepted,
+    MintingEnabled,
     Rejected { timestamp: u64 },
     Cancelled { timestamp: u64 },
     Expired { timestamp: u64 },
@@ -56,6 +57,7 @@ impl From<MintRequestStatus> for MintRequestStatusWeb {
             },
             MintRequestStatus::Offered => MintRequestStatusWeb::Offered,
             MintRequestStatus::Accepted => MintRequestStatusWeb::Accepted,
+            MintRequestStatus::MintingEnabled => MintRequestStatusWeb::MintingEnabled,
             MintRequestStatus::Rejected { timestamp } => MintRequestStatusWeb::Rejected {
                 timestamp: timestamp.inner(),
             },


### PR DESCRIPTION
Adaptations to the bcr-common changes in https://github.com/BitcreditProtocol/bcr-common/pull/42, adding the MintingEnabled state and only minting, once it's in that state.

@codingpeanut157 From E-Bill perspective, https://github.com/BitcreditProtocol/bcr-common/pull/42 can be merged :+1: then I'll adapt the bcr-common rev/version, merge this and do a release