### PR TITLE
Fix signing address and signatory for anon signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.4
+
+* If the bill holder is anon, the `signing_address` needs to not be set
+* If the bill holder is anon and a company, the `signatory` shouldn't have a `name` set (breaking DB and bill block change)
+
 # 0.5.3
 
 * Fix minting URL and use new bcr-common

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/BitcreditProtocol/Bitcredit-Core"

--- a/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
@@ -12,7 +12,7 @@ use bcr_ebill_core::{
                     BillOfferToSellBlockData, BillRecourseBlockData, BillRecourseReasonBlockData,
                     BillRejectBlockData, BillRejectToBuyBlockData, BillRequestRecourseBlockData,
                     BillRequestToAcceptBlockData, BillRequestToPayBlockData, BillSellBlockData,
-                    ContactType,
+                    BillSignatoryBlockData, ContactType,
                 },
                 participant::BillParticipant,
             },
@@ -109,9 +109,16 @@ impl BillService {
                     } else {
                         signer_public_data.clone().into()
                     },
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -141,9 +148,16 @@ impl BillService {
                         signer_public_data.clone().into()
                     },
                     currency: currency.to_owned(),
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -188,9 +202,16 @@ impl BillService {
                     recoursee: recoursee.clone().into(),
                     sum,
                     recourse_reason: reason,
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -227,9 +248,16 @@ impl BillService {
                     recoursee: recoursee.clone().into(),
                     sum: sum.clone(),
                     recourse_reason: reason,
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -260,9 +288,16 @@ impl BillService {
                     },
                     endorsee: mint.clone().into(),
                     sum: sum.clone(),
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -298,9 +333,16 @@ impl BillService {
                     buyer: buyer.clone().into(),
                     sum: sum.clone(),
                     payment_address: address_to_pay,
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -333,9 +375,16 @@ impl BillService {
                     buyer: buyer.clone().into(),
                     sum: sum.clone(),
                     payment_address: payment_address.to_owned(),
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -365,9 +414,16 @@ impl BillService {
                         signer_public_data.clone().into()
                     },
                     endorsee: endorsee.clone().into(),
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -426,9 +482,16 @@ impl BillService {
                     } else {
                         signer_public_data.clone().into()
                     },
-                    signatory: signing_keys.signatory_identity,
+                    signatory: signatory_for_signer(
+                        holder_is_anon,
+                        signing_keys.signatory_identity,
+                    ),
                     signing_timestamp: timestamp,
-                    signing_address: signer_public_data.postal_address(),
+                    signing_address: if holder_is_anon {
+                        None
+                    } else {
+                        signer_public_data.postal_address()
+                    },
                     signer_identity_proof: if holder_is_anon {
                         None
                     } else {
@@ -752,4 +815,17 @@ impl BillService {
             .await?;
         Ok(())
     }
+}
+
+/// if the signer is anonymous, the signatory also needs to be anonymous
+fn signatory_for_signer(
+    signer_is_anon: bool,
+    signatory_data: Option<BillSignatoryBlockData>,
+) -> Option<BillSignatoryBlockData> {
+    signatory_data.map(|mut d| {
+        if signer_is_anon {
+            d.name = None;
+        }
+        d
+    })
 }

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -127,7 +127,10 @@ impl BillService {
                         (
                             signatory_identity.key_pair.clone(),
                             Some(signer_keys.clone()),
-                            Some(signatory_identity.identity.clone().into()),
+                            Some(BillSignatoryBlockData {
+                                node_id: signatory_identity.identity.node_id.clone(),
+                                name: Some(signatory_identity.identity.name.clone()),
+                            }),
                         )
                     }
                 };

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -9,8 +9,9 @@ use crate::{
     },
     tests::tests::{
         bill_id_test, bill_id_test_other, bill_id_test_other2,
-        bill_identified_participant_only_node_id, empty_address, empty_bill_identified_participant,
-        empty_identity, init_test_cfg, node_id_test, node_id_test_other, private_key_test,
+        bill_identified_participant_only_node_id, bill_participant_only_node_id, empty_address,
+        empty_bill_identified_participant, empty_identity, init_test_cfg, node_id_test,
+        node_id_test_another, node_id_test_other, private_key_test, private_key_test_another,
         signed_identity_proof_test, test_ts, valid_payment_address_testnet,
     },
     util::get_uuid_v4,
@@ -31,7 +32,7 @@ use bcr_ebill_core::{
         blockchain::{
             Block, Blockchain,
             bill::{
-                BillBlock, BillOpCode, PastPaymentStatus, RecourseReason,
+                BillBlock, BillOpCode, ContactType, PastPaymentStatus, RecourseReason,
                 block::{
                     BillEndorseBlockData, BillMintBlockData, BillOfferToSellBlockData,
                     BillParticipantBlockData, BillRecourseReasonBlockData, BillRejectBlockData,
@@ -3441,6 +3442,104 @@ async fn endorse_bitcredit_bill_anon_baseline() {
 }
 
 #[tokio::test]
+async fn endorse_bitcredit_bill_anon_company_and_back() {
+    let mut ctx = get_ctx();
+    let identity = get_baseline_identity();
+    let company_node_id = node_id_test_another();
+    let company_participant =
+        BillAnonParticipant::from(bill_participant_only_node_id(company_node_id.clone()));
+    let mut bill = get_baseline_bill(&bill_id_test());
+    bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(
+        identity.identity.node_id.clone(),
+    ));
+    ctx.bill_store
+        .expect_save_bill_to_cache()
+        .returning(|_, _, _| Ok(()));
+    let company_participant_clone = company_participant.clone();
+    ctx.bill_blockchain_store
+        .expect_get_chain()
+        .returning(move |_| {
+            let mut chain = get_genesis_chain(Some(bill.clone()));
+
+            // add endorse block from payee to endorsee
+            let endorse_block = BillBlock::create_block_for_endorse(
+                bill_id_test(),
+                chain.get_latest_block(),
+                &BillEndorseBlockData {
+                    endorsee: BillParticipantBlockData::Anon(
+                        company_participant_clone.clone().into(),
+                    ),
+                    // endorsed by payee
+                    endorser: BillParticipantBlockData::Ident(
+                        BillIdentParticipant::new(get_baseline_identity().identity)
+                            .unwrap()
+                            .into(),
+                    ),
+                    signatory: None,
+                    signing_timestamp: test_ts() - 14,
+                    signing_address: Some(empty_address()),
+                    signer_identity_proof: Some(signed_identity_proof_test().into()),
+                },
+                &BcrKeys::from_private_key(&private_key_test()),
+                Some(&BcrKeys::from_private_key(&private_key_test_another())),
+                &BcrKeys::from_private_key(&private_key_test()),
+                test_ts() - 14,
+            )
+            .unwrap();
+            assert!(chain.try_add_block(endorse_block));
+            Ok(chain)
+        });
+    // Bill is endorsed event should be sent
+    ctx.transport_service
+        .expect_send_bill_is_endorsed_event()
+        .returning(|_| Ok(()));
+    ctx.company_store
+        .expect_get_email_confirmations()
+        .returning(|_| Ok(vec![signed_identity_proof_test()]))
+        .times(1);
+    ctx.company_store.expect_get().returning(|_| {
+        let mut company = get_baseline_company_data();
+        company.1.0.id = node_id_test_another();
+        Ok(company.1.0)
+    });
+
+    // Populates identity block
+    expect_populates_company_and_identity_block(&mut ctx);
+
+    let service = get_service(ctx);
+
+    let mut company_ident_participant = bill_participant_only_node_id(company_node_id.clone());
+    if let BillParticipant::Ident(ref mut bill_ident_participant) = company_ident_participant {
+        bill_ident_participant.t = ContactType::Company;
+    };
+
+    let res = service
+        .execute_bill_action(
+            &bill_id_test(),
+            BillAction::Endorse(BillParticipant::Ident(
+                BillIdentParticipant::new(get_baseline_identity().identity).unwrap(),
+            )),
+            &company_ident_participant,
+            &BcrKeys::from_private_key(&private_key_test_another()),
+            test_ts(),
+        )
+        .await;
+    assert!(res.is_ok());
+    assert!(res.as_ref().unwrap().blocks().len() == 3);
+    assert!(res.as_ref().unwrap().blocks()[1].op_code == BillOpCode::Endorse);
+    assert!(res.as_ref().unwrap().blocks()[2].op_code == BillOpCode::Endorse);
+    let last_endorse_data: BillEndorseBlockData = res
+        .unwrap()
+        .blocks()
+        .get(2)
+        .unwrap()
+        .get_decrypted_block(&BcrKeys::from_private_key(&private_key_test()))
+        .unwrap();
+    assert!(last_endorse_data.signatory.as_ref().unwrap().name.is_none()); // name is not set, because company was anon signer
+    assert!(last_endorse_data.signing_address.is_none()); // address is not set, because company was anon signer
+}
+
+#[tokio::test]
 async fn endorse_bitcredit_bill_fails_if_waiting_for_offer_to_sell() {
     let mut ctx = get_ctx();
     let identity = get_baseline_identity();
@@ -5622,7 +5721,7 @@ async fn check_bills_in_recourse_payment_company_is_recourser() {
                     recourse_reason: BillRecourseReasonBlockData::Pay,
                     signatory: Some(BillSignatoryBlockData {
                         node_id: get_baseline_identity().identity.node_id.clone(),
-                        name: get_baseline_identity().identity.name.clone(),
+                        name: Some(get_baseline_identity().identity.name.clone()),
                     }),
                     signing_timestamp: now,
                     signing_address: Some(empty_address()),

--- a/crates/bcr-ebill-core/src/application/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/application/bill/mod.rs
@@ -2,11 +2,14 @@ use super::{
     contact::{LightBillIdentParticipant, LightBillParticipant},
     notification::Notification,
 };
-use crate::protocol::{
-    BitcoinAddress, City, Country, Date, File, PostalAddress, Sum, Timestamp,
-    blockchain::bill::{
-        BillHistory, BillOpCode, ContactType, PastPaymentStatus,
-        participant::{BillIdentParticipant, BillParticipant, SignedBy},
+use crate::{
+    application::contact::LightBillSignatory,
+    protocol::{
+        BitcoinAddress, City, Country, Date, File, PostalAddress, Sum, Timestamp,
+        blockchain::bill::{
+            BillHistory, BillOpCode, PastPaymentStatus,
+            participant::{BillIdentParticipant, BillParticipant, SignedBy},
+        },
     },
 };
 use bcr_common::core::{BillId, NodeId};
@@ -416,20 +419,16 @@ pub struct Endorsement {
 #[derive(Clone, Debug)]
 pub struct LightSignedBy {
     pub data: LightBillParticipant,
-    pub signatory: Option<LightBillIdentParticipant>,
+    pub signatory: Option<LightBillSignatory>,
 }
 
 impl From<SignedBy> for LightSignedBy {
     fn from(value: SignedBy) -> Self {
         Self {
             data: value.data.into(),
-            signatory: value.signatory.map(|s| {
-                LightBillIdentParticipant {
-                    // signatories are always identified people
-                    t: ContactType::Person,
-                    name: s.name,
-                    node_id: s.node_id,
-                }
+            signatory: value.signatory.map(|s| LightBillSignatory {
+                name: s.name,
+                node_id: s.node_id,
             }),
         }
     }

--- a/crates/bcr-ebill-core/src/application/contact/mod.rs
+++ b/crates/bcr-ebill-core/src/application/contact/mod.rs
@@ -67,6 +67,12 @@ pub struct LightBillIdentParticipant {
     pub node_id: NodeId,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightBillSignatory {
+    pub name: Option<Name>,
+    pub node_id: NodeId,
+}
+
 impl From<BillParticipant> for LightBillParticipant {
     fn from(value: BillParticipant) -> Self {
         match value {

--- a/crates/bcr-ebill-core/src/application/identity/mod.rs
+++ b/crates/bcr-ebill-core/src/application/identity/mod.rs
@@ -1,5 +1,4 @@
 use crate::protocol::blockchain::bill::ContactType;
-use crate::protocol::blockchain::bill::block::BillSignatoryBlockData;
 use crate::protocol::blockchain::identity::IdentityType;
 use crate::protocol::{File, OptionalPostalAddress};
 use crate::{
@@ -63,15 +62,6 @@ impl From<Identity> for IdentityCreateBlockData {
             nostr_relays: value.nostr_relays,
             profile_picture_file: value.profile_picture_file,
             identity_document_file: value.identity_document_file,
-        }
-    }
-}
-
-impl From<Identity> for BillSignatoryBlockData {
-    fn from(value: Identity) -> Self {
-        Self {
-            name: value.name,
-            node_id: value.node_id,
         }
     }
 }

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
@@ -440,7 +440,7 @@ impl TryFrom<u64> for ContactType {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct BillSignatoryBlockData {
     pub node_id: NodeId,
-    pub name: Name,
+    pub name: Option<Name>, // only set if the signer the signatory is signing for is not an anon holder
 }
 
 /// The identity proof data, signature and witness for the signer of the block
@@ -1976,7 +1976,7 @@ pub mod tests {
                 payment_address: valid_payment_address_testnet(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: buyer.node_id().clone(),
-                    name: Name::new("some name").unwrap(),
+                    name: Some(Name::new("some name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(valid_address()),
@@ -2631,7 +2631,7 @@ pub mod tests {
                 bill,
                 Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 test_ts(),
                 signed_identity_proof_test(),
@@ -2660,7 +2660,7 @@ pub mod tests {
                 endorsee: BillParticipant::Ident(other_party.clone()).into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2693,7 +2693,7 @@ pub mod tests {
                 sum: Sum::new_sat(5000).expect("sat works"),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2724,7 +2724,7 @@ pub mod tests {
                 requester: BillParticipant::Ident(signer.clone()).into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2757,7 +2757,7 @@ pub mod tests {
                 currency: Currency::sat(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2789,7 +2789,7 @@ pub mod tests {
                 accepter: signer.clone().into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: signer.postal_address.clone(),
@@ -2823,7 +2823,7 @@ pub mod tests {
                 payment_address: valid_payment_address_testnet(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2858,7 +2858,7 @@ pub mod tests {
                 payment_address: valid_payment_address_testnet(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2889,7 +2889,7 @@ pub mod tests {
                 rejecter: signer.clone().into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: signer.postal_address.clone(),
@@ -2920,7 +2920,7 @@ pub mod tests {
                 rejecter: BillParticipant::Ident(signer.clone()).into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -2951,7 +2951,7 @@ pub mod tests {
                 rejecter: signer.clone().into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: signer.postal_address.clone(),
@@ -2982,7 +2982,7 @@ pub mod tests {
                 rejecter: signer.clone().into(),
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: signer.postal_address.clone(),
@@ -3017,7 +3017,7 @@ pub mod tests {
                 recourse_reason: BillRecourseReasonBlockData::Accept,
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -3052,7 +3052,7 @@ pub mod tests {
                 recourse_reason: BillRecourseReasonBlockData::Pay,
                 signatory: Some(BillSignatoryBlockData {
                     node_id: NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 signing_timestamp: test_ts(),
                 signing_address: Some(signer.postal_address.clone()),
@@ -3097,7 +3097,7 @@ pub mod tests {
                 bill,
                 Some(BillSignatoryBlockData {
                     node_id: node_id_test(),
-                    name: Name::new("signatory name").unwrap(),
+                    name: Some(Name::new("signatory name").unwrap()),
                 }),
                 test_ts(),
                 signed_identity_proof_test(),
@@ -3153,7 +3153,7 @@ pub mod tests {
     fn valid_bill_signatory_block_data() -> BillSignatoryBlockData {
         BillSignatoryBlockData {
             node_id: node_id_test(),
-            name: Name::new("Johanna Smith").unwrap(),
+            name: Some(Name::new("Johanna Smith").unwrap()),
         }
     }
 

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/participant.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/participant.rs
@@ -179,11 +179,11 @@ pub struct SignedBy {
     pub signatory: Option<BillSignatory>,
 }
 
-/// The name and node_id of a company signatory
+/// The optional name and node_id of a company signatory
 #[derive(Debug, Clone)]
 pub struct BillSignatory {
     pub node_id: NodeId,
-    pub name: Name,
+    pub name: Option<Name>,
 }
 
 impl From<(BillParticipantBlockData, Option<BillSignatoryBlockData>)> for SignedBy {

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -16,7 +16,7 @@ use bcr_ebill_core::application::bill::{
 };
 use bcr_ebill_core::application::contact::{
     LightBillAnonParticipant, LightBillIdentParticipant, LightBillIdentParticipantWithAddress,
-    LightBillParticipant,
+    LightBillParticipant, LightBillSignatory,
 };
 use bcr_ebill_core::protocol::BlockId;
 use bcr_ebill_core::protocol::City;
@@ -988,7 +988,7 @@ impl From<&Endorsement> for EndorsementDb {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightSignedByDb {
     pub data: BillParticipantDb,
-    pub signatory: Option<LightBillIdentParticipantDb>,
+    pub signatory: Option<LightBillSignatoryDb>,
 }
 
 impl From<LightSignedByDb> for SignedBy {
@@ -1025,14 +1025,10 @@ impl From<&SignedBy> for LightSignedByDb {
     fn from(value: &SignedBy) -> Self {
         Self {
             data: (&value.data).into(),
-            signatory: value
-                .signatory
-                .as_ref()
-                .map(|s| LightBillIdentParticipantDb {
-                    t: ContactType::Person, // signatory is always person
-                    name: s.name.to_owned(),
-                    node_id: s.node_id.to_owned(),
-                }),
+            signatory: value.signatory.as_ref().map(|s| LightBillSignatoryDb {
+                name: s.name.to_owned(),
+                node_id: s.node_id.to_owned(),
+            }),
         }
     }
 }
@@ -1086,6 +1082,30 @@ impl From<&LightBillIdentParticipant> for LightBillIdentParticipantDb {
     fn from(value: &LightBillIdentParticipant) -> Self {
         Self {
             t: value.t.to_owned(),
+            name: value.name.to_owned(),
+            node_id: value.node_id.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightBillSignatoryDb {
+    pub name: Option<Name>,
+    pub node_id: NodeId,
+}
+
+impl From<LightBillSignatoryDb> for LightBillSignatory {
+    fn from(value: LightBillSignatoryDb) -> Self {
+        Self {
+            name: value.name,
+            node_id: value.node_id,
+        }
+    }
+}
+
+impl From<&LightBillSignatory> for LightBillSignatoryDb {
+    fn from(value: &LightBillSignatory) -> Self {
+        Self {
             name: value.name.to_owned(),
             node_id: value.node_id.to_owned(),
         }

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -12,7 +12,7 @@ use bcr_ebill_core::{
         },
         contact::{
             LightBillAnonParticipant, LightBillIdentParticipant,
-            LightBillIdentParticipantWithAddress, LightBillParticipant,
+            LightBillIdentParticipantWithAddress, LightBillParticipant, LightBillSignatory,
         },
     },
     protocol::{
@@ -207,7 +207,7 @@ impl From<PastEndorsee> for PastEndorseeWeb {
 #[tsify(into_wasm_abi)]
 pub struct LightSignedByWeb {
     pub data: LightBillParticipantWeb,
-    pub signatory: Option<LightBillIdentParticipantWeb>,
+    pub signatory: Option<LightBillSignatoryWeb>,
 }
 
 impl From<LightSignedBy> for LightSignedByWeb {
@@ -223,8 +223,7 @@ impl From<SignedBy> for LightSignedByWeb {
     fn from(val: SignedBy) -> Self {
         LightSignedByWeb {
             data: LightBillParticipant::from(val.data).into(),
-            signatory: val.signatory.map(|s| LightBillIdentParticipantWeb {
-                t: ContactTypeWeb::Person,
+            signatory: val.signatory.map(|s| LightBillSignatoryWeb {
                 name: s.name,
                 node_id: s.node_id,
             }),
@@ -1077,6 +1076,24 @@ impl From<BillIdentParticipant> for LightBillIdentParticipantWeb {
     fn from(val: BillIdentParticipant) -> Self {
         LightBillIdentParticipantWeb {
             t: val.t.into(),
+            name: val.name,
+            node_id: val.node_id,
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct LightBillSignatoryWeb {
+    #[tsify(type = "string | undefined")]
+    pub name: Option<Name>,
+    #[tsify(type = "string")]
+    pub node_id: NodeId,
+}
+
+impl From<LightBillSignatory> for LightBillSignatoryWeb {
+    fn from(val: LightBillSignatory) -> Self {
+        Self {
             name: val.name,
             node_id: val.node_id,
         }


### PR DESCRIPTION
## 📝 Description

* If the bill holder is anon, the `signing_address` needs to not be set
* If the bill holder is anon and a company, the `signatory` shouldn't have a `name` set (breaking DB and bill block change)

Relates to #840 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. create bill - endorse to company as bearer - endorse back, signatory name should be `None`, signing_address should be `None`

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #840 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
