### PR TITLE
Request to pay before maturity date fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.5
+
+* Request to pay can only be done after maturity date end-of-day
+
 # 0.5.4
 
 * If the bill holder is anon, the `signing_address` needs to not be set

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/BitcreditProtocol/Bitcredit-Core"
@@ -68,7 +68,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "42ee734f0486304a9dfb0b16ec052a4d5d956356" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "59c24c6c5307bd9effe3075cbf6a6b8cdb71f4ee" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -32,7 +32,6 @@ use bcr_ebill_core::{
             BitcreditBill, OfferToSellWaitingForPayment, RecourseReason, RecourseWaitingForPayment,
             block::{BillSignatoryBlockData, ContactType},
             participant::{BillParticipant, PastEndorsee},
-            validation::get_expiration_deadline_base_for_req_to_pay,
         },
         identity::IdentityType,
     },
@@ -279,16 +278,10 @@ impl BillService {
             }
 
             let (is_expired, payment_deadline) = chain
-                .is_req_to_pay_block_payment_expired(
-                    req_to_pay_block,
-                    bill_keys,
-                    current_timestamp,
-                    Some(&bill.maturity_date),
-                )
+                .is_req_to_pay_block_payment_expired(req_to_pay_block, bill_keys, current_timestamp)
                 .map_err(|e| Error::Protocol(e.into()))?;
             payment_deadline_timestamp = Some(payment_deadline);
             if !paid && !rejected_to_pay && is_expired {
-                // this is true, if the payment is expired (after maturity date)
                 request_to_pay_timed_out = true;
                 bill_payment_state = BillPaymentState::Expired(payment_deadline);
             }
@@ -559,11 +552,6 @@ impl BillService {
                     None
                 } else if request_to_pay_timed_out {
                     // payment expired, we're not waiting anymore
-                    None
-                } else if let Some(payment_deadline) = payment_deadline_timestamp
-                    && current_timestamp.has_deadline_passed(&payment_deadline)
-                {
-                    // the request timed out, we're not waiting anymore, but the payment isn't expired
                     None
                 } else {
                     // we're waiting, collect data
@@ -1035,12 +1023,7 @@ impl BillService {
             // we check for the payment expiration, not the request expiration
             // if the request expired, but the payment deadline hasn't, it's not a past payment
             let (is_expired, payment_deadline) = chain
-                .is_req_to_pay_block_payment_expired(
-                    req_to_pay,
-                    bill_keys,
-                    timestamp,
-                    Some(&bill.maturity_date),
-                )
+                .is_req_to_pay_block_payment_expired(req_to_pay, bill_keys, timestamp)
                 .map_err(|e| Error::Protocol(e.into()))?;
 
             let is_rejected = chain.block_with_operation_code_exists(BillOpCode::RejectToPay);
@@ -1176,23 +1159,9 @@ impl BillService {
             && !payment.rejected_to_pay
             && !payment.request_to_pay_timed_out
             && let Some(payment_deadline) = payment.payment_deadline_timestamp
+            && current_timestamp.has_deadline_passed(&payment_deadline)
         {
-            let deadline_base = get_expiration_deadline_base_for_req_to_pay(
-                payment_deadline,
-                &bill.data.maturity_date,
-            )?;
-            // payment has expired (after maturity date)
-            if current_timestamp.has_deadline_passed(&deadline_base) {
-                invalidate_and_recalculate = true;
-            }
-            // if it was req to pay and is currently waiting, we have to check, if it's expired
-            // once it's expired, we don't have to check this anymore
-            if let Some(BillCurrentWaitingState::Payment(_)) = bill.current_waiting_state {
-                // req to pay has expired (before maturity date)
-                if current_timestamp.has_deadline_passed(&payment_deadline) {
-                    invalidate_and_recalculate = true;
-                }
-            }
+            invalidate_and_recalculate = true;
         }
 
         let sell = &bill.status.sell;
@@ -1549,7 +1518,33 @@ pub mod tests {
         )
         .expect("to work");
 
-        // holder can OfferToSell, Endorse, Req to Pay, Req to Accept
+        // holder can OfferToSell, Endorse, Req to Accept
+        assert_eq!(res.len(), 3);
+        assert!(res.contains(&BillCallerBillAction::OfferToSell));
+        assert!(res.contains(&BillCallerBillAction::Endorse));
+        assert!(res.contains(&BillCallerBillAction::RequestAcceptance));
+
+        // initial bill, called by payee, maturity date in the past
+        let res = calculate_possible_bill_actions_for_caller(
+            chain.clone(),
+            drawee.clone(),
+            payee.clone(),
+            endorsee.clone(),
+            Date::new("1999-10-15").unwrap(),
+            bill_keys.clone(),
+            timestamp,
+            payee.clone(), // caller is payee
+            is_paid,
+            is_waiting_for_req_to_pay,
+            waiting_for_recourse_payment.clone(),
+            waiting_for_offer_to_sell.clone(),
+            is_req_to_pay_expired,
+            is_req_to_accept_expired,
+            past_endorsees.clone(),
+        )
+        .expect("to work");
+
+        // holder can OfferToSell, Endorse, Req to Accept
         assert_eq!(res.len(), 4);
         assert!(res.contains(&BillCallerBillAction::OfferToSell));
         assert!(res.contains(&BillCallerBillAction::Endorse));
@@ -1627,10 +1622,9 @@ pub mod tests {
         .expect("to work");
 
         // holder can OfferToSell, Endorse, Req to Pay
-        assert_eq!(res.len(), 3);
+        assert_eq!(res.len(), 2);
         assert!(res.contains(&BillCallerBillAction::OfferToSell));
         assert!(res.contains(&BillCallerBillAction::Endorse));
-        assert!(res.contains(&BillCallerBillAction::RequestToPay));
 
         // req to accept  bill, called by drawee
         let res = calculate_possible_bill_actions_for_caller(

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -227,20 +227,12 @@ impl BillService {
         let bill_keys = self.store.get_keys(bill_id).await?;
         let contacts = self.contact_store.get_map().await?;
         let mut recoursee = None;
-        let bill_data = chain
-            .get_first_version_bill(&bill_keys)
-            .map_err(|e| Error::Protocol(e.into()))?;
 
         let latest_block = chain.get_latest_block();
         if let Some(action) = match latest_block.op_code {
             BillOpCode::RequestToPay
                 if chain
-                    .is_req_to_pay_block_payment_expired(
-                        latest_block,
-                        &bill_keys,
-                        now,
-                        Some(&bill_data.maturity_date),
-                    )
+                    .is_req_to_pay_block_payment_expired(latest_block, &bill_keys, now)
                     .map_err(|e| Error::Protocol(e.into()))?
                     .0 =>
             {

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -6414,15 +6414,6 @@ fn check_req_for_expiration_baseline() {
             .check_requests_for_expiration(&bill_payment, Timestamp::new(1531593929).unwrap())
             .unwrap()
     );
-    // false, because maturity date is after the deadline, but we call in-between
-    // deadline: 1531766728 (2018-07-16)
-    // maturity: 1531864799 (2018-07-15 + 2d end of day)
-    // called with: Timestamp::new(1531864789).unwrap()(in-between)
-    assert!(
-        !service
-            .check_requests_for_expiration(&bill_payment, Timestamp::new(1531864789).unwrap())
-            .unwrap()
-    );
     // true, because after maturity date
     assert!(
         service
@@ -6459,16 +6450,6 @@ fn check_req_for_expiration_baseline() {
             .unwrap()
     );
     bill_payment.current_waiting_state = None;
-    // req to pay expired, but not yet 2 days after end of day maturity date
-    // but no current waiting state, so was already checked
-    assert!(
-        !service
-            .check_requests_for_expiration(
-                &bill_payment,
-                Timestamp::new(1531593929).unwrap() + PAYMENT_DEADLINE_SECONDS + 1
-            )
-            .unwrap()
-    );
     // after req to pay, and after end of day maturity date, payment expired
     assert!(
         service

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
@@ -8,14 +8,12 @@ use super::block::{
 };
 use super::{BillOpCode, RecourseWaitingForPayment};
 use super::{OfferToSellWaitingForPayment, RecoursePaymentInfo};
-use crate::protocol::Date;
 use crate::protocol::Sha256Hash;
 use crate::protocol::Timestamp;
 use crate::protocol::blockchain::bill::block::BillRejectToBuyBlockData;
 use crate::protocol::blockchain::bill::participant::{
     BillParticipant, BillSignatory, PastEndorsee, SignedBy,
 };
-use crate::protocol::blockchain::bill::validation::get_expiration_deadline_base_for_req_to_pay;
 use crate::protocol::blockchain::bill::{BillHistory, BillHistoryBlock, PaymentStatus};
 use crate::protocol::blockchain::{Block, Blockchain, Error, borsh_to_json_value};
 use crate::protocol::crypto::BcrKeys;
@@ -614,19 +612,12 @@ impl BillBlockchain {
         req_to_pay: &BillBlock,
         bill_keys: &BcrKeys,
         current_timestamp: Timestamp,
-        bill_maturity_date: Option<&Date>,
     ) -> Result<(bool, Timestamp)> {
         let block_data_decrypted: BillRequestToPayBlockData =
             req_to_pay.get_decrypted_block(bill_keys)?;
 
         let deadline = block_data_decrypted.payment_deadline_timestamp;
-        let deadline_base = if let Some(maturity_date) = bill_maturity_date {
-            get_expiration_deadline_base_for_req_to_pay(deadline, maturity_date)?
-        } else {
-            deadline
-        };
-
-        if current_timestamp.has_deadline_passed(&deadline_base) {
+        if current_timestamp.has_deadline_passed(&deadline) {
             return Ok((true, deadline));
         }
         Ok((false, deadline))

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
@@ -1,7 +1,7 @@
 use crate::protocol::blockchain::bill::BillValidationActionMode;
 use crate::protocol::blockchain::bill::participant::{BillParticipant, PastEndorsee};
 use crate::protocol::{
-    Date, ProtocolValidationError, Timestamp, Validate,
+    ProtocolValidationError, Validate,
     blockchain::{
         Block, Blockchain,
         bill::{
@@ -9,7 +9,6 @@ use crate::protocol::{
             block::BillRecourseReasonBlockData,
         },
     },
-    constants::PAYMENT_DEADLINE_SECONDS,
 };
 
 use super::{BillAction, BillIssueData, BillValidateActionData, RecourseReason};
@@ -104,6 +103,10 @@ impl Validate for BillValidateActionData {
                 }
             }
             BillOpCode::RequestToPay => {
+                // request to pay not before maturity date
+                if self.timestamp < self.maturity_date.to_timestamp().end_of_day() {
+                    return Err(ProtocolValidationError::RequestToPayBeforeMaturityDate);
+                }
                 self.bill_is_blocked()?;
                 self.bill_can_only_be_recoursed()?;
                 // not already requested to pay - checked above already
@@ -196,7 +199,6 @@ impl Validate for BillValidateActionData {
                                             req_to_pay,
                                             &self.bill_keys,
                                             self.timestamp,
-                                            Some(&self.maturity_date),
                                         )
                                         .map_err(|e| {
                                             ProtocolValidationError::Blockchain(e.to_string())
@@ -413,28 +415,6 @@ impl Validate for BillValidateActionData {
     }
 }
 
-/// calculates the expiration deadline of a request to pay - if the deadline was before the
-/// maturity date, we take the end of the day of the maturity date, otherwise the end of
-/// day of the req to pay deadline
-pub fn get_expiration_deadline_base_for_req_to_pay(
-    req_to_pay_deadline: Timestamp,
-    bill_maturity_date: &Date,
-) -> Result<Timestamp, ProtocolValidationError> {
-    let maturity_date_plus_min_deadline =
-        bill_maturity_date.to_timestamp() + PAYMENT_DEADLINE_SECONDS;
-    // we calculate from the end of the day
-    let maturity_date_end_of_day = maturity_date_plus_min_deadline.end_of_day();
-    // we calculate from the end of the day of the request to pay deadline
-    let mut deadline = req_to_pay_deadline.end_of_day();
-    // requested to pay deadline after maturity date - deadline is req to pay deadline
-    if deadline < maturity_date_end_of_day {
-        // deadline to pay before end of day of maturity date - deadline base is maturity
-        // date end of day
-        deadline = maturity_date_end_of_day;
-    }
-    Ok(deadline)
-}
-
 impl BillValidateActionData {
     /// if the bill was rejected to accept, rejected to pay, or either of them expired, it can only
     /// be recoursed from that point on
@@ -473,7 +453,6 @@ impl BillValidateActionData {
                                     req_to_pay_block,
                                     &self.bill_keys,
                                     self.timestamp,
-                                    Some(&self.maturity_date),
                                 )
                                 .map_err(|e| ProtocolValidationError::Blockchain(e.to_string()))?;
                             is_expired
@@ -608,7 +587,6 @@ impl BillValidateActionData {
                             req_to_pay,
                             &self.bill_keys,
                             self.timestamp,
-                            None, // not calculated from maturity date
                         )
                         .map_err(|e| ProtocolValidationError::Blockchain(e.to_string()))?;
                     if !self.is_paid && !is_expired {
@@ -670,7 +648,7 @@ impl BillValidateActionData {
 #[cfg(test)]
 mod tests {
     use crate::protocol::{
-        City, Country, Currency, Sum,
+        City, Country, Currency, Date, Sum, Timestamp,
         blockchain::bill::{
             BillBlock, BillBlockchain,
             block::{
@@ -1130,7 +1108,7 @@ mod tests {
     #[rstest]
     #[case::req_to_pay(BillValidateActionData { signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
     #[case::req_to_pay_after_maturity(BillValidateActionData { maturity_date: Date::new("2022-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
-    #[case::req_to_pay_before_maturity(BillValidateActionData { maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Ok(()))]
+    #[case::req_to_pay_on_maturity_at_end_of_day(BillValidateActionData { timestamp: Timestamp::new(4098211199).unwrap(), maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Ok(()))]
     fn test_validate_bill_req_to_pay_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,
@@ -1149,6 +1127,8 @@ mod tests {
     #[case::acceptance_expired_only_recourse(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), timestamp: Timestamp::now() + (ACCEPT_DEADLINE_SECONDS * 2), ..valid_bill_validate_action_data(add_req_to_accept_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ProtocolValidationError::BillAcceptanceExpired))]
     #[case::req_to_pay_not_holder(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), signer_node_id: node_id_test(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ProtocolValidationError::CallerIsNotHolder))]
     #[case::req_to_pay_already_req_to_payed(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ProtocolValidationError::BillIsRequestedToPayAndWaitingForPayment))]
+    #[case::req_to_pay_before_maturity(BillValidateActionData { maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Err(ProtocolValidationError::RequestToPayBeforeMaturityDate))]
+    #[case::req_to_pay_on_maturity_before_end_of_day(BillValidateActionData { timestamp: Timestamp::new(4098211198).unwrap(), maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Err(ProtocolValidationError::RequestToPayBeforeMaturityDate))]
     fn test_validate_bill_req_to_pay_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,
@@ -1289,7 +1269,6 @@ mod tests {
 
     #[rstest]
     #[case::offer_to_sell(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::OfferToSell(valid_other_bill_participant(), Sum::new_sat(500).expect("sat works"), safe_deadline_ts(DAY_IN_SECS))), signer_node_id: node_id_test_other(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
-    #[case::offer_to_sell_req_to_pay_expired_before_maturity(BillValidateActionData { maturity_date: Date::new("2099-11-12").unwrap(), timestamp: Timestamp::now() + (PAYMENT_DEADLINE_SECONDS * 2) , mode: BillValidationActionMode::Deep(BillAction::OfferToSell(valid_other_bill_participant(), Sum::new_sat(500).expect("sat works"), safe_deadline_ts(DAY_IN_SECS))), signer_node_id: node_id_test_other(), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
     fn test_validate_bill_offer_to_sell_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,
@@ -1316,9 +1295,6 @@ mod tests {
 
     #[rstest]
     #[case::sell(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::Sell(valid_bill_participant(), Sum::new_sat(500).expect("sat works"), valid_payment_address_testnet())), signer_node_id: node_id_test_other(), ..valid_bill_validate_action_data(add_offer_to_sell_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Ok(()))]
-    // minus 8 seconds so timestamp is before offer to sell expiry and after req to pay expiry
-    // as every block adds 1 sec to issue block, which is now() - 10
-    #[case::sell_req_to_pay_expired_before_maturity(BillValidateActionData { maturity_date: Date::new("2099-11-12").unwrap(), timestamp: Timestamp::now() + (PAYMENT_DEADLINE_SECONDS - 8), mode: BillValidationActionMode::Deep(BillAction::Sell(valid_bill_participant(), Sum::new_sat(500).expect("sat works"), valid_payment_address_testnet())), signer_node_id: node_id_test_other(), ..valid_bill_validate_action_data(add_offer_to_sell_block(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)))) }, Ok(()))]
     fn test_validate_bill_sell_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,

--- a/crates/bcr-ebill-core/src/protocol/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/mod.rs
@@ -137,6 +137,10 @@ pub enum ProtocolValidationError {
     #[error("Issue date after maturity date")]
     IssueDateAfterMaturityDate,
 
+    /// error returned if the request to pay happened before the maturity date
+    #[error("Request to pay before maturity date")]
+    RequestToPayBeforeMaturityDate,
+
     /// error returned if the currency was invalid
     #[error("Invalid currency")]
     InvalidCurrency,

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -379,8 +379,7 @@ async function triggerBill(t, blank) {
 
     const now = new Date();
     const issue_date = now.toISOString().split('T')[0];
-    const nMonthsLater = new Date(now);
-    nMonthsLater.setMonth(now.getMonth() + 3); // use to set maturity date after issue date
+    const nMonthsLater = new Date(now); // maturity date today end of day
     const maturity_date = nMonthsLater.toISOString().split('T')[0];
 
     let file_upload_id = document.getElementById("file_upload_id").value || undefined;

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -63,6 +63,7 @@ enum JsErrorType {
     InvalidMint,
     IssueDateAfterMaturityDate,
     MaturityDateInThePast,
+    RequestToPayBeforeMaturityDate,
     InvalidFileUploadId,
     InvalidNodeId,
     InvalidBillId,
@@ -286,6 +287,9 @@ fn protocol_validation_error_data(e: ProtocolValidationError) -> JsErrorData {
         }
         ProtocolValidationError::IssueDateAfterMaturityDate => {
             err_400(e, JsErrorType::IssueDateAfterMaturityDate)
+        }
+        ProtocolValidationError::RequestToPayBeforeMaturityDate => {
+            err_400(e, JsErrorType::RequestToPayBeforeMaturityDate)
         }
         ProtocolValidationError::InvalidFileUploadId => {
             err_400(e, JsErrorType::InvalidFileUploadId)


### PR DESCRIPTION
## 📝 Description

* Request to pay can only be done after the maturity date

Relates to #774 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. try req to pay before maturity date and after maturity date
3. check that deadline checks still work the same as before

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #774 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
