### PR TITLE
Add payment fields in Bill History, Replace Links with helpers, Fix Contignent Balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Add payment data to payment blocks (RequestToPay, OfferToSell, RequestRecourse) (breaking DB & breaking bill chain change)
     * These blocks now have `payment_data: BillPaymentBlockData`
     * Remove payment data from `Sell` and `Recourse` endorsement blocks
+* Add `Option<payment_data>` to `BillHistoryBlock` for payment request blocks (breaking DB change)
+* Remove `mempool_link_for_address_to_pay` and `link_to_pay` from data models (breaking DB and API change)
+* Add endpoints to get `mempool_link` and `link_to_pay` to general API
+* Fix a bug where contingent balance was calculated wrongly, for a `payee` that was not endorsee anymore
 
 # 0.5.4
 

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -472,16 +472,6 @@ impl BillService {
 
                     let address_to_pay = payment_info.payment_address.clone();
 
-                    let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                        &address_to_pay,
-                        &payment_info.sum,
-                        &format!("Payment in relation to a bill {}", &bill.id),
-                    );
-
-                    let mempool_link_for_address_to_pay = self
-                        .bitcoin_client
-                        .get_mempool_link_for_address(&address_to_pay);
-
                     // if we're payer, create pay action, if we're payee, create check payment action
                     if current_identity_node_id == buyer.node_id() {
                         payment_actions.push(BillCallerPaymentAction::Pay(
@@ -491,10 +481,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    link_to_pay: link_to_pay.clone(),
                                     address_to_pay: address_to_pay.clone(),
-                                    mempool_link_for_address_to_pay:
-                                        mempool_link_for_address_to_pay.clone(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.buying_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -512,10 +499,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    link_to_pay: link_to_pay.clone(),
                                     address_to_pay: address_to_pay.clone(),
-                                    mempool_link_for_address_to_pay:
-                                        mempool_link_for_address_to_pay.clone(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.buying_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -533,9 +517,7 @@ impl BillService {
                         payment_data: BillWaitingStatePaymentData {
                             time_of_request: last_block.timestamp,
                             sum: payment_info.sum.clone(),
-                            link_to_pay,
                             address_to_pay,
-                            mempool_link_for_address_to_pay,
                             tx_id,
                             in_mempool,
                             confirmations,
@@ -580,16 +562,6 @@ impl BillService {
                         .bitcoin_client
                         .get_address_to_pay(&bill_keys.pub_key(), &holder.node_id().pub_key())?;
 
-                    let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                        &address_to_pay,
-                        &bill.sum,
-                        &format!("Payment in relation to a bill {}", bill.id.clone()),
-                    );
-
-                    let mempool_link_for_address_to_pay = self
-                        .bitcoin_client
-                        .get_mempool_link_for_address(&address_to_pay);
-
                     if let Some(payment_deadline) = payment_deadline_timestamp {
                         // if we're payer, create pay action, if we're payee, create check payment action
                         if current_identity_node_id == bill.drawee.node_id {
@@ -600,10 +572,7 @@ impl BillService {
                                     state: BillCallerPaymentState {
                                         time_of_request: last_block.timestamp,
                                         sum: bill.sum.clone(),
-                                        link_to_pay: link_to_pay.clone(),
                                         address_to_pay: address_to_pay.clone(),
-                                        mempool_link_for_address_to_pay:
-                                            mempool_link_for_address_to_pay.clone(),
                                         status: PaymentStatus::Requested(last_block.timestamp),
                                         payment_deadline,
                                         tx_id: tx_id.clone(),
@@ -621,10 +590,7 @@ impl BillService {
                                     state: BillCallerPaymentState {
                                         time_of_request: last_block.timestamp,
                                         sum: bill.sum.clone(),
-                                        link_to_pay: link_to_pay.clone(),
                                         address_to_pay: address_to_pay.clone(),
-                                        mempool_link_for_address_to_pay:
-                                            mempool_link_for_address_to_pay.clone(),
                                         status: PaymentStatus::Requested(last_block.timestamp),
                                         payment_deadline,
                                         tx_id: tx_id.clone(),
@@ -644,9 +610,7 @@ impl BillService {
                             payment_data: BillWaitingStatePaymentData {
                                 time_of_request: last_block.timestamp,
                                 sum: bill.sum.clone(),
-                                link_to_pay,
                                 address_to_pay,
-                                mempool_link_for_address_to_pay,
                                 tx_id,
                                 in_mempool,
                                 confirmations,
@@ -711,16 +675,6 @@ impl BillService {
                         &payment_info.recourser.node_id().pub_key(),
                     )?;
 
-                    let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                        &address_to_pay,
-                        &payment_info.sum,
-                        &format!("Payment in relation to a bill {}", &bill.id),
-                    );
-
-                    let mempool_link_for_address_to_pay = self
-                        .bitcoin_client
-                        .get_mempool_link_for_address(&address_to_pay);
-
                     // if we're payer, create pay action, if we're payee, create check payment action
                     if current_identity_node_id == recoursee.node_id {
                         payment_actions.push(BillCallerPaymentAction::Pay(
@@ -730,10 +684,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    link_to_pay: link_to_pay.clone(),
                                     address_to_pay: address_to_pay.clone(),
-                                    mempool_link_for_address_to_pay:
-                                        mempool_link_for_address_to_pay.clone(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.recourse_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -751,10 +702,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    link_to_pay: link_to_pay.clone(),
                                     address_to_pay: address_to_pay.clone(),
-                                    mempool_link_for_address_to_pay:
-                                        mempool_link_for_address_to_pay.clone(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.recourse_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -773,9 +721,7 @@ impl BillService {
                             payment_data: BillWaitingStatePaymentData {
                                 time_of_request: last_block.timestamp,
                                 sum: payment_info.sum.clone(),
-                                link_to_pay,
                                 address_to_pay,
-                                mempool_link_for_address_to_pay,
                                 tx_id,
                                 in_mempool,
                                 confirmations,
@@ -815,9 +761,7 @@ impl BillService {
                         state: BillCallerPaymentState {
                             time_of_request: data.time_of_request,
                             sum: data.sum,
-                            link_to_pay: data.link_to_pay,
                             address_to_pay: data.address_to_pay,
-                            mempool_link_for_address_to_pay: data.mempool_link_for_address_to_pay,
                             status: data.status,
                             payment_deadline: data.payment_deadline,
                             tx_id: None,
@@ -834,9 +778,7 @@ impl BillService {
                         state: BillCallerPaymentState {
                             time_of_request: data.time_of_request,
                             sum: data.sum,
-                            link_to_pay: data.link_to_pay,
                             address_to_pay: data.address_to_pay,
-                            mempool_link_for_address_to_pay: data.mempool_link_for_address_to_pay,
                             status: data.status,
                             payment_deadline: data.payment_deadline,
                             tx_id: None,
@@ -853,9 +795,7 @@ impl BillService {
                         state: BillCallerPaymentState {
                             time_of_request: data.time_of_request,
                             sum: data.sum,
-                            link_to_pay: data.link_to_pay,
                             address_to_pay: data.address_to_pay,
-                            mempool_link_for_address_to_pay: data.mempool_link_for_address_to_pay,
                             status: data.status,
                             payment_deadline: data.payment_deadline,
                             tx_id: None,
@@ -1011,14 +951,6 @@ impl BillService {
             let address_to_pay = self
                 .bitcoin_client
                 .get_address_to_pay(&bill_keys.pub_key(), &holder.node_id().pub_key())?;
-            let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                &address_to_pay,
-                &bill.sum,
-                &format!("Payment in relation to a bill {}", bill.id.clone()),
-            );
-            let mempool_link_for_address_to_pay = self
-                .bitcoin_client
-                .get_mempool_link_for_address(&address_to_pay);
 
             // we check for the payment expiration, not the request expiration
             // if the request expired, but the payment deadline hasn't, it's not a past payment
@@ -1034,10 +966,8 @@ impl BillService {
                     payer: bill_parties.drawee.clone().into(),
                     payee: holder.clone().into(),
                     sum: bill.sum.clone(),
-                    link_to_pay,
                     address_to_pay,
                     private_descriptor_to_spend: descriptor_to_spend.clone(),
-                    mempool_link_for_address_to_pay,
                     status: if is_paid {
                         if let Ok(Some(PaymentState::PaidConfirmed(paid_date))) =
                             self.store.get_payment_state(bill_id).await
@@ -1070,24 +1000,14 @@ impl BillService {
             .map_err(|e| Error::Protocol(e.into()))?;
         for past_sell_payment in past_sell_payments {
             let address_to_pay = past_sell_payment.0.payment_address;
-            let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                &address_to_pay,
-                &past_sell_payment.0.sum,
-                &format!("Payment in relation to a bill {}", &bill.id),
-            );
-            let mempool_link_for_address_to_pay = self
-                .bitcoin_client
-                .get_mempool_link_for_address(&address_to_pay);
 
             result.push(PastPaymentResult::Sell(PastPaymentDataSell {
                 time_of_request: past_sell_payment.2,
                 buyer: past_sell_payment.0.buyer,
                 seller: past_sell_payment.0.seller,
                 sum: past_sell_payment.0.sum,
-                link_to_pay,
                 address_to_pay,
                 private_descriptor_to_spend: descriptor_to_spend.clone(),
-                mempool_link_for_address_to_pay,
                 status: past_sell_payment.1,
                 payment_deadline: past_sell_payment.0.buying_deadline_timestamp,
             }));
@@ -1106,24 +1026,14 @@ impl BillService {
                 &bill_keys.pub_key(),
                 &past_sell_payment.0.recourser.node_id().pub_key(),
             )?;
-            let link_to_pay = self.bitcoin_client.generate_link_to_pay(
-                &address_to_pay,
-                &past_sell_payment.0.sum,
-                &format!("Payment in relation to a bill {}", &bill.id),
-            );
-            let mempool_link_for_address_to_pay = self
-                .bitcoin_client
-                .get_mempool_link_for_address(&address_to_pay);
 
             result.push(PastPaymentResult::Recourse(PastPaymentDataRecourse {
                 time_of_request: past_sell_payment.2,
                 recoursee: past_sell_payment.0.recoursee.into(),
                 recourser: past_sell_payment.0.recourser.into(),
                 sum: past_sell_payment.0.sum,
-                link_to_pay,
                 address_to_pay,
                 private_descriptor_to_spend: descriptor_to_spend.clone(),
-                mempool_link_for_address_to_pay,
                 status: past_sell_payment.1,
                 payment_deadline: past_sell_payment.0.recourse_deadline_timestamp,
             }));

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -6,8 +6,10 @@ use bcr_ebill_core::application::bill::{
     Endorsement, LightBitcreditBillResult, PastPaymentResult,
 };
 use bcr_ebill_core::application::identity::{Identity, IdentityWithAll};
+use bcr_ebill_core::protocol::BitcoinAddress;
 use bcr_ebill_core::protocol::Currency;
 use bcr_ebill_core::protocol::SecretKey;
+use bcr_ebill_core::protocol::Sum;
 use bcr_ebill_core::protocol::Timestamp;
 use bcr_ebill_core::protocol::blockchain::bill::chain::BillBlockPlaintextWrapper;
 use bcr_ebill_core::protocol::blockchain::bill::participant::BillParticipant;
@@ -256,4 +258,8 @@ pub trait BillServiceApi: ServiceTraitBounds {
         caller_keys: &BcrKeys,
         current_timestamp: Timestamp,
     ) -> Result<BillHistory>;
+
+    fn mempool_link(&self, address: &BitcoinAddress) -> String;
+
+    fn link_to_pay(&self, address: &BitcoinAddress, sum: &Sum, bill_id: &BillId) -> String;
 }

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -21,7 +21,6 @@ use bcr_ebill_core::application::bill::{
 use bcr_ebill_core::application::company::Company;
 use bcr_ebill_core::application::contact::{Contact, LightBillParticipant};
 use bcr_ebill_core::application::identity::{Identity, IdentityWithAll};
-use bcr_ebill_core::protocol::Email;
 use bcr_ebill_core::protocol::PublicKey;
 use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::Timestamp;
@@ -39,6 +38,7 @@ use bcr_ebill_core::protocol::blockchain::{Blockchain, identity::IdentityType};
 use bcr_ebill_core::protocol::crypto::{self, BcrKeys};
 use bcr_ebill_core::protocol::event::ActionType;
 use bcr_ebill_core::protocol::mint::{MintRequest, MintRequestState, MintRequestStatus};
+use bcr_ebill_core::protocol::{BitcoinAddress, Email};
 use bcr_ebill_core::protocol::{Currency, Sum};
 use bcr_ebill_core::{
     application::ServiceTraitBounds, application::ValidationError, protocol::File,
@@ -784,6 +784,15 @@ impl BillServiceApi for BillService {
                                 break;
                             }
                         }
+
+                        // If we're contingent, but not in endorsements, we could be payee
+                        if !in_guarantee_chain_as_non_anon
+                            && bill.participants.payee.node_id() == current_identity_node_id
+                            && matches!(bill.participants.payee, BillParticipant::Ident(_))
+                        {
+                            in_guarantee_chain_as_non_anon = true;
+                        }
+
                         if in_guarantee_chain_as_non_anon
                             || bill.participants.drawer.node_id == current_identity_node_id
                         {
@@ -1456,7 +1465,6 @@ impl BillServiceApi for BillService {
         }
 
         // Upload existing files for the mint
-        // TODO(multi-relay): don't default to first, but to file upload relay of receiver
         let file_urls_for_mint = self
             .upload_bill_files_for_node_id(
                 bill_id,
@@ -1818,7 +1826,6 @@ impl BillServiceApi for BillService {
             .await?;
 
         // Upload existing files for the court to our relay
-        // TODO(multi-relay): don't default to first, but to file upload relay of receiver
         let file_urls_for_court = self
             .upload_bill_files_for_node_id(
                 bill_id,
@@ -1868,5 +1875,17 @@ impl BillServiceApi for BillService {
             )
             .await?;
         Ok(detail.history)
+    }
+
+    fn mempool_link(&self, address: &BitcoinAddress) -> String {
+        self.bitcoin_client.get_mempool_link_for_address(address)
+    }
+
+    fn link_to_pay(&self, address: &BitcoinAddress, sum: &Sum, bill_id: &BillId) -> String {
+        self.bitcoin_client.generate_link_to_pay(
+            address,
+            sum,
+            &format!("Payment in relation to a bill {}", &bill_id),
+        )
     }
 }

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -216,14 +216,6 @@ pub fn get_service(mut ctx: MockBillContext) -> BillService {
         .returning(|_, _| {
             Ok(BitcoinAddress::from_str("tb1qssh7nk78mm35h75dg4th77zqz4qk3eay68krf9").unwrap())
         });
-    bitcoin_client
-        .expect_get_mempool_link_for_address()
-        .returning(|_| {
-            String::from(
-                "https://esplora.minibill.tech/testnet/address/1Jfn2nZcJ4T7bhE8FdMRz8T3P3YV4LsWn2",
-            )
-        });
-    bitcoin_client.expect_generate_link_to_pay().returning(|_,_,_| String::from("bitcoin:1Jfn2nZcJ4T7bhE8FdMRz8T3P3YV4LsWn2?amount=0.01&message=Payment in relation to bill some bill"));
     ctx.nostr_contact_store
         .expect_by_node_id()
         .returning(|_| Ok(None));

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -6538,9 +6538,7 @@ fn check_req_for_expiration_baseline() {
             payment_data: BillWaitingStatePaymentData {
                 time_of_request: Timestamp::new(1531593928).unwrap(),
                 sum: Sum::new_sat(10).expect("sat works"),
-                link_to_pay: String::default(),
                 address_to_pay: valid_payment_address_testnet(),
-                mempool_link_for_address_to_pay: String::default(),
                 tx_id: None,
                 confirmations: 0,
                 in_mempool: false,

--- a/crates/bcr-ebill-core/src/application/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/application/bill/mod.rs
@@ -84,9 +84,7 @@ pub enum BillCallerPayment {
 pub struct BillCallerPaymentState {
     pub time_of_request: Timestamp,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatus,
     pub payment_deadline: Timestamp,
     pub tx_id: Option<String>,
@@ -156,9 +154,7 @@ pub struct BillWaitingForRecourseState {
 pub struct BillWaitingStatePaymentData {
     pub time_of_request: Timestamp,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
-    pub mempool_link_for_address_to_pay: String,
     pub tx_id: Option<String>,
     pub in_mempool: bool,
     pub confirmations: u64,
@@ -532,10 +528,8 @@ pub struct PastPaymentDataSell {
     pub buyer: BillParticipant,
     pub seller: BillParticipant,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatus,
     pub payment_deadline: Timestamp,
 }
@@ -546,10 +540,8 @@ pub struct PastPaymentDataPayment {
     pub payer: BillIdentParticipant,
     pub payee: BillParticipant,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatus,
     pub payment_deadline: Timestamp,
 }
@@ -560,10 +552,8 @@ pub struct PastPaymentDataRecourse {
     pub recourser: BillParticipant,
     pub recoursee: BillIdentParticipant,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatus,
     pub payment_deadline: Timestamp,
 }

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
@@ -1178,6 +1178,7 @@ impl BillBlock {
                     self,
                     None,
                     None,
+                    None,
                     SignedBy::from((
                         BillParticipantBlockData::Ident(block_data_decrypted.drawer),
                         block_data_decrypted.signatory,
@@ -1191,6 +1192,7 @@ impl BillBlock {
                 BillHistoryBlock::new(
                     self,
                     Some(block_data_decrypted.endorsee.into()),
+                    None,
                     None,
                     SignedBy::from((
                         block_data_decrypted.endorser,
@@ -1206,6 +1208,7 @@ impl BillBlock {
                     self,
                     Some(block_data_decrypted.endorsee.into()),
                     None,
+                    None,
                     SignedBy::from((
                         block_data_decrypted.endorser,
                         block_data_decrypted.signatory,
@@ -1218,6 +1221,7 @@ impl BillBlock {
                     self.get_decrypted_block(bill_keys)?;
                 BillHistoryBlock::new(
                     self,
+                    None,
                     None,
                     Some(block_data_decrypted.acceptance_deadline_timestamp),
                     SignedBy::from((
@@ -1234,6 +1238,7 @@ impl BillBlock {
                     self,
                     None,
                     None,
+                    None,
                     SignedBy::from((
                         BillParticipantBlockData::Ident(block_data_decrypted.accepter),
                         block_data_decrypted.signatory,
@@ -1247,6 +1252,7 @@ impl BillBlock {
                 BillHistoryBlock::new(
                     self,
                     None,
+                    Some(block_data_decrypted.payment_data.clone().into()),
                     Some(block_data_decrypted.payment_data.payment_deadline),
                     SignedBy::from((
                         block_data_decrypted.requester,
@@ -1261,6 +1267,7 @@ impl BillBlock {
                 BillHistoryBlock::new(
                     self,
                     Some(block_data_decrypted.buyer.into()),
+                    Some(block_data_decrypted.payment_data.clone().into()),
                     Some(block_data_decrypted.payment_data.payment_deadline),
                     SignedBy::from((block_data_decrypted.seller, block_data_decrypted.signatory)),
                     block_data_decrypted.signing_address,
@@ -1273,6 +1280,7 @@ impl BillBlock {
                     self,
                     Some(block_data_decrypted.buyer.into()),
                     None,
+                    None,
                     SignedBy::from((block_data_decrypted.seller, block_data_decrypted.signatory)),
                     block_data_decrypted.signing_address,
                 )
@@ -1282,6 +1290,7 @@ impl BillBlock {
                     self.get_decrypted_block(bill_keys)?;
                 BillHistoryBlock::new(
                     self,
+                    None,
                     None,
                     None,
                     SignedBy::from((
@@ -1298,6 +1307,7 @@ impl BillBlock {
                     self,
                     None,
                     None,
+                    None,
                     SignedBy::from((
                         BillParticipantBlockData::Ident(block_data_decrypted.rejecter),
                         block_data_decrypted.signatory,
@@ -1310,6 +1320,7 @@ impl BillBlock {
                     self.get_decrypted_block(bill_keys)?;
                 BillHistoryBlock::new(
                     self,
+                    None,
                     None,
                     None,
                     SignedBy::from((
@@ -1326,6 +1337,7 @@ impl BillBlock {
                     self,
                     None,
                     None,
+                    None,
                     SignedBy::from((
                         block_data_decrypted.rejecter,
                         block_data_decrypted.signatory,
@@ -1339,6 +1351,7 @@ impl BillBlock {
                 BillHistoryBlock::new(
                     self,
                     Some(BillParticipantBlockData::Ident(block_data_decrypted.recoursee).into()),
+                    Some(block_data_decrypted.payment_data.clone().into()),
                     Some(block_data_decrypted.payment_data.payment_deadline),
                     SignedBy::from((
                         block_data_decrypted.recourser,
@@ -1353,6 +1366,7 @@ impl BillBlock {
                 BillHistoryBlock::new(
                     self,
                     Some(BillParticipantBlockData::Ident(block_data_decrypted.recoursee).into()),
+                    None,
                     None,
                     SignedBy::from((
                         block_data_decrypted.recourser,

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/mod.rs
@@ -23,6 +23,7 @@ use crate::protocol::Date;
 use crate::protocol::File;
 use crate::protocol::PostalAddress;
 use crate::protocol::blockchain::Block;
+use crate::protocol::blockchain::bill::block::BillPaymentBlockData;
 use crate::protocol::blockchain::bill::participant::BillIdentParticipant;
 use crate::protocol::blockchain::bill::participant::BillParticipant;
 use crate::protocol::blockchain::bill::participant::PastEndorsee;
@@ -279,6 +280,7 @@ pub struct BillHistoryBlock {
     pub block_id: BlockId,
     pub block_type: BillOpCode,
     pub pay_to_the_order_of: Option<BillParticipant>,
+    pub payment_data: Option<BillHistoryBlockPaymentData>,
     pub request_deadline: Option<Timestamp>,
     pub signed: SignedBy,
     pub signing_timestamp: Timestamp,
@@ -289,6 +291,7 @@ impl BillHistoryBlock {
     pub fn new(
         block: &BillBlock,
         pay_to_the_order_of: Option<BillParticipant>,
+        payment_data: Option<BillHistoryBlockPaymentData>,
         request_deadline: Option<Timestamp>,
         signed: SignedBy,
         signing_address: Option<PostalAddress>,
@@ -297,10 +300,26 @@ impl BillHistoryBlock {
             block_id: block.id(),
             block_type: block.op_code().to_owned(),
             pay_to_the_order_of,
+            payment_data,
             request_deadline,
             signed,
             signing_timestamp: block.timestamp(),
             signing_address,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BillHistoryBlockPaymentData {
+    pub sum: Sum,
+    pub payment_address: BitcoinAddress,
+}
+
+impl From<BillPaymentBlockData> for BillHistoryBlockPaymentData {
+    fn from(value: BillPaymentBlockData) -> Self {
+        Self {
+            sum: value.sum,
+            payment_address: value.payment_address,
         }
     }
 }

--- a/crates/bcr-ebill-core/src/protocol/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/mod.rs
@@ -393,6 +393,10 @@ pub enum ProtocolValidationError {
     /// error returned if an identity proof is not valid
     #[error("Identity proof is invalid")]
     InvalidIdentityProof,
+
+    /// error returned if a bitcoin address is invalid
+    #[error("Bitcoin Address is invalid")]
+    InvalidBitcoinAddress,
 }
 
 impl From<bcr_common::core::Error> for ProtocolValidationError {

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -29,7 +29,9 @@ use bcr_ebill_core::protocol::Timestamp;
 use bcr_ebill_core::protocol::blockchain::bill::participant::{
     BillAnonParticipant, BillIdentParticipant, BillParticipant, BillSignatory, SignedBy,
 };
-use bcr_ebill_core::protocol::blockchain::bill::{BillHistory, BillHistoryBlock, PaymentStatus};
+use bcr_ebill_core::protocol::blockchain::bill::{
+    BillHistory, BillHistoryBlock, BillHistoryBlockPaymentData, PaymentStatus,
+};
 use bcr_ebill_core::protocol::blockchain::bill::{BillOpCode, ContactType};
 use bcr_ebill_core::protocol::crypto::BcrKeys;
 use bcr_ebill_core::protocol::{BitcoinAddress, SecretKey};
@@ -457,9 +459,7 @@ impl From<&BillCurrentWaitingState> for BillCurrentWaitingStateDb {
 pub struct BillWaitingStatePaymentDataDb {
     pub time_of_request: Timestamp,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
-    pub mempool_link_for_address_to_pay: String,
     pub tx_id: Option<String>,
     pub in_mempool: bool,
     pub confirmations: u64,
@@ -471,9 +471,7 @@ impl From<BillWaitingStatePaymentDataDb> for BillWaitingStatePaymentData {
         Self {
             time_of_request: value.time_of_request,
             sum: value.sum,
-            link_to_pay: value.link_to_pay,
             address_to_pay: value.address_to_pay,
-            mempool_link_for_address_to_pay: value.mempool_link_for_address_to_pay,
             tx_id: value.tx_id,
             in_mempool: value.in_mempool,
             confirmations: value.confirmations,
@@ -487,9 +485,7 @@ impl From<&BillWaitingStatePaymentData> for BillWaitingStatePaymentDataDb {
         Self {
             time_of_request: value.time_of_request,
             sum: value.sum.clone(),
-            link_to_pay: value.link_to_pay.clone(),
             address_to_pay: value.address_to_pay.clone(),
-            mempool_link_for_address_to_pay: value.mempool_link_for_address_to_pay.clone(),
             tx_id: value.tx_id.clone(),
             in_mempool: value.in_mempool,
             confirmations: value.confirmations,
@@ -1177,10 +1173,8 @@ impl From<&BillCallerPayment> for BillCallerPaymentDb {
 pub struct BillCallerPaymentStateDb {
     pub time_of_request: Timestamp,
     pub sum: Sum,
-    pub link_to_pay: String,
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: Option<String>,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatusDb,
     pub payment_deadline: Timestamp,
     pub tx_id: Option<String>,
@@ -1193,10 +1187,8 @@ impl From<BillCallerPaymentStateDb> for BillCallerPaymentState {
         Self {
             time_of_request: value.time_of_request,
             sum: value.sum,
-            link_to_pay: value.link_to_pay,
             address_to_pay: value.address_to_pay,
             private_descriptor_to_spend: value.private_descriptor_to_spend,
-            mempool_link_for_address_to_pay: value.mempool_link_for_address_to_pay,
             status: value.status.into(),
             payment_deadline: value.payment_deadline,
             tx_id: value.tx_id,
@@ -1211,13 +1203,11 @@ impl From<&BillCallerPaymentState> for BillCallerPaymentStateDb {
         Self {
             time_of_request: value.time_of_request,
             sum: value.sum.to_owned(),
-            link_to_pay: value.link_to_pay.to_owned(),
             address_to_pay: value.address_to_pay.to_owned(),
             private_descriptor_to_spend: value
                 .private_descriptor_to_spend
                 .as_ref()
                 .map(|pd| pd.to_owned()),
-            mempool_link_for_address_to_pay: value.mempool_link_for_address_to_pay.to_owned(),
             status: (&value.status).into(),
             payment_deadline: value.payment_deadline,
             tx_id: value.tx_id.as_ref().map(|tx| tx.to_owned()),
@@ -1262,6 +1252,7 @@ pub struct BillHistoryBlockDb {
     pub block_id: BlockId,
     pub block_type: BillOpCode,
     pub pay_to_the_order_of: Option<BillParticipantDb>,
+    pub payment_data: Option<BillHistoryBlockPaymentDataDb>,
     pub request_deadline: Option<Timestamp>,
     pub signed: LightSignedByDb,
     pub signing_timestamp: Timestamp,
@@ -1274,6 +1265,7 @@ impl From<BillHistoryBlockDb> for BillHistoryBlock {
             block_id: value.block_id,
             block_type: value.block_type,
             pay_to_the_order_of: value.pay_to_the_order_of.map(|pttoo| pttoo.into()),
+            payment_data: value.payment_data.map(|pd| pd.into()),
             request_deadline: value.request_deadline,
             signed: value.signed.into(),
             signing_timestamp: value.signing_timestamp,
@@ -1288,10 +1280,35 @@ impl From<BillHistoryBlock> for BillHistoryBlockDb {
             block_id: value.block_id,
             block_type: value.block_type,
             pay_to_the_order_of: value.pay_to_the_order_of.as_ref().map(|pttoo| pttoo.into()),
+            payment_data: value.payment_data.map(|pd| pd.into()),
             request_deadline: value.request_deadline,
             signed: (&value.signed).into(),
             signing_timestamp: value.signing_timestamp,
             signing_address: value.signing_address.map(|sa| sa.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BillHistoryBlockPaymentDataDb {
+    pub sum: Sum,
+    pub payment_address: BitcoinAddress,
+}
+
+impl From<BillHistoryBlockPaymentDataDb> for BillHistoryBlockPaymentData {
+    fn from(value: BillHistoryBlockPaymentDataDb) -> Self {
+        Self {
+            sum: value.sum,
+            payment_address: value.payment_address,
+        }
+    }
+}
+
+impl From<BillHistoryBlockPaymentData> for BillHistoryBlockPaymentDataDb {
+    fn from(value: BillHistoryBlockPaymentData) -> Self {
+        Self {
+            sum: value.sum,
+            payment_address: value.payment_address,
         }
     }
 }

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -193,6 +193,10 @@
             <button type="button" id="reject_buying">Reject to Buy</button>
             <button type="button" id="reject_recourse">Reject to Recourse</button>
             <br />
+            BTC Address: <input type="text" id="btc_address"/>
+            Payment Sum: <input type="text" id="payment_sum"/>
+            <button type="button" id="mempool_link">Mempool Link</button>
+            <button type="button" id="link_to_pay">Link to Pay</button>
             <h3>Minting</h3>
             <button type="button" id="request_to_mint">Request to Mint</button>
             <button type="button" id="get_mint_state">Get Mint State</button>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -82,6 +82,8 @@ document.getElementById("clear_bill_cache").addEventListener("click", clearBillC
 document.getElementById("sync_bill_chain").addEventListener("click", syncBillChain);
 document.getElementById("dev_mode_get_bill_chain").addEventListener("click", devModeGetBillChain);
 document.getElementById("share_bill_with_court").addEventListener("click", shareBillWithCourt);
+document.getElementById("mempool_link").addEventListener("click", mempoolLink);
+document.getElementById("link_to_pay").addEventListener("click", linkToPay);
 
 // companies
 document.getElementById("company_create").addEventListener("click", createCompany);
@@ -1001,7 +1003,7 @@ async function changeEmail() {
 async function editIdentity() {
   console.log("editIdentity");
   let measured = measure(async () => {
-    return success_or_fail(await window.identityApi.change({ postal_address: { country: "AT", zip: "1020" } }));
+    return success_or_fail(await window.identityApi.change({ postal_address: { country: "AT", zip: "1030" } }));
   });
   await measured();
 }
@@ -1036,6 +1038,24 @@ async function shareBillWithCourt() {
   let court_node_id = document.getElementById("court_node_id").value;
   let measured = measure(async () => {
     return success_or_fail(await window.billApi.share_bill_with_court({ bill_id: bill_id, court_node_id: court_node_id }));
+  });
+  await measured();
+}
+
+async function mempoolLink() {
+  let btc_address = document.getElementById("btc_address").value;
+  let measured = measure(async () => {
+    return success_or_fail(await window.generalApi.mempool_link({ address: btc_address }));
+  });
+  await measured();
+}
+
+async function linkToPay() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let btc_address = document.getElementById("btc_address").value;
+  let sum = document.getElementById("payment_sum").value;
+  let measured = measure(async () => {
+    return success_or_fail(await window.generalApi.link_to_pay({ bill_id: bill_id, address: btc_address, sum: sum }));
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/api/general.rs
+++ b/crates/bcr-ebill-wasm/src/api/general.rs
@@ -4,7 +4,9 @@ use super::Result;
 use bcr_ebill_api::service::{Error, file_upload_service::detect_content_type_for_bytes};
 use bcr_ebill_core::{
     application::GeneralSearchFilterItemType,
-    protocol::{Currency, ProtocolValidationError, constants::VALID_CURRENCIES},
+    protocol::{
+        BitcoinAddress, Currency, ProtocolValidationError, Sum, constants::VALID_CURRENCIES,
+    },
 };
 use uuid::Uuid;
 use wasm_bindgen::prelude::*;
@@ -14,9 +16,10 @@ use crate::{
     api::bill::get_signer_public_data_and_keys,
     context::get_ctx,
     data::{
-        BalanceResponse, BinaryFileResponse, CurrenciesResponse, CurrencyResponse,
-        GeneralSearchFilterPayload, GeneralSearchResponse, OverviewBalanceResponse,
-        OverviewResponse, StatusResponse,
+        BalanceResponse, BinaryFileResponse, BtcAddressAndSumPayload, BtcAddressPayload,
+        CurrenciesResponse, CurrencyResponse, GeneralSearchFilterPayload, GeneralSearchResponse,
+        LinkToPayResponse, MempoolLinkResponse, OverviewBalanceResponse, OverviewResponse,
+        StatusResponse,
     },
     is_transport_connected,
 };
@@ -161,6 +164,44 @@ impl General {
                 .await?;
 
             Ok(result.into())
+        }
+        .await;
+        TSResult::res_to_js(res)
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "TSResult<LinkToPayResponse>")]
+    pub async fn link_to_pay(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "BtcAddressAndSumPayload")] payload: JsValue,
+    ) -> JsValue {
+        let res: Result<LinkToPayResponse> = async {
+            let pl: BtcAddressAndSumPayload = serde_wasm_bindgen::from_value(payload)?;
+            let parsed_addr = BitcoinAddress::from_str(&pl.address)
+                .map_err(|_| ProtocolValidationError::InvalidBitcoinAddress)?;
+            let parsed_sum = Sum::new_sat_from_str(&pl.sum)?;
+            let result = get_ctx()
+                .bill_service
+                .link_to_pay(&parsed_addr, &parsed_sum, &pl.bill_id);
+            Ok(LinkToPayResponse {
+                link_to_pay: result,
+            })
+        }
+        .await;
+        TSResult::res_to_js(res)
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "TSResult<MempoolLinkResponse>")]
+    pub async fn mempool_link(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "BtcAddressPayload")] payload: JsValue,
+    ) -> JsValue {
+        let res: Result<MempoolLinkResponse> = async {
+            let pl: BtcAddressPayload = serde_wasm_bindgen::from_value(payload)?;
+            let parsed_addr = BitcoinAddress::from_str(&pl.address)
+                .map_err(|_| ProtocolValidationError::InvalidBitcoinAddress)?;
+            Ok(MempoolLinkResponse {
+                mempool_link: get_ctx().bill_service.mempool_link(&parsed_addr),
+            })
         }
         .await;
         TSResult::res_to_js(res)

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -20,7 +20,7 @@ use bcr_ebill_core::{
     protocol::{
         BitcoinAddress, BlockId, City, Country, Date, Email, Name, Timestamp,
         blockchain::bill::{
-            BillHistory, BillHistoryBlock, BillOpCode, PaymentStatus,
+            BillHistory, BillHistoryBlock, BillHistoryBlockPaymentData, BillOpCode, PaymentStatus,
             participant::{
                 BillAnonParticipant, BillIdentParticipant, BillParticipant, PastEndorsee, SignedBy,
             },
@@ -304,6 +304,7 @@ pub struct BillHistoryBlockWeb {
     pub block_id: BlockId,
     pub block_type: BillOpCodeWeb,
     pub pay_to_the_order_of: Option<LightBillParticipantWeb>,
+    pub payment_data: Option<BillHistoryBlockPaymentDataWeb>,
     #[tsify(type = "number | undefined")]
     pub request_deadline: Option<Timestamp>,
     pub signed: LightSignedByWeb,
@@ -320,10 +321,30 @@ impl From<BillHistoryBlock> for BillHistoryBlockWeb {
             pay_to_the_order_of: value
                 .pay_to_the_order_of
                 .map(|pttoo| LightBillParticipant::from(pttoo).into()),
+            payment_data: value.payment_data.map(|pd| pd.into()),
             request_deadline: value.request_deadline,
             signed: value.signed.into(),
             signing_timestamp: value.signing_timestamp,
             signing_address: value.signing_address.map(|sa| sa.into()),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Clone, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct BillHistoryBlockPaymentDataWeb {
+    pub currency: String,
+    pub sum: String,
+    #[tsify(type = "string")]
+    pub payment_address: BitcoinAddress,
+}
+
+impl From<BillHistoryBlockPaymentData> for BillHistoryBlockPaymentDataWeb {
+    fn from(value: BillHistoryBlockPaymentData) -> Self {
+        Self {
+            currency: value.sum.currency().code().to_owned(),
+            sum: value.sum.as_sat_string(),
+            payment_address: value.payment_address,
         }
     }
 }
@@ -399,11 +420,9 @@ pub struct PastPaymentDataSellWeb {
     pub seller: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
-    pub link_to_pay: String,
     #[tsify(type = "string")]
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatusWeb,
 }
 
@@ -415,10 +434,8 @@ impl From<PastPaymentDataSell> for PastPaymentDataSellWeb {
             seller: val.seller.into(),
             currency: val.sum.currency().code().to_owned(),
             sum: val.sum.as_sat_string(),
-            link_to_pay: val.link_to_pay,
             address_to_pay: val.address_to_pay,
             private_descriptor_to_spend: val.private_descriptor_to_spend,
-            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
             status: val.status.into(),
         }
     }
@@ -433,11 +450,9 @@ pub struct PastPaymentDataPaymentWeb {
     pub payee: BillParticipantWeb,
     pub currency: String,
     pub sum: String,
-    pub link_to_pay: String,
     #[tsify(type = "string")]
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatusWeb,
 }
 impl From<PastPaymentDataPayment> for PastPaymentDataPaymentWeb {
@@ -448,10 +463,8 @@ impl From<PastPaymentDataPayment> for PastPaymentDataPaymentWeb {
             payee: val.payee.into(),
             currency: val.sum.currency().code().to_owned(),
             sum: val.sum.as_sat_string(),
-            link_to_pay: val.link_to_pay,
             address_to_pay: val.address_to_pay,
             private_descriptor_to_spend: val.private_descriptor_to_spend,
-            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
             status: val.status.into(),
         }
     }
@@ -466,11 +479,9 @@ pub struct PastPaymentDataRecourseWeb {
     pub recoursee: BillIdentParticipantWeb,
     pub currency: String,
     pub sum: String,
-    pub link_to_pay: String,
     #[tsify(type = "string")]
     pub address_to_pay: BitcoinAddress,
     pub private_descriptor_to_spend: String,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatusWeb,
 }
 
@@ -482,10 +493,8 @@ impl From<PastPaymentDataRecourse> for PastPaymentDataRecourseWeb {
             recoursee: val.recoursee.into(),
             currency: val.sum.currency().code().to_owned(),
             sum: val.sum.as_sat_string(),
-            link_to_pay: val.link_to_pay,
             address_to_pay: val.address_to_pay,
             private_descriptor_to_spend: val.private_descriptor_to_spend,
-            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
             status: val.status.into(),
         }
     }
@@ -633,10 +642,8 @@ pub struct BillWaitingStatePaymentDataWeb {
     pub time_of_request: Timestamp,
     pub currency: String,
     pub sum: String,
-    pub link_to_pay: String,
     #[tsify(type = "string")]
     pub address_to_pay: BitcoinAddress,
-    pub mempool_link_for_address_to_pay: String,
     pub tx_id: Option<String>,
     pub in_mempool: bool,
     pub confirmations: u64,
@@ -650,9 +657,7 @@ impl From<BillWaitingStatePaymentData> for BillWaitingStatePaymentDataWeb {
             time_of_request: val.time_of_request,
             currency: val.sum.currency().code().to_owned(),
             sum: val.sum.as_sat_string(),
-            link_to_pay: val.link_to_pay,
             address_to_pay: val.address_to_pay,
-            mempool_link_for_address_to_pay: val.mempool_link_for_address_to_pay,
             tx_id: val.tx_id,
             in_mempool: val.in_mempool,
             confirmations: val.confirmations,
@@ -1090,10 +1095,8 @@ pub struct BillCallerPaymentStateWeb {
     pub time_of_request: Timestamp,
     pub currency: String,
     pub sum: String,
-    pub link_to_pay: String,
     #[tsify(type = "string")]
     pub address_to_pay: BitcoinAddress,
-    pub mempool_link_for_address_to_pay: String,
     pub status: PaymentStatusWeb,
     #[tsify(type = "number")]
     pub payment_deadline: Timestamp,
@@ -1110,9 +1113,7 @@ impl From<BillCallerPaymentState> for BillCallerPaymentStateWeb {
             time_of_request: value.time_of_request,
             currency: value.sum.currency().code().to_owned(),
             sum: value.sum.as_sat_string(),
-            link_to_pay: value.link_to_pay,
             address_to_pay: value.address_to_pay,
-            mempool_link_for_address_to_pay: value.mempool_link_for_address_to_pay,
             status: value.status.into(),
             payment_deadline: value.payment_deadline,
             tx_id: value.tx_id,

--- a/crates/bcr-ebill-wasm/src/data/mod.rs
+++ b/crates/bcr-ebill-wasm/src/data/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use bcr_common::core::NodeId;
+use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_api::service::file_upload_service::{
     UploadFileHandler, detect_content_type_for_bytes,
 };
@@ -379,6 +379,33 @@ impl From<UploadFileResult> for UploadFileResponse {
             file_upload_id: val.file_upload_id,
         }
     }
+}
+
+#[derive(Tsify, Debug, Deserialize, Clone)]
+#[tsify(from_wasm_abi)]
+pub struct BtcAddressPayload {
+    pub address: String,
+}
+
+#[derive(Tsify, Debug, Deserialize, Clone)]
+#[tsify(from_wasm_abi)]
+pub struct BtcAddressAndSumPayload {
+    #[tsify(type = "string")]
+    pub bill_id: BillId,
+    pub address: String,
+    pub sum: String,
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct MempoolLinkResponse {
+    pub mempool_link: String,
+}
+
+#[derive(Tsify, Debug, Serialize, Clone)]
+#[tsify(into_wasm_abi)]
+pub struct LinkToPayResponse {
+    pub link_to_pay: String,
 }
 
 // Checks if the given JS Value has the given field - also works with nested fields like postal_address.zip

--- a/crates/bcr-ebill-wasm/src/error.rs
+++ b/crates/bcr-ebill-wasm/src/error.rs
@@ -47,6 +47,7 @@ enum JsErrorType {
     FieldInvalid,
     InvalidSum,
     InvalidCurrency,
+    InvalidBitcoinAddress,
     InvalidContentType,
     IdentityCantBeAnon,
     InvalidContactType,
@@ -266,6 +267,9 @@ fn protocol_validation_error_data(e: ProtocolValidationError) -> JsErrorData {
         ProtocolValidationError::FieldEmpty(_) => err_400(e, JsErrorType::FieldEmpty),
         ProtocolValidationError::FieldInvalid(_) => err_400(e, JsErrorType::FieldInvalid),
         ProtocolValidationError::InvalidSum => err_400(e, JsErrorType::InvalidSum),
+        ProtocolValidationError::InvalidBitcoinAddress => {
+            err_400(e, JsErrorType::InvalidBitcoinAddress)
+        }
         ProtocolValidationError::InvalidCurrency => err_400(e, JsErrorType::InvalidCurrency),
         ProtocolValidationError::InvalidContactType => err_400(e, JsErrorType::InvalidContactType),
         ProtocolValidationError::InvalidIdentityType => {


### PR DESCRIPTION
## 📝 Description

Further progress on Request to Pay changes with some cleanup of the data model:

* Add `Option<payment_data>` to `BillHistoryBlock` for payment request blocks (breaking DB change)
* Remove `mempool_link_for_address_to_pay` and `link_to_pay` from data models (breaking DB and API change)
* Add endpoints to get `mempool_link` and `link_to_pay` to general API
* Fix a bug where contingent balance was calculated wrongly, for a `payee` that was not enodorsee anymore

Relates to #774 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. check balance for payee who is not endorsee anymore
3. check that bill history now has payment data for payment requests
4. check new endpoints for getting link to pay and mempool link

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #774 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
