### PR TITLE
Use Unique Payment Addresses and Descriptors per Payment Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Add endpoints to get `mempool_link` and `link_to_pay` to general API
 * Fix a bug where contingent balance was calculated wrongly, for a `payee` that was not endorsee anymore
 * Use taproot Addresses
+* Use and validate unique payment addresses per payment request (breaking Bills on a protocol level)
+* Changed `get_combined_bitcoin_key_for_bill` to `get_combined_bitcoin_keys_for_bill`, returning all bitcoin keys for payments within this bill for the caller
+* Update local dev defaults for relay
 
 # 0.5.4
 

--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -20,7 +20,6 @@ anyhow.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 bitcoin.workspace = true
-miniscript.workspace = true
 nostr.workspace = true
 futures.workspace = true
 infer = { version = "0.19.0", default-features = false }

--- a/crates/bcr-ebill-api/src/external/bitcoin.rs
+++ b/crates/bcr-ebill-api/src/external/bitcoin.rs
@@ -4,11 +4,10 @@ use bcr_ebill_core::{
     application::ServiceTraitBounds,
     application::bill::{InMempoolData, PaidData, PaymentState},
     protocol::BitcoinAddress,
-    protocol::PublicKey,
     protocol::Sum,
     protocol::Timestamp,
 };
-use bitcoin::{Network, secp256k1::Scalar};
+use bitcoin::Network;
 use log::debug;
 use log::warn;
 use serde::Deserialize;
@@ -27,22 +26,6 @@ pub enum Error {
     #[error("External Bitcoin Web API error: {0}")]
     Api(#[from] reqwest::Error),
 
-    /// all errors originating from dealing with secp256k1 keys
-    #[error("External Bitcoin Key error: {0}")]
-    Key(#[from] bitcoin::secp256k1::Error),
-
-    /// all errors originating from dealing with public secp256k1 keys
-    #[error("External Bitcoin Public Key error: {0}")]
-    PublicKey(String),
-
-    /// all errors originating from dealing with private secp256k1 keys
-    #[error("External Bitcoin Private Key error: {0}")]
-    PrivateKey(String),
-
-    /// all errors originating from dealing with bitcoin descriptors
-    #[error("External Bitcoin Descriptor error: {0}")]
-    Descriptor(String),
-
     /// all errors originating from dealing with invalid data from the API
     #[error("Got invalid data from the API")]
     InvalidData(String),
@@ -55,12 +38,6 @@ use mockall::automock;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait BitcoinClientApi: ServiceTraitBounds {
-    async fn get_address_info(&self, address: &BitcoinAddress) -> Result<AddressInfo>;
-
-    async fn get_transactions(&self, address: &BitcoinAddress) -> Result<Transactions>;
-
-    async fn get_last_block_height(&self) -> Result<u64>;
-
     /// Checks payment by iterating over the transactions on the address in chronological order, until
     /// the target amount is filled, returning the respective payment status
     async fn check_payment_for_address(
@@ -69,21 +46,10 @@ pub trait BitcoinClientApi: ServiceTraitBounds {
         target_amount: u64,
     ) -> Result<PaymentState>;
 
-    /// Get p2tr address for the given keys
-    fn get_address_to_pay(
-        &self,
-        bill_public_key: &PublicKey,
-        holder_public_key: &PublicKey,
-    ) -> Result<BitcoinAddress>;
-
+    /// Generates a payment link
     fn generate_link_to_pay(&self, address: &BitcoinAddress, sum: &Sum, message: &str) -> String;
 
-    fn get_combined_private_descriptor(
-        &self,
-        pkey: &bitcoin::PrivateKey,
-        pkey_to_combine: &bitcoin::PrivateKey,
-    ) -> Result<String>;
-
+    /// Generates a link to check the address on the configured mempool browser
     fn get_mempool_link_for_address(&self, address: &BitcoinAddress) -> String;
 }
 
@@ -212,24 +178,6 @@ impl BitcoinClient {
             .expect("esplora_base_urls must not be empty")
             .into())
     }
-}
-
-impl Default for BitcoinClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl BitcoinClientApi for BitcoinClient {
-    async fn get_address_info(&self, address: &BitcoinAddress) -> Result<AddressInfo> {
-        let addr_str = address.assume_checked_ref().to_string();
-        self.request_with_fallback(|base_url| {
-            self.build_api_url(base_url, &format!("/address/{addr_str}"))
-        })
-        .await
-    }
 
     async fn get_transactions(&self, address: &BitcoinAddress) -> Result<Transactions> {
         let addr_str = address.assume_checked_ref().to_string();
@@ -243,7 +191,17 @@ impl BitcoinClientApi for BitcoinClient {
         self.request_with_fallback(|base_url| self.build_api_url(base_url, "/blocks/tip/height"))
             .await
     }
+}
 
+impl Default for BitcoinClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl BitcoinClientApi for BitcoinClient {
     async fn check_payment_for_address(
         &self,
         address: &BitcoinAddress,
@@ -253,32 +211,11 @@ impl BitcoinClientApi for BitcoinClient {
             "checking if btc address {} is paid {target_amount}",
             address.assume_checked_ref()
         );
-        // in parallel, get current chain height, transactions and address info for the given address
+        // in parallel, get current chain height and transactions
         let (chain_block_height, txs) =
-            try_join!(self.get_last_block_height(), self.get_transactions(address),)?;
+            try_join!(self.get_last_block_height(), self.get_transactions(address))?;
 
         payment_state_from_transactions(chain_block_height, txs, address, target_amount)
-    }
-
-    fn get_address_to_pay(
-        &self,
-        bill_public_key: &PublicKey,
-        holder_public_key: &PublicKey,
-    ) -> Result<BitcoinAddress> {
-        let combined_key = bill_public_key
-            .combine(holder_public_key)
-            .map_err(Error::from)?;
-
-        let (x_only_pub_key, _parity) = combined_key.x_only_public_key();
-
-        Ok(bitcoin::Address::p2tr(
-            secp256k1::global::SECP256K1,
-            x_only_pub_key,
-            None,
-            get_config().bitcoin_network(),
-        )
-        .as_unchecked()
-        .to_owned())
     }
 
     fn generate_link_to_pay(&self, address: &BitcoinAddress, sum: &Sum, message: &str) -> String {
@@ -288,33 +225,6 @@ impl BitcoinClientApi for BitcoinClient {
             address.assume_checked_ref()
         );
         link
-    }
-
-    fn get_combined_private_descriptor(
-        &self,
-        pkey: &bitcoin::PrivateKey,
-        pkey_to_combine: &bitcoin::PrivateKey,
-    ) -> Result<String> {
-        let combined_key = pkey
-            .inner
-            .add_tweak(&Scalar::from(pkey_to_combine.inner))
-            .map_err(|e| Error::PrivateKey(e.to_string()))?;
-        let priv_key = bitcoin::PrivateKey::new(combined_key, get_config().bitcoin_network());
-        let single = miniscript::descriptor::SinglePriv {
-            key: priv_key,
-            origin: None,
-        };
-        let desc_seckey = miniscript::descriptor::DescriptorSecretKey::Single(single);
-        let desc_pubkey = desc_seckey
-            .to_public(secp256k1::global::SECP256K1)
-            .map_err(|e| Error::Descriptor(e.to_string()))?;
-        let kmap = miniscript::descriptor::KeyMap::from_iter(std::iter::once((
-            desc_pubkey.clone(),
-            desc_seckey,
-        )));
-        let desc = miniscript::Descriptor::new_tr(desc_pubkey, None)
-            .map_err(|e| Error::Descriptor(e.to_string()))?;
-        Ok(desc.to_string_with_secret(&kmap))
     }
 
     fn get_mempool_link_for_address(&self, address: &BitcoinAddress) -> String {

--- a/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/blocks.rs
@@ -2,11 +2,11 @@ use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_core::{
     application::identity::IdentityWithAll,
     protocol::{
-        ProtocolValidationError, Timestamp, Validate,
+        BlockId, ProtocolValidationError, Timestamp, Validate,
         blockchain::{
-            self, Blockchain,
+            self, Block, Blockchain,
             bill::{
-                BillBlock, BillBlockchain, BitcreditBill, RecourseReason,
+                BillBlock, BillBlockchain, BillOpCode, BitcreditBill, RecourseReason,
                 block::{
                     BillAcceptBlockData, BillEndorseBlockData, BillMintBlockData,
                     BillOfferToSellBlockData, BillPaymentBlockData, BillRecourseBlockData,
@@ -26,7 +26,10 @@ use bcr_ebill_core::{
                 IdentitySignPersonBillBlockData,
             },
         },
-        crypto::BcrKeys,
+        crypto::{
+            BcrKeys,
+            btc::{calculate_tweak_hash_for_payment_request, get_address_to_pay},
+        },
         event::{CompanyChainEvent, IdentityChainEvent},
     },
 };
@@ -141,9 +144,17 @@ impl BillService {
             }
             // can req to pay as anon
             BillAction::RequestToPay(_currency, payment_deadline_timestamp) => {
-                let address_to_pay = self.bitcoin_client.get_address_to_pay(
+                // calculate payment address with unique tweak
+                let address_to_pay = get_address_to_pay(
                     &bill_keys.pub_key(),
                     &signer_public_data.node_id().pub_key(),
+                    &calculate_tweak_hash_for_payment_request(
+                        BillOpCode::RequestToPay,
+                        &BlockId::next_from_previous_block_id(&previous_block.id()),
+                        previous_block.hash(),
+                    )
+                    .map_err(|e| Error::Protocol(e.into()))?,
+                    get_config().bitcoin_network(),
                 )?;
                 let block_data = BillRequestToPayBlockData {
                     requester: if holder_is_anon {
@@ -200,10 +211,19 @@ impl BillService {
                         (sum.to_owned(), BillRecourseReasonBlockData::Pay)
                     }
                 };
-                let address_to_pay = self.bitcoin_client.get_address_to_pay(
+                // calculate payment address with unique tweak
+                let address_to_pay = get_address_to_pay(
                     &bill_keys.pub_key(),
                     &signer_public_data.node_id().pub_key(),
+                    &calculate_tweak_hash_for_payment_request(
+                        BillOpCode::RequestRecourse,
+                        &BlockId::next_from_previous_block_id(&previous_block.id()),
+                        previous_block.hash(),
+                    )
+                    .map_err(|e| Error::Protocol(e.into()))?,
+                    get_config().bitcoin_network(),
                 )?;
+
                 let block_data = BillRequestRecourseBlockData {
                     recourser: if holder_is_anon {
                         // if holder is anon, we need to continue as anon
@@ -328,9 +348,17 @@ impl BillService {
             // can be anon to offer to sell
             BillAction::OfferToSell(buyer, sum, buying_deadline_timestamp) => {
                 validate_node_id_network(&buyer.node_id())?;
-                let address_to_pay = self.bitcoin_client.get_address_to_pay(
+                // calculate payment address with unique tweak
+                let address_to_pay = get_address_to_pay(
                     &bill_keys.pub_key(),
                     &signer_public_data.node_id().pub_key(),
+                    &calculate_tweak_hash_for_payment_request(
+                        BillOpCode::OfferToSell,
+                        &BlockId::next_from_previous_block_id(&previous_block.id()),
+                        previous_block.hash(),
+                    )
+                    .map_err(|e| Error::Protocol(e.into()))?,
+                    get_config().bitcoin_network(),
                 )?;
                 let block_data = BillOfferToSellBlockData {
                     seller: if holder_is_anon {

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -15,6 +15,9 @@ use bcr_ebill_core::protocol::Validate;
 use bcr_ebill_core::protocol::blockchain::Block;
 use bcr_ebill_core::protocol::blockchain::bill::block::BillIssueBlockData;
 use bcr_ebill_core::protocol::blockchain::bill::{BillValidateActionData, PaymentStatus};
+use bcr_ebill_core::protocol::crypto::btc::{
+    calculate_tweak_hash_for_payment_request, get_combined_private_descriptor,
+};
 use bcr_ebill_core::protocol::{Date, ProtocolValidationError};
 use bcr_ebill_core::protocol::{EmailIdentityProofData, SignedIdentityProof, Sum};
 use bcr_ebill_core::{
@@ -262,6 +265,7 @@ impl BillService {
         let mut request_to_pay_timed_out = false;
         let mut time_of_request_to_pay = None;
         let mut payment_deadline_timestamp = None;
+        let mut req_to_pay_address = None;
         let mut is_waiting_for_req_to_pay = false;
         if let Some(req_to_pay_block) =
             chain.get_last_version_block_with_op_code(BillOpCode::RequestToPay)
@@ -277,10 +281,11 @@ impl BillService {
                 bill_payment_state = BillPaymentState::Rejected(reject_to_pay_block.timestamp);
             }
 
-            let (is_expired, payment_deadline) = chain
+            let (is_expired, payment_deadline, payment_address) = chain
                 .is_req_to_pay_block_payment_expired(req_to_pay_block, bill_keys, current_timestamp)
                 .map_err(|e| Error::Protocol(e.into()))?;
             payment_deadline_timestamp = Some(payment_deadline);
+            req_to_pay_address = Some(payment_address);
             if !paid && !rejected_to_pay && is_expired {
                 request_to_pay_timed_out = true;
                 bill_payment_state = BillPaymentState::Expired(payment_deadline);
@@ -536,88 +541,89 @@ impl BillService {
                     // payment expired, we're not waiting anymore
                     None
                 } else {
-                    // we're waiting, collect data
-                    is_waiting_for_req_to_pay = true;
-                    let payment_state = self.store.get_payment_state(&bill.id).await?;
+                    if let Some(address_to_pay) = req_to_pay_address {
+                        // we're waiting, collect data
+                        is_waiting_for_req_to_pay = true;
+                        let payment_state = self.store.get_payment_state(&bill.id).await?;
 
-                    let mut tx_id = None;
-                    let mut in_mempool = false;
-                    let mut confirmations = 0;
+                        let mut tx_id = None;
+                        let mut in_mempool = false;
+                        let mut confirmations = 0;
 
-                    if let Some(ps) = payment_state {
-                        match ps {
-                            PaymentState::PaidConfirmed(paid_data)
-                            | PaymentState::PaidUnconfirmed(paid_data) => {
-                                tx_id = Some(paid_data.tx_id);
-                                confirmations = paid_data.confirmations;
+                        if let Some(ps) = payment_state {
+                            match ps {
+                                PaymentState::PaidConfirmed(paid_data)
+                                | PaymentState::PaidUnconfirmed(paid_data) => {
+                                    tx_id = Some(paid_data.tx_id);
+                                    confirmations = paid_data.confirmations;
+                                }
+                                PaymentState::InMempool(in_mempool_data) => {
+                                    tx_id = Some(in_mempool_data.tx_id);
+                                    in_mempool = true;
+                                }
+                                PaymentState::NotFound => (),
                             }
-                            PaymentState::InMempool(in_mempool_data) => {
-                                tx_id = Some(in_mempool_data.tx_id);
-                                in_mempool = true;
+                        }
+
+                        if let Some(payment_deadline) = payment_deadline_timestamp {
+                            // if we're payer, create pay action, if we're payee, create check payment action
+                            if current_identity_node_id == bill.drawee.node_id {
+                                payment_actions.push(BillCallerPaymentAction::Pay(
+                                    BillCallerPayment::Payment {
+                                        payer: bill.drawee.clone(),
+                                        payee: holder.clone(),
+                                        state: BillCallerPaymentState {
+                                            time_of_request: last_block.timestamp,
+                                            sum: bill.sum.clone(),
+                                            address_to_pay: address_to_pay.clone(),
+                                            status: PaymentStatus::Requested(last_block.timestamp),
+                                            payment_deadline,
+                                            tx_id: tx_id.clone(),
+                                            in_mempool,
+                                            confirmations,
+                                            private_descriptor_to_spend: None,
+                                        },
+                                    },
+                                ));
+                            } else if current_identity_node_id == holder.node_id() {
+                                payment_actions.push(BillCallerPaymentAction::CheckPayment(
+                                    BillCallerPayment::Payment {
+                                        payer: bill.drawee.clone(),
+                                        payee: holder.clone(),
+                                        state: BillCallerPaymentState {
+                                            time_of_request: last_block.timestamp,
+                                            sum: bill.sum.clone(),
+                                            address_to_pay: address_to_pay.clone(),
+                                            status: PaymentStatus::Requested(last_block.timestamp),
+                                            payment_deadline,
+                                            tx_id: tx_id.clone(),
+                                            in_mempool,
+                                            confirmations,
+                                            private_descriptor_to_spend: None,
+                                        },
+                                    },
+                                ));
                             }
-                            PaymentState::NotFound => (),
                         }
-                    }
-                    let address_to_pay = self
-                        .bitcoin_client
-                        .get_address_to_pay(&bill_keys.pub_key(), &holder.node_id().pub_key())?;
 
-                    if let Some(payment_deadline) = payment_deadline_timestamp {
-                        // if we're payer, create pay action, if we're payee, create check payment action
-                        if current_identity_node_id == bill.drawee.node_id {
-                            payment_actions.push(BillCallerPaymentAction::Pay(
-                                BillCallerPayment::Payment {
-                                    payer: bill.drawee.clone(),
-                                    payee: holder.clone(),
-                                    state: BillCallerPaymentState {
-                                        time_of_request: last_block.timestamp,
-                                        sum: bill.sum.clone(),
-                                        address_to_pay: address_to_pay.clone(),
-                                        status: PaymentStatus::Requested(last_block.timestamp),
-                                        payment_deadline,
-                                        tx_id: tx_id.clone(),
-                                        in_mempool,
-                                        confirmations,
-                                        private_descriptor_to_spend: None,
-                                    },
+                        Some(BillCurrentWaitingState::Payment(
+                            BillWaitingForPaymentState {
+                                payer: bill.drawee.clone(),
+                                payee: holder.clone(),
+                                payment_data: BillWaitingStatePaymentData {
+                                    time_of_request: last_block.timestamp,
+                                    sum: bill.sum.clone(),
+                                    address_to_pay,
+                                    tx_id,
+                                    in_mempool,
+                                    confirmations,
+                                    payment_deadline: payment_deadline_timestamp,
                                 },
-                            ));
-                        } else if current_identity_node_id == holder.node_id() {
-                            payment_actions.push(BillCallerPaymentAction::CheckPayment(
-                                BillCallerPayment::Payment {
-                                    payer: bill.drawee.clone(),
-                                    payee: holder.clone(),
-                                    state: BillCallerPaymentState {
-                                        time_of_request: last_block.timestamp,
-                                        sum: bill.sum.clone(),
-                                        address_to_pay: address_to_pay.clone(),
-                                        status: PaymentStatus::Requested(last_block.timestamp),
-                                        payment_deadline,
-                                        tx_id: tx_id.clone(),
-                                        in_mempool,
-                                        confirmations,
-                                        private_descriptor_to_spend: None,
-                                    },
-                                },
-                            ));
-                        }
-                    }
-
-                    Some(BillCurrentWaitingState::Payment(
-                        BillWaitingForPaymentState {
-                            payer: bill.drawee.clone(),
-                            payee: holder.clone(),
-                            payment_data: BillWaitingStatePaymentData {
-                                time_of_request: last_block.timestamp,
-                                sum: bill.sum.clone(),
-                                address_to_pay,
-                                tx_id,
-                                in_mempool,
-                                confirmations,
-                                payment_deadline: payment_deadline_timestamp,
                             },
-                        },
-                    ))
+                        ))
+                    } else {
+                        None
+                    }
                 }
             }
             BillOpCode::RequestRecourse => {
@@ -670,11 +676,6 @@ impl BillService {
                         )
                         .await;
 
-                    let address_to_pay = self.bitcoin_client.get_address_to_pay(
-                        &bill_keys.pub_key(),
-                        &payment_info.recourser.node_id().pub_key(),
-                    )?;
-
                     // if we're payer, create pay action, if we're payee, create check payment action
                     if current_identity_node_id == recoursee.node_id {
                         payment_actions.push(BillCallerPaymentAction::Pay(
@@ -684,7 +685,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    address_to_pay: address_to_pay.clone(),
+                                    address_to_pay: payment_info.payment_address.to_owned(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.recourse_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -702,7 +703,7 @@ impl BillService {
                                 state: BillCallerPaymentState {
                                     time_of_request: last_block.timestamp,
                                     sum: payment_info.sum.clone(),
-                                    address_to_pay: address_to_pay.clone(),
+                                    address_to_pay: payment_info.payment_address.to_owned(),
                                     status: PaymentStatus::Requested(last_block.timestamp),
                                     payment_deadline: payment_info.recourse_deadline_timestamp,
                                     tx_id: tx_id.clone(),
@@ -721,7 +722,7 @@ impl BillService {
                             payment_data: BillWaitingStatePaymentData {
                                 time_of_request: last_block.timestamp,
                                 sum: payment_info.sum.clone(),
-                                address_to_pay,
+                                address_to_pay: payment_info.payment_address.to_owned(),
                                 tx_id,
                                 in_mempool,
                                 confirmations,
@@ -937,30 +938,37 @@ impl BillService {
             Some(ref endorsee) => endorsee,
         };
 
-        let descriptor_to_spend = self.bitcoin_client.get_combined_private_descriptor(
-            &BcrKeys::from_private_key(&bill_keys.get_private_key())
-                .get_bitcoin_private_key(get_config().bitcoin_network()),
-            &caller_keys.get_bitcoin_private_key(get_config().bitcoin_network()),
-        )?;
+        let btc_network = get_config().bitcoin_network();
 
         // Request to Pay
         if holder.node_id() == caller_public_data.node_id()
             && let Some(req_to_pay) =
                 chain.get_last_version_block_with_op_code(BillOpCode::RequestToPay)
         {
-            let address_to_pay = self
-                .bitcoin_client
-                .get_address_to_pay(&bill_keys.pub_key(), &holder.node_id().pub_key())?;
-
             // we check for the payment expiration, not the request expiration
             // if the request expired, but the payment deadline hasn't, it's not a past payment
-            let (is_expired, payment_deadline) = chain
+            let (is_expired, payment_deadline, address_to_pay) = chain
                 .is_req_to_pay_block_payment_expired(req_to_pay, bill_keys, timestamp)
                 .map_err(|e| Error::Protocol(e.into()))?;
 
             let is_rejected = chain.block_with_operation_code_exists(BillOpCode::RejectToPay);
 
             if is_paid || is_rejected || is_expired {
+                // calculate tweak
+                let tweak = calculate_tweak_hash_for_payment_request(
+                    req_to_pay.op_code().to_owned(),
+                    &req_to_pay.id(),
+                    req_to_pay.previous_hash(),
+                )
+                .map_err(|e| Error::Protocol(e.into()))?;
+                let descriptor_to_spend = get_combined_private_descriptor(
+                    &BcrKeys::from_private_key(&bill_keys.get_private_key())
+                        .get_bitcoin_private_key(btc_network),
+                    &caller_keys.get_bitcoin_private_key(btc_network),
+                    &tweak,
+                    btc_network,
+                )?;
+
                 result.push(PastPaymentResult::Payment(PastPaymentDataPayment {
                     time_of_request: req_to_pay.timestamp,
                     payer: bill_parties.drawee.clone().into(),
@@ -996,7 +1004,13 @@ impl BillService {
 
         // OfferToSell
         let past_sell_payments = chain
-            .get_past_sell_payments_for_node_id(bill_keys, &caller_public_data.node_id(), timestamp)
+            .get_past_sell_payments_for_node_id(
+                bill_keys,
+                caller_keys,
+                btc_network,
+                &caller_public_data.node_id(),
+                timestamp,
+            )
             .map_err(|e| Error::Protocol(e.into()))?;
         for past_sell_payment in past_sell_payments {
             let address_to_pay = past_sell_payment.0.payment_address;
@@ -1007,7 +1021,7 @@ impl BillService {
                 seller: past_sell_payment.0.seller,
                 sum: past_sell_payment.0.sum,
                 address_to_pay,
-                private_descriptor_to_spend: descriptor_to_spend.clone(),
+                private_descriptor_to_spend: past_sell_payment.3,
                 status: past_sell_payment.1,
                 payment_deadline: past_sell_payment.0.buying_deadline_timestamp,
             }));
@@ -1017,25 +1031,22 @@ impl BillService {
         let past_recourse_payments = chain
             .get_past_recourse_payments_for_node_id(
                 bill_keys,
+                caller_keys,
+                btc_network,
                 &caller_public_data.node_id(),
                 timestamp,
             )
             .map_err(|e| Error::Protocol(e.into()))?;
-        for past_sell_payment in past_recourse_payments {
-            let address_to_pay = self.bitcoin_client.get_address_to_pay(
-                &bill_keys.pub_key(),
-                &past_sell_payment.0.recourser.node_id().pub_key(),
-            )?;
-
+        for past_recourse_payment in past_recourse_payments {
             result.push(PastPaymentResult::Recourse(PastPaymentDataRecourse {
-                time_of_request: past_sell_payment.2,
-                recoursee: past_sell_payment.0.recoursee.into(),
-                recourser: past_sell_payment.0.recourser.into(),
-                sum: past_sell_payment.0.sum,
-                address_to_pay,
-                private_descriptor_to_spend: descriptor_to_spend.clone(),
-                status: past_sell_payment.1,
-                payment_deadline: past_sell_payment.0.recourse_deadline_timestamp,
+                time_of_request: past_recourse_payment.2,
+                recoursee: past_recourse_payment.0.recoursee.into(),
+                recourser: past_recourse_payment.0.recourser.into(),
+                sum: past_recourse_payment.0.sum,
+                address_to_pay: past_recourse_payment.0.payment_address,
+                private_descriptor_to_spend: past_recourse_payment.3,
+                status: past_recourse_payment.1,
+                payment_deadline: past_recourse_payment.0.recourse_deadline_timestamp,
             }));
         }
 

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -76,13 +76,13 @@ pub trait BillServiceApi: ServiceTraitBounds {
         caller_keys: &BcrKeys,
     ) -> Result<Vec<BitcreditBillResult>>;
 
-    /// Gets the combined bitcoin private key for a given bill
-    async fn get_combined_bitcoin_key_for_bill(
+    /// Gets the combined bitcoin private keys for a given bill
+    async fn get_combined_bitcoin_keys_for_bill(
         &self,
         bill_id: &BillId,
         caller_public_data: &BillParticipant,
         caller_keys: &BcrKeys,
-    ) -> Result<BillCombinedBitcoinKey>;
+    ) -> Result<Vec<BillCombinedBitcoinKey>>;
 
     /// Gets the detail for the given bill id
     async fn get_detail(

--- a/crates/bcr-ebill-api/src/service/bill_service/payment.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/payment.rs
@@ -3,21 +3,26 @@ use super::service::BillService;
 use crate::service::bill_service::{BillAction, BillServiceApi};
 use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_core::{
-    application::bill::PaymentState,
-    application::company::Company,
-    application::identity::{Identity, IdentityWithAll},
-    protocol::Timestamp,
-    protocol::blockchain::{
-        Blockchain,
-        bill::{
-            BillBlockchain, BillOpCode, BitcreditBill, OfferToSellWaitingForPayment,
-            RecourseWaitingForPayment,
-            participant::{BillAnonParticipant, BillIdentParticipant, BillParticipant},
-        },
-        identity::IdentityType,
+    application::{
+        bill::PaymentState,
+        company::Company,
+        identity::{Identity, IdentityWithAll},
     },
-    protocol::crypto::BcrKeys,
-    protocol::event::BillChainEvent,
+    protocol::{
+        Timestamp,
+        blockchain::{
+            Blockchain,
+            bill::{
+                BillBlockchain, BillOpCode, BitcreditBill, OfferToSellWaitingForPayment,
+                RecourseWaitingForPayment,
+                block::BillRequestToPayBlockData,
+                participant::{BillAnonParticipant, BillIdentParticipant, BillParticipant},
+            },
+            identity::IdentityType,
+        },
+        crypto::BcrKeys,
+        event::BillChainEvent,
+    },
 };
 use log::{debug, info};
 use std::collections::HashMap;
@@ -42,20 +47,27 @@ impl BillService {
             return Ok(());
         }
 
-        let holder_public_key = match bill.endorsee {
-            None => &bill.payee.node_id(),
-            Some(ref endorsee) => &endorsee.node_id(),
-        };
-        let address_to_pay = self
-            .bitcoin_client
-            .get_address_to_pay(&bill_keys.pub_key(), &holder_public_key.pub_key())?;
-        match self
-            .bitcoin_client
-            .check_payment_for_address(&address_to_pay, bill.sum.as_sat())
-            .await
+        if let Some(req_to_pay_block) =
+            chain.get_last_version_block_with_op_code(BillOpCode::RequestToPay)
         {
-            Ok(payment_state) => {
-                let should_update = match self
+            let Ok(block_data) =
+                req_to_pay_block.get_decrypted_block::<BillRequestToPayBlockData>(&bill_keys)
+            else {
+                log::error!(
+                    "Error checking bill payment for {bill_id} - could not decrypt req to pay block data"
+                );
+                return Ok(());
+            };
+            match self
+                .bitcoin_client
+                .check_payment_for_address(
+                    &block_data.payment_data.payment_address,
+                    bill.sum.as_sat(),
+                )
+                .await
+            {
+                Ok(payment_state) => {
+                    let should_update = match self
                     .store
                     .get_payment_state(bill_id)
                     .await {
@@ -66,29 +78,33 @@ impl BillService {
                         _ => true
                     };
 
-                if should_update {
-                    debug!(
-                        "Updating bill payment state for {bill_id} to {payment_state:?} and invalidating cache"
-                    );
-                    self.store
-                        .set_payment_state(bill_id, &payment_state)
-                        .await?;
-                    // invalidate bill cache, so payment state is updated on next fetch
-                    self.store.invalidate_bill_in_cache(bill_id).await?;
-                    // the bill is paid now - trigger notification
-                    if let PaymentState::PaidConfirmed(_) = payment_state
-                        && let Err(e) = self
-                            .trigger_is_paid_notification(identity, &chain, &bill_keys, &bill)
-                            .await
-                    {
-                        log::error!("Could not send is-paid notification for {bill_id}: {e}");
+                    if should_update {
+                        debug!(
+                            "Updating bill payment state for {bill_id} to {payment_state:?} and invalidating cache"
+                        );
+                        self.store
+                            .set_payment_state(bill_id, &payment_state)
+                            .await?;
+                        // invalidate bill cache, so payment state is updated on next fetch
+                        self.store.invalidate_bill_in_cache(bill_id).await?;
+                        // the bill is paid now - trigger notification
+                        if let PaymentState::PaidConfirmed(_) = payment_state
+                            && let Err(e) = self
+                                .trigger_is_paid_notification(identity, &chain, &bill_keys, &bill)
+                                .await
+                        {
+                            log::error!("Could not send is-paid notification for {bill_id}: {e}");
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                log::error!("Error checking payment for {bill_id}: {e}");
-            }
-        };
+                Err(e) => {
+                    log::error!("Error checking payment for {bill_id}: {e}");
+                }
+            };
+        } else {
+            log::warn!("Checking payment for {bill_id}, but there was no request to pay block!");
+        }
+
         Ok(())
     }
 
@@ -125,15 +141,10 @@ impl BillService {
         if let Ok(RecourseWaitingForPayment::Yes(payment_info)) =
             chain.is_last_request_to_recourse_block_waiting_for_payment(&bill_keys, now)
         {
-            // calculate payment address
-            let payment_address = self.bitcoin_client.get_address_to_pay(
-                &bill_keys.pub_key(),
-                &payment_info.recourser.node_id().pub_key(),
-            )?;
             // check if paid
             if let Ok(payment_state) = self
                 .bitcoin_client
-                .check_payment_for_address(&payment_address, payment_info.sum.as_sat())
+                .check_payment_for_address(&payment_info.payment_address, payment_info.sum.as_sat())
                 .await
             {
                 let should_update = match self

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -24,9 +24,10 @@ use bcr_ebill_core::application::identity::{Identity, IdentityWithAll};
 use bcr_ebill_core::protocol::PublicKey;
 use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::Timestamp;
+use bcr_ebill_core::protocol::blockchain::Block;
 use bcr_ebill_core::protocol::blockchain::bill::block::{
-    BillIdentParticipantBlockData, BillParticipantBlockData, BillRequestRecourseBlockData,
-    ContactType,
+    BillIdentParticipantBlockData, BillOfferToSellBlockData, BillParticipantBlockData,
+    BillRequestRecourseBlockData, BillRequestToPayBlockData, ContactType,
 };
 use bcr_ebill_core::protocol::blockchain::bill::chain::BillBlockPlaintextWrapper;
 use bcr_ebill_core::protocol::blockchain::bill::{
@@ -970,12 +971,12 @@ impl BillServiceApi for BillService {
             .collect())
     }
 
-    async fn get_combined_bitcoin_key_for_bill(
+    async fn get_combined_bitcoin_keys_for_bill(
         &self,
         bill_id: &BillId,
         caller_public_data: &BillParticipant,
         caller_keys: &BcrKeys,
-    ) -> Result<BillCombinedBitcoinKey> {
+    ) -> Result<Vec<BillCombinedBitcoinKey>> {
         validate_bill_id_network(bill_id)?;
         validate_node_id_network(&caller_public_data.node_id())?;
         let chain = self.blockchain_store.get_chain(bill_id).await?;
@@ -992,13 +993,67 @@ impl BillServiceApi for BillService {
             return Err(Error::NotFound);
         }
 
-        // The first key is always the bill key
-        let private_descriptor = self.bitcoin_client.get_combined_private_descriptor(
-            &BcrKeys::from_private_key(&bill_keys.get_private_key())
-                .get_bitcoin_private_key(get_config().bitcoin_network()),
-            &caller_keys.get_bitcoin_private_key(get_config().bitcoin_network()),
-        )?;
-        return Ok(BillCombinedBitcoinKey { private_descriptor });
+        let btc_network = get_config().bitcoin_network();
+        let mut res: Vec<BillCombinedBitcoinKey> = Vec::new();
+        // Iterate the chain and for each payment request block by the caller, create the descriptor and collect metadata
+        for block in chain.blocks().iter() {
+            match block.op_code() {
+                BillOpCode::RequestToPay => {
+                    let block_data: BillRequestToPayBlockData = block
+                        .get_decrypted_block(&bill_keys)
+                        .map_err(|e| Error::Protocol(e.into()))?;
+                    // we are requester
+                    if block_data.requester.node_id() == caller_public_data.node_id() {
+                        res.push(
+                            BillCombinedBitcoinKey::from_block_and_keys(
+                                block,
+                                &bill_keys,
+                                caller_keys,
+                                btc_network,
+                            )
+                            .map_err(Error::Protocol)?,
+                        );
+                    }
+                }
+                BillOpCode::OfferToSell => {
+                    let block_data: BillOfferToSellBlockData = block
+                        .get_decrypted_block(&bill_keys)
+                        .map_err(|e| Error::Protocol(e.into()))?;
+                    // we are requester
+                    if block_data.seller.node_id() == caller_public_data.node_id() {
+                        res.push(
+                            BillCombinedBitcoinKey::from_block_and_keys(
+                                block,
+                                &bill_keys,
+                                caller_keys,
+                                btc_network,
+                            )
+                            .map_err(Error::Protocol)?,
+                        );
+                    }
+                }
+                BillOpCode::RequestRecourse => {
+                    let block_data: BillRequestRecourseBlockData = block
+                        .get_decrypted_block(&bill_keys)
+                        .map_err(|e| Error::Protocol(e.into()))?;
+                    // we are requester
+                    if block_data.recourser.node_id() == caller_public_data.node_id() {
+                        res.push(
+                            BillCombinedBitcoinKey::from_block_and_keys(
+                                block,
+                                &bill_keys,
+                                caller_keys,
+                                btc_network,
+                            )
+                            .map_err(Error::Protocol)?,
+                        );
+                    }
+                }
+                _ => {} // nothing to do
+            };
+        }
+
+        return Ok(res);
     }
 
     async fn get_detail(

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -24,7 +24,7 @@ use bcr_ebill_core::{
         BillSellStatus, BillState, BillStatus, PaidData, PaymentState,
     },
     protocol::{
-        Address, BitcoinAddress, City, Country, Date, Name, Sum, Timestamp,
+        Address, City, Country, Date, Name, Sum, Timestamp,
         blockchain::bill::{
             BillBlock,
             block::{
@@ -44,7 +44,6 @@ use bcr_ebill_core::{
 };
 use external::{bitcoin::MockBitcoinClientApi, mint::MockMintClientApi};
 use service::BillService;
-use std::str::FromStr;
 use std::{collections::HashMap, sync::Arc};
 
 pub struct MockBillContext {
@@ -203,18 +202,6 @@ pub fn get_service(mut ctx: MockBillContext) -> BillService {
                 confirmations: 7,
                 tx_id: "80e4dc03b2ea934c97e265fa1855eba5c02788cb269e3f43a8e9a7bb0e114e2c".into(),
             }))
-        });
-    bitcoin_client
-        .expect_get_combined_private_descriptor()
-        .returning(|_, _| {
-            Ok(String::from(
-                "tr(cPHbchvqgi9ACegotAK34Hr17RokaeEqavMdsRw3XuWtghXBUYU2)#ujfsz6y4",
-            ))
-        });
-    bitcoin_client
-        .expect_get_address_to_pay()
-        .returning(|_, _| {
-            Ok(BitcoinAddress::from_str("tb1qssh7nk78mm35h75dg4th77zqz4qk3eay68krf9").unwrap())
         });
     ctx.nostr_contact_store
         .expect_by_node_id()

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -3787,7 +3787,7 @@ async fn endorse_bitcredit_bill_fails_if_payee_not_caller() {
 }
 
 #[tokio::test]
-async fn get_combined_bitcoin_key_for_bill_baseline() {
+async fn get_combined_bitcoin_keys_for_bill_baseline() {
     init_test_cfg();
     let mut ctx = get_ctx();
     let identity = get_baseline_identity();
@@ -3801,7 +3801,7 @@ async fn get_combined_bitcoin_key_for_bill_baseline() {
     let service = get_service(ctx);
 
     let res = service
-        .get_combined_bitcoin_key_for_bill(
+        .get_combined_bitcoin_keys_for_bill(
             &bill_id_test(),
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
@@ -3811,7 +3811,7 @@ async fn get_combined_bitcoin_key_for_bill_baseline() {
 }
 
 #[tokio::test]
-async fn get_combined_bitcoin_key_for_bill_err() {
+async fn get_combined_bitcoin_keys_for_bill_err() {
     let mut ctx = get_ctx();
     let mut bill = get_baseline_bill(&bill_id_test());
     bill.payee = BillParticipant::Ident(bill_identified_participant_only_node_id(NodeId::new(
@@ -3825,7 +3825,7 @@ async fn get_combined_bitcoin_key_for_bill_err() {
 
     let non_participant_keys = BcrKeys::new();
     let res = service
-        .get_combined_bitcoin_key_for_bill(
+        .get_combined_bitcoin_keys_for_bill(
             &bill_id_test(),
             &BillParticipant::Ident(bill_identified_participant_only_node_id(NodeId::new(
                 non_participant_keys.pub_key(),
@@ -7323,7 +7323,7 @@ async fn wrong_network_failures() {
 
     assert!(matches!(
         service
-            .get_combined_bitcoin_key_for_bill(&mainnet_bill_id, &participant, &BcrKeys::new())
+            .get_combined_bitcoin_keys_for_bill(&mainnet_bill_id, &participant, &BcrKeys::new())
             .await,
         Err(Error::Validation(ValidationError::Protocol(
             ProtocolValidationError::InvalidBillId
@@ -7331,7 +7331,7 @@ async fn wrong_network_failures() {
     ));
     assert!(matches!(
         service
-            .get_combined_bitcoin_key_for_bill(
+            .get_combined_bitcoin_keys_for_bill(
                 &bill_id_test(),
                 &mainnet_participant,
                 &BcrKeys::new()

--- a/crates/bcr-ebill-core/Cargo.toml
+++ b/crates/bcr-ebill-core/Cargo.toml
@@ -21,6 +21,7 @@ bitcoin.workspace = true
 bip39.workspace = true
 ecies.workspace = true
 nostr.workspace = true
+miniscript.workspace = true
 secp256k1 = { workspace = true, features = ["global-context"] }
 bcr-common.workspace = true
 url.workspace = true

--- a/crates/bcr-ebill-core/src/application/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/application/bill/mod.rs
@@ -2,14 +2,21 @@ use super::{
     contact::{LightBillIdentParticipant, LightBillParticipant},
     notification::Notification,
 };
-use crate::application::contact::LightBillSignatory;
 use crate::protocol::{
-    BitcoinAddress, City, Country, Date, File, PostalAddress, Sum, Timestamp,
-    blockchain::bill::{
-        BillHistory, BillOpCode, PaymentStatus,
-        participant::{BillIdentParticipant, BillParticipant, SignedBy},
+    BitcoinAddress, City, Country, Date, File, PostalAddress, ProtocolError, Sum, Timestamp,
+    blockchain::{
+        Block,
+        bill::{
+            BillBlock, BillHistory, BillOpCode, PaymentStatus,
+            participant::{BillIdentParticipant, BillParticipant, SignedBy},
+        },
+    },
+    crypto::{
+        BcrKeys,
+        btc::{calculate_tweak_hash_for_payment_request, get_combined_private_descriptor},
     },
 };
+use crate::{application::contact::LightBillSignatory, protocol::BlockId};
 use bcr_common::core::{BillId, NodeId};
 use serde::{Deserialize, Serialize};
 use strum::{EnumCount, EnumIter};
@@ -476,9 +483,42 @@ pub enum BillRole {
     Contingent,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BillCombinedBitcoinKey {
+    pub block_id: BlockId,
+    pub signing_timestamp: Timestamp,
+    pub payment_op: BillOpCode,
     pub private_descriptor: String,
+}
+
+impl BillCombinedBitcoinKey {
+    pub fn from_block_and_keys(
+        block: &BillBlock,
+        bill_keys: &BcrKeys,
+        caller_keys: &BcrKeys,
+        btc_network: bitcoin::Network,
+    ) -> Result<Self, ProtocolError> {
+        // calculate tweak
+        let tweak = calculate_tweak_hash_for_payment_request(
+            block.op_code().to_owned(),
+            &block.id(),
+            block.previous_hash(),
+        )?;
+        // create private descriptor
+        let private_descriptor = get_combined_private_descriptor(
+            &BcrKeys::from_private_key(&bill_keys.get_private_key())
+                .get_bitcoin_private_key(btc_network),
+            &caller_keys.get_bitcoin_private_key(btc_network),
+            &tweak,
+            btc_network,
+        )?;
+        Ok(Self {
+            block_id: block.id(),
+            signing_timestamp: block.timestamp,
+            payment_op: block.op_code().to_owned(),
+            private_descriptor,
+        })
+    }
 }
 
 #[derive(Debug)]

--- a/crates/bcr-ebill-core/src/protocol/base/hash.rs
+++ b/crates/bcr-ebill-core/src/protocol/base/hash.rs
@@ -31,6 +31,10 @@ impl Sha256Hash {
         // safe, because we only create and deserialize from base58 encoded sha256 hashes
         base58::decode(&self.0).expect("is base58 encoded")
     }
+
+    pub fn decode_to_array(&self) -> [u8; 32] {
+        self.decode().try_into().expect("decoded hash is 32 bytes")
+    }
 }
 
 impl Display for Sha256Hash {

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
@@ -8,7 +8,6 @@ use super::block::{
 };
 use super::{BillOpCode, RecourseWaitingForPayment};
 use super::{OfferToSellWaitingForPayment, RecoursePaymentInfo};
-use crate::protocol::Sha256Hash;
 use crate::protocol::Timestamp;
 use crate::protocol::blockchain::bill::block::BillRejectToBuyBlockData;
 use crate::protocol::blockchain::bill::participant::{
@@ -17,6 +16,10 @@ use crate::protocol::blockchain::bill::participant::{
 use crate::protocol::blockchain::bill::{BillHistory, BillHistoryBlock, PaymentStatus};
 use crate::protocol::blockchain::{Block, Blockchain, Error, borsh_to_json_value};
 use crate::protocol::crypto::BcrKeys;
+use crate::protocol::crypto::btc::{
+    calculate_tweak_hash_for_payment_request, get_combined_private_descriptor,
+};
+use crate::protocol::{BitcoinAddress, Sha256Hash};
 use bcr_common::core::NodeId;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use log::error;
@@ -351,9 +354,11 @@ impl BillBlockchain {
     pub fn get_past_sell_payments_for_node_id(
         &self,
         bill_keys: &BcrKeys,
+        caller_keys: &BcrKeys,
+        btc_network: bitcoin::Network,
         node_id: &NodeId,
         timestamp: Timestamp,
-    ) -> Result<Vec<(SellPaymentInfo, PaymentStatus, Timestamp)>> {
+    ) -> Result<Vec<(SellPaymentInfo, PaymentStatus, Timestamp, String)>> {
         let mut result = vec![];
         let blocks = self.blocks();
         let mut sell_pairs: Vec<(BillBlock, Option<BillBlock>)> = vec![];
@@ -419,6 +424,20 @@ impl BillBlockchain {
                 buying_deadline_timestamp: block_data_decrypted.payment_data.payment_deadline,
             };
 
+            // calculate tweak
+            let tweak = calculate_tweak_hash_for_payment_request(
+                offer_to_sell_block.op_code().to_owned(),
+                &offer_to_sell_block.id(),
+                offer_to_sell_block.previous_hash(),
+            )?;
+            let descriptor_to_spend = get_combined_private_descriptor(
+                &BcrKeys::from_private_key(&bill_keys.get_private_key())
+                    .get_bitcoin_private_key(btc_network),
+                &caller_keys.get_bitcoin_private_key(btc_network),
+                &tweak,
+                btc_network,
+            )?;
+
             match sell_pair.1 {
                 Some(reject_or_sell_block) => match reject_or_sell_block.op_code() {
                     BillOpCode::RejectToBuy => {
@@ -426,6 +445,7 @@ impl BillBlockchain {
                             payment_info,
                             PaymentStatus::Rejected(reject_or_sell_block.timestamp),
                             offer_to_sell_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                     BillOpCode::Sell => {
@@ -433,6 +453,7 @@ impl BillBlockchain {
                             payment_info,
                             PaymentStatus::Paid(reject_or_sell_block.timestamp),
                             offer_to_sell_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                     _ => (),
@@ -448,6 +469,7 @@ impl BillBlockchain {
                                 block_data_decrypted.payment_data.payment_deadline,
                             ),
                             offer_to_sell_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                 }
@@ -461,9 +483,11 @@ impl BillBlockchain {
     pub fn get_past_recourse_payments_for_node_id(
         &self,
         bill_keys: &BcrKeys,
+        caller_keys: &BcrKeys,
+        btc_network: bitcoin::Network,
         node_id: &NodeId,
         timestamp: Timestamp,
-    ) -> Result<Vec<(RecoursePaymentInfo, PaymentStatus, Timestamp)>> {
+    ) -> Result<Vec<(RecoursePaymentInfo, PaymentStatus, Timestamp, String)>> {
         let mut result = vec![];
         let blocks = self.blocks();
         let mut recourse_pairs: Vec<(BillBlock, Option<BillBlock>)> = vec![];
@@ -524,10 +548,25 @@ impl BillBlockchain {
                 recoursee: block_data_decrypted.recoursee,
                 recourser: block_data_decrypted.recourser,
                 sum: block_data_decrypted.payment_data.sum,
+                payment_address: block_data_decrypted.payment_data.payment_address,
                 reason: block_data_decrypted.recourse_reason,
                 block_id: request_to_recourse_block.id(),
                 recourse_deadline_timestamp: block_data_decrypted.payment_data.payment_deadline,
             };
+
+            // calculate tweak
+            let tweak = calculate_tweak_hash_for_payment_request(
+                request_to_recourse_block.op_code().to_owned(),
+                &request_to_recourse_block.id(),
+                request_to_recourse_block.previous_hash(),
+            )?;
+            let descriptor_to_spend = get_combined_private_descriptor(
+                &BcrKeys::from_private_key(&bill_keys.get_private_key())
+                    .get_bitcoin_private_key(btc_network),
+                &caller_keys.get_bitcoin_private_key(btc_network),
+                &tweak,
+                btc_network,
+            )?;
 
             match recourse_pair.1 {
                 Some(reject_or_recourse_block) => match reject_or_recourse_block.op_code() {
@@ -536,6 +575,7 @@ impl BillBlockchain {
                             payment_info,
                             PaymentStatus::Rejected(reject_or_recourse_block.timestamp),
                             request_to_recourse_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                     BillOpCode::Recourse => {
@@ -543,6 +583,7 @@ impl BillBlockchain {
                             payment_info,
                             PaymentStatus::Paid(reject_or_recourse_block.timestamp),
                             request_to_recourse_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                     _ => (),
@@ -558,6 +599,7 @@ impl BillBlockchain {
                                 block_data_decrypted.payment_data.payment_deadline,
                             ),
                             request_to_recourse_block.timestamp,
+                            descriptor_to_spend,
                         ));
                     }
                 }
@@ -614,15 +656,23 @@ impl BillBlockchain {
         req_to_pay: &BillBlock,
         bill_keys: &BcrKeys,
         current_timestamp: Timestamp,
-    ) -> Result<(bool, Timestamp)> {
+    ) -> Result<(bool, Timestamp, BitcoinAddress)> {
         let block_data_decrypted: BillRequestToPayBlockData =
             req_to_pay.get_decrypted_block(bill_keys)?;
 
         let deadline = block_data_decrypted.payment_data.payment_deadline;
         if current_timestamp.has_deadline_passed(&deadline) {
-            return Ok((true, deadline));
+            return Ok((
+                true,
+                deadline,
+                block_data_decrypted.payment_data.payment_address,
+            ));
         }
-        Ok((false, deadline))
+        Ok((
+            false,
+            deadline,
+            block_data_decrypted.payment_data.payment_address,
+        ))
     }
 
     /// Checks if the req to accept of the given block is expired, returning the result and
@@ -704,6 +754,7 @@ impl BillBlockchain {
                         recoursee: block_data_decrypted.recoursee,
                         recourser: block_data_decrypted.recourser,
                         sum: block_data_decrypted.payment_data.sum,
+                        payment_address: block_data_decrypted.payment_data.payment_address,
                         reason: block_data_decrypted.recourse_reason,
                         block_id: last_version_block.id(),
                         recourse_deadline_timestamp: block_data_decrypted

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/mod.rs
@@ -81,6 +81,7 @@ pub struct RecoursePaymentInfo {
     pub recourser: BillParticipantBlockData, // recourser can be anon
     pub recoursee: BillIdentParticipantBlockData, // recoursee has to be identified
     pub sum: Sum,
+    pub payment_address: BitcoinAddress,
     pub reason: BillRecourseReasonBlockData,
     pub block_id: BlockId,
     pub recourse_deadline_timestamp: Timestamp,

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
@@ -190,7 +190,7 @@ impl Validate for BillValidateActionData {
                             // only if the bill is not paid already - checked above
                             let is_expired = match self.mode {
                                 BillValidationActionMode::Deep(_) => {
-                                    let (is_expired, _) = self
+                                    let (is_expired, _, _) = self
                                         .blockchain
                                         .is_req_to_pay_block_payment_expired(
                                             req_to_pay,
@@ -436,7 +436,7 @@ impl BillValidateActionData {
                 {
                     let is_expired = match self.mode {
                         BillValidationActionMode::Deep(_) => {
-                            let (is_expired, _) = self
+                            let (is_expired, _, _) = self
                                 .blockchain
                                 .is_req_to_pay_block_payment_expired(
                                     req_to_pay_block,
@@ -570,7 +570,7 @@ impl BillValidateActionData {
                         .blockchain
                         .get_last_version_block_with_op_code(BillOpCode::RequestToPay)
                 {
-                    let (is_expired, _) = self
+                    let (is_expired, _, _) = self
                         .blockchain
                         .is_req_to_pay_block_payment_expired(
                             req_to_pay,

--- a/crates/bcr-ebill-core/src/protocol/blockchain/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/mod.rs
@@ -42,6 +42,10 @@ pub enum Error {
     #[error("Block's signature does not match the signer")]
     BlockSignatureDoesNotMatchSigner,
 
+    /// If a block operation is not valid for an operation
+    #[error("Block operation not valid for this operation")]
+    InvalidBlockOp,
+
     /// Errors stemming from cryptography, such as converting keys, encryption and decryption
     #[error("Secp256k1Cryptography error: {0}")]
     Secp256k1Cryptography(#[from] crypto::Error),

--- a/crates/bcr-ebill-core/src/protocol/crypto/btc.rs
+++ b/crates/bcr-ebill-core/src/protocol/crypto/btc.rs
@@ -1,0 +1,425 @@
+use super::{Error, Result};
+use crate::protocol::{
+    BitcoinAddress, BlockId, PublicKey, Sha256Hash, blockchain::bill::BillOpCode,
+};
+use bitcoin::secp256k1::Scalar;
+
+/// Get p2tr address for the given keys
+pub fn get_address_to_pay(
+    bill_public_key: &PublicKey,
+    holder_public_key: &PublicKey,
+    tweak_hash: &Sha256Hash,
+    network: bitcoin::Network,
+) -> Result<BitcoinAddress> {
+    let combined_key = bill_public_key
+        .combine(holder_public_key)
+        .map_err(Error::from)?;
+
+    // tweak key with the given tweak hash
+    let tweak = Scalar::from_be_bytes(tweak_hash.decode_to_array())
+        .map_err(|e| Error::Tweak(e.to_string()))?;
+    let tweaked_key = combined_key.add_exp_tweak(secp256k1::global::SECP256K1, &tweak)?;
+
+    let (x_only_pub_key, _parity) = tweaked_key.x_only_public_key();
+
+    Ok(
+        bitcoin::Address::p2tr(secp256k1::global::SECP256K1, x_only_pub_key, None, network)
+            .as_unchecked()
+            .to_owned(),
+    )
+}
+
+/// Get tr descriptor with wif for the given keys
+pub fn get_combined_private_descriptor(
+    pkey: &bitcoin::PrivateKey,
+    pkey_to_combine: &bitcoin::PrivateKey,
+    tweak_hash: &Sha256Hash,
+    network: bitcoin::Network,
+) -> Result<String> {
+    let combined_key = pkey.inner.add_tweak(&Scalar::from(pkey_to_combine.inner))?;
+
+    // tweak key with the given tweak hash
+    let tweak = Scalar::from_be_bytes(tweak_hash.decode_to_array())
+        .map_err(|e| Error::Tweak(e.to_string()))?;
+    let tweaked_key = combined_key.add_tweak(&tweak)?;
+
+    let priv_key = bitcoin::PrivateKey::new(tweaked_key, network);
+    let single = miniscript::descriptor::SinglePriv {
+        key: priv_key,
+        origin: None,
+    };
+    let desc_seckey = miniscript::descriptor::DescriptorSecretKey::Single(single);
+    let desc_pubkey = desc_seckey
+        .to_public(secp256k1::global::SECP256K1)
+        .map_err(|e| Error::BtcDescriptor(e.to_string()))?;
+    let kmap = miniscript::descriptor::KeyMap::from_iter(std::iter::once((
+        desc_pubkey.clone(),
+        desc_seckey,
+    )));
+    let desc = miniscript::Descriptor::new_tr(desc_pubkey, None)
+        .map_err(|e| Error::BtcDescriptor(e.to_string()))?;
+    Ok(desc.to_string_with_secret(&kmap))
+}
+
+/// Calculates the tweak for the payment address with the previous hash, the block id and a tag based on the
+/// type of payment
+pub fn calculate_tweak_hash_for_payment_request(
+    payment_op: BillOpCode,
+    block_id: &BlockId,
+    previous_hash: &Sha256Hash,
+) -> Result<Sha256Hash> {
+    let mut input = Vec::new();
+    let tag = match payment_op {
+        BillOpCode::RequestToPay => "bcr/request-to-pay/v1",
+        BillOpCode::OfferToSell => "bcr/offer-to-sell/v1",
+        BillOpCode::RequestRecourse => "bcr/request-recourse/v1",
+        _ => return Err(Error::Tweak("Invalid operation".to_owned())),
+    };
+    input.extend_from_slice(tag.as_bytes());
+    input.extend_from_slice(&block_id.inner().to_be_bytes());
+    input.extend_from_slice(&previous_hash.decode());
+
+    let tweak_hash = Sha256Hash::from_bytes(&input);
+    Ok(tweak_hash)
+}
+
+/// Calculates the payment address with the given values and validates it against the given address
+pub fn validate_payment_address_for_payment_request(
+    payment_op: BillOpCode,
+    block_id: &BlockId,
+    previous_hash: &Sha256Hash,
+    bill_pub_key: &PublicKey,
+    caller_pub_key: &PublicKey,
+    btc_network: bitcoin::Network,
+    address_to_check: &BitcoinAddress,
+) -> Result<()> {
+    let addr = get_address_to_pay(
+        bill_pub_key,
+        caller_pub_key,
+        &calculate_tweak_hash_for_payment_request(payment_op, block_id, previous_hash)?,
+        btc_network,
+    )?;
+    if &addr != address_to_check {
+        Err(super::Error::BtcAddress("Addresses don't match".to_owned()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::{AddressType, Network, PrivateKey};
+    use miniscript::{Descriptor, DescriptorPublicKey};
+    use secp256k1::{SecretKey, global::SECP256K1};
+
+    use super::*;
+
+    fn test_privkeys(network: Network) -> (PrivateKey, PrivateKey) {
+        let sk1 = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let sk2 = SecretKey::from_slice(&[2u8; 32]).unwrap();
+
+        (PrivateKey::new(sk1, network), PrivateKey::new(sk2, network))
+    }
+
+    fn test_pubkeys(network: Network) -> (PublicKey, PublicKey) {
+        let (pk1, pk2) = test_privkeys(network);
+        (
+            pk1.public_key(SECP256K1).inner,
+            pk2.public_key(SECP256K1).inner,
+        )
+    }
+
+    #[test]
+    fn address_is_taproot_on_expected_network() {
+        let network = Network::Testnet;
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+
+        let tweak_hash =
+            Sha256Hash::new("1111111111111111111111111111111111111111111111111111111111111111");
+
+        let addr = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        assert_eq!(
+            addr.assume_checked_ref().address_type(),
+            Some(AddressType::P2tr)
+        );
+        assert!(addr.is_valid_for_network(network));
+        assert!(addr.assume_checked_ref().to_string().starts_with("tb1p"));
+    }
+
+    #[test]
+    fn same_keys_and_same_tweak_give_same_address_and_descriptor() {
+        let network = Network::Testnet;
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+        let (bill_priv, holder_priv) = test_privkeys(network);
+
+        let tweak_hash =
+            Sha256Hash::new("1111111111111111111111111111111111111111111111111111111111111111");
+
+        let addr1 = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+        let addr2 = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        let desc1 = get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash, network)
+            .unwrap();
+        let desc2 = get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash, network)
+            .unwrap();
+
+        assert_eq!(addr1, addr2);
+        assert_eq!(desc1, desc2);
+    }
+
+    #[test]
+    fn different_tweaks_give_different_addresses_and_descriptors() {
+        let network = Network::Testnet;
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+        let (bill_priv, holder_priv) = test_privkeys(network);
+
+        let tweak_hash_1 =
+            Sha256Hash::new("1111111111111111111111111111111111111111111111111111111111111111");
+        let tweak_hash_2 =
+            Sha256Hash::new("2222222222222222222222222222222222222222222222222222222222222222");
+
+        let addr1 = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash_1, network).unwrap();
+        let addr2 = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash_2, network).unwrap();
+
+        let desc1 =
+            get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash_1, network)
+                .unwrap();
+        let desc2 =
+            get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash_2, network)
+                .unwrap();
+
+        assert_ne!(addr1, addr2);
+        assert_ne!(desc1, desc2);
+    }
+
+    #[test]
+    fn private_descriptor_gives_access_to_same_address() {
+        let network = Network::Testnet;
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+        let (bill_priv, holder_priv) = test_privkeys(network);
+
+        let tweak_hash =
+            Sha256Hash::new("1111111111111111111111111111111111111111111111111111111111111111");
+
+        let address = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        let descriptor =
+            get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash, network)
+                .unwrap();
+
+        let (parsed_desc, _kmap) =
+            Descriptor::<DescriptorPublicKey>::parse_descriptor(SECP256K1, &descriptor).unwrap();
+        let address_from_descriptor = parsed_desc
+            .at_derivation_index(0)
+            .unwrap()
+            .address(network)
+            .unwrap();
+
+        assert_eq!(address.assume_checked(), address_from_descriptor);
+    }
+
+    #[test]
+    fn calculates_tweak_hash_for_request_to_pay() {
+        let block_id = BlockId::first().add(1);
+        let previous_hash = Sha256Hash::from_bytes(b"previous-hash");
+
+        let result1 = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id,
+            &previous_hash,
+        )
+        .expect("works");
+        let result2 = calculate_tweak_hash_for_payment_request(
+            BillOpCode::OfferToSell,
+            &block_id,
+            &previous_hash,
+        )
+        .expect("works");
+        let result3 = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestRecourse,
+            &block_id,
+            &previous_hash,
+        )
+        .expect("works");
+        assert_ne!(result1, result2);
+        assert_ne!(result2, result3);
+
+        let result_invalid =
+            calculate_tweak_hash_for_payment_request(BillOpCode::Issue, &block_id, &previous_hash);
+
+        assert!(matches!(result_invalid, Err(Error::Tweak(_))));
+    }
+
+    #[test]
+    fn hash_depends_on_block_id_and_previous_hash() {
+        let previous_hash_1 = Sha256Hash::from_bytes(b"previous-hash-1");
+        let previous_hash_2 = Sha256Hash::from_bytes(b"previous-hash-2");
+        let block_id_1 = BlockId::first();
+        let block_id_2 = BlockId::first().add(2);
+
+        let hash_a = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id_1,
+            &previous_hash_1,
+        )
+        .unwrap();
+
+        let hash_b = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id_2,
+            &previous_hash_1,
+        )
+        .unwrap();
+
+        let hash_c = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id_1,
+            &previous_hash_2,
+        )
+        .unwrap();
+
+        assert_ne!(hash_a, hash_b);
+        assert_ne!(hash_a, hash_c);
+    }
+
+    #[test]
+    fn validate_payment_address_accepts_matching_address() {
+        let network = Network::Testnet;
+        let block_id = BlockId::first().add(6);
+        let previous_hash =
+            Sha256Hash::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+
+        let tweak_hash = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id,
+            &previous_hash,
+        )
+        .unwrap();
+
+        let address = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        let result = validate_payment_address_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id,
+            &previous_hash,
+            &bill_pub,
+            &holder_pub,
+            network,
+            &address,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_payment_address_rejects_non_matching_address() {
+        let network = Network::Testnet;
+        let block_id = BlockId::first().add(6);
+        let previous_hash =
+            Sha256Hash::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+
+        let wrong_address = BitcoinAddress::from_str(
+            "tb1p98hgytlecct3qzfmd9qnf05q03ql032xvpdg9kpwfftej2t95t8s0eyx5k",
+        )
+        .unwrap();
+
+        let err = validate_payment_address_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id,
+            &previous_hash,
+            &bill_pub,
+            &holder_pub,
+            network,
+            &wrong_address,
+        )
+        .expect_err("wrong address should fail");
+
+        match err {
+            super::Error::BtcAddress(msg) => assert!(msg.contains("don't match")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_payment_address_rejects_when_op_changes() {
+        let network = Network::Testnet;
+        let block_id = BlockId::first().add(6);
+        let previous_hash =
+            Sha256Hash::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+
+        let tweak_hash = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestToPay,
+            &block_id,
+            &previous_hash,
+        )
+        .unwrap();
+
+        let address = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        let err = validate_payment_address_for_payment_request(
+            BillOpCode::OfferToSell,
+            &block_id,
+            &previous_hash,
+            &bill_pub,
+            &holder_pub,
+            network,
+            &address,
+        )
+        .expect_err("different op should fail");
+
+        match err {
+            super::Error::BtcAddress(msg) => assert!(msg.contains("don't match")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn full_flow_tweak_address_descriptor_validation_all_match() {
+        let network = Network::Testnet;
+        let block_id = BlockId::first().add(6);
+        let previous_hash =
+            Sha256Hash::new("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+        let (bill_pub, holder_pub) = test_pubkeys(network);
+        let (bill_priv, holder_priv) = test_privkeys(network);
+
+        let tweak_hash = calculate_tweak_hash_for_payment_request(
+            BillOpCode::RequestRecourse,
+            &block_id,
+            &previous_hash,
+        )
+        .unwrap();
+
+        let address = get_address_to_pay(&bill_pub, &holder_pub, &tweak_hash, network).unwrap();
+
+        let descriptor =
+            get_combined_private_descriptor(&bill_priv, &holder_priv, &tweak_hash, network)
+                .unwrap();
+
+        let (parsed_desc, _kmap) =
+            Descriptor::<DescriptorPublicKey>::parse_descriptor(SECP256K1, &descriptor).unwrap();
+        let address_from_descriptor = parsed_desc
+            .at_derivation_index(0)
+            .unwrap()
+            .address(network)
+            .unwrap();
+
+        assert_eq!(address.clone().assume_checked(), address_from_descriptor);
+
+        validate_payment_address_for_payment_request(
+            BillOpCode::RequestRecourse,
+            &block_id,
+            &previous_hash,
+            &bill_pub,
+            &holder_pub,
+            network,
+            &address,
+        )
+        .unwrap();
+    }
+}

--- a/crates/bcr-ebill-core/src/protocol/crypto/mod.rs
+++ b/crates/bcr-ebill-core/src/protocol/crypto/mod.rs
@@ -2,6 +2,7 @@ use secp256k1::{PublicKey, SecretKey};
 use thiserror::Error;
 
 mod bcrkeys;
+pub mod btc;
 
 pub type Result<T> = std::result::Result<T, Error>;
 pub use bcrkeys::BcrKeys;
@@ -25,6 +26,18 @@ pub enum Error {
     /// Errors stemming from parsing the recovery id
     #[error("Parse recovery id error: {0}")]
     ParseRecoveryId(#[from] std::num::ParseIntError),
+
+    /// all errors originating from dealing with bitcoin descriptors
+    #[error("Bitcoin Descriptor error: {0}")]
+    BtcDescriptor(String),
+
+    /// all errors originating from dealing with bitcoin addresses
+    #[error("Bitcoin Address error: {0}")]
+    BtcAddress(String),
+
+    /// all errors originating from dealing with tweaks
+    #[error("External Bitcoin Tweak error: {0}")]
+    Tweak(String),
 
     #[error("Mnemonic seed phrase error {0}")]
     Mnemonic(#[from] bip39::Error),

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
@@ -4,18 +4,23 @@ use crate::handler::public_chain_helpers::{
 use crate::{Error, Result};
 use async_trait::async_trait;
 use bcr_common::core::BillId;
+use bcr_ebill_api::get_config;
 use bcr_ebill_api::service::transport_service::transport_client::TransportClientApi;
 use bcr_ebill_core::application::ServiceTraitBounds;
 use bcr_ebill_core::protocol::BlockId;
 use bcr_ebill_core::protocol::Validate;
 use bcr_ebill_core::protocol::blockchain::bill::BillOpCode;
-use bcr_ebill_core::protocol::blockchain::bill::block::BillIssueBlockData;
+use bcr_ebill_core::protocol::blockchain::bill::block::{
+    BillIssueBlockData, BillOfferToSellBlockData, BillRequestRecourseBlockData,
+    BillRequestToPayBlockData,
+};
 use bcr_ebill_core::protocol::blockchain::bill::{BillBlock, BillBlockchain};
 use bcr_ebill_core::protocol::blockchain::bill::{
     BillValidateActionData, BillValidationActionMode,
 };
 use bcr_ebill_core::protocol::blockchain::{Block, Blockchain, BlockchainType};
 use bcr_ebill_core::protocol::crypto::BcrKeys;
+use bcr_ebill_core::protocol::crypto::btc::validate_payment_address_for_payment_request;
 use bcr_ebill_persistence::bill::BillChainStoreApi;
 use bcr_ebill_persistence::bill::BillStoreApi;
 use log::{debug, error, info, warn};
@@ -379,6 +384,7 @@ impl BillChainEventProcessor {
         // create a clone of the chain for validating the bill action later, since the chain
         // will be mutated with the integrity checks
         let chain_clone_for_validation = chain.clone();
+        let latest_block_before_add = chain_clone_for_validation.get_latest_block();
 
         // first, do cheap integrity checks (mutates chain in-memory)
         if !chain.try_add_block(block.clone()) {
@@ -398,6 +404,56 @@ impl BillChainEventProcessor {
                 );
                 return Err(Error::Blockchain(e.to_string()));
             }
+        };
+
+        // validate payment address for payment requests
+        match block.op_code() {
+            BillOpCode::RequestToPay => {
+                let data: BillRequestToPayBlockData = block
+                    .get_decrypted_block(bill_keys)
+                    .map_err(|e| Error::Blockchain(e.to_string()))?;
+                validate_payment_address_for_payment_request(
+                    block.op_code().to_owned(),
+                    &block.id(),
+                    latest_block_before_add.hash(),
+                    &bill_keys.pub_key(),
+                    &signer.pub_key(),
+                    get_config().bitcoin_network(),
+                    &data.payment_data.payment_address,
+                )
+                .map_err(|e| Error::Blockchain(e.to_string()))?;
+            }
+            BillOpCode::OfferToSell => {
+                let data: BillOfferToSellBlockData = block
+                    .get_decrypted_block(bill_keys)
+                    .map_err(|e| Error::Blockchain(e.to_string()))?;
+                validate_payment_address_for_payment_request(
+                    block.op_code().to_owned(),
+                    &block.id(),
+                    latest_block_before_add.hash(),
+                    &bill_keys.pub_key(),
+                    &signer.pub_key(),
+                    get_config().bitcoin_network(),
+                    &data.payment_data.payment_address,
+                )
+                .map_err(|e| Error::Blockchain(e.to_string()))?;
+            }
+            BillOpCode::RequestRecourse => {
+                let data: BillRequestRecourseBlockData = block
+                    .get_decrypted_block(bill_keys)
+                    .map_err(|e| Error::Blockchain(e.to_string()))?;
+                validate_payment_address_for_payment_request(
+                    block.op_code().to_owned(),
+                    &block.id(),
+                    latest_block_before_add.hash(),
+                    &bill_keys.pub_key(),
+                    &signer.pub_key(),
+                    get_config().bitcoin_network(),
+                    &data.payment_data.payment_address,
+                )
+                .map_err(|e| Error::Blockchain(e.to_string()))?;
+            }
+            _ => {} // nothing to do for non-payment-requests
         };
 
         // then, validate the bill action

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -26,6 +26,7 @@
             <button type="button" id="attach_identity_profile_picture">Attach to current identity profile picture</button>
             <button type="button" id="attach_contact_avatar">Attach to current contact avatar</button>
             <button type="button" id="attach_company_proof">Attach to current company proof</button>
+            <button type="button" id="remove_company_proof">Remove current company proof</button>
             <div>Bill creation already uses the current file upload id automatically.</div>
         </div>
         <div>
@@ -233,6 +234,7 @@
             <button type="button" id="bill_balances">Fetch Balances</button>
             <button type="button" id="bill_history">Fetch Bill History</button>
             <button type="button" id="bill_search">Search Bills</button>
+            <button type="button" id="bitcoin_keys">Get BTC Keys</button>
             <button type="button" id="sync_bill_chain">Sync Bill Chain</button>
             <div>Execution Time: <span id="bill_execution_time"></div>
             <div>Results: <span id="bill_results"></div>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -5,6 +5,7 @@ document.getElementById("fileInput").addEventListener("change", uploadFile);
 document.getElementById("attach_identity_profile_picture").addEventListener("click", attachIdentityProfilePicture);
 document.getElementById("attach_contact_avatar").addEventListener("click", attachContactAvatar);
 document.getElementById("attach_company_proof").addEventListener("click", attachCompanyProof);
+document.getElementById("remove_company_proof").addEventListener("click", removeCompanyProof);
 document.getElementById("build_blossom_url").addEventListener("click", buildBlossomUrl);
 document.getElementById("open_blossom_url").addEventListener("click", openBlossomUrl);
 
@@ -79,6 +80,7 @@ document.getElementById("bill_test_self_drafted").addEventListener("click", trig
 document.getElementById("bill_test_promissory").addEventListener("click", triggerBill.bind(null, 0, false));
 document.getElementById("bill_test_promissory_blank").addEventListener("click", triggerBill.bind(null, 0, true));
 document.getElementById("clear_bill_cache").addEventListener("click", clearBillCache);
+document.getElementById("bitcoin_keys").addEventListener("click", getBitcoinKeys);
 document.getElementById("sync_bill_chain").addEventListener("click", syncBillChain);
 document.getElementById("dev_mode_get_bill_chain").addEventListener("click", devModeGetBillChain);
 document.getElementById("share_bill_with_court").addEventListener("click", shareBillWithCourt);
@@ -119,9 +121,9 @@ let config = {
   bitcoin_network: "testnet",
   esplora_base_url: "https://esplora.minibill.tech",
   // nostr_relays: ["ws://localhost:8080"],
-  nostr_relays: ["wss://bcr-relay-dev.minibill.tech"],
+  nostr_relays: ["wss://relay.wildcat0.clowder-dev.minibill.tech"],
   // this would be the default with current relay config
-  blossom_servers: ["https://bcr-relay-dev.minibill.tech"],
+  blossom_servers: ["https://relay.wildcat0.clowder-dev.minibill.tech"],
   // if set to true we will drop DMs from nostr that we don't have in contacts
   nostr_only_known_contacts: false,
   job_runner_initial_delay_seconds: 5,
@@ -330,6 +332,18 @@ async function attachCompanyProof() {
     buildBlossomUrl();
   }
   console.log("attached uploaded file as company proof:", company);
+}
+
+async function removeCompanyProof() {
+  const id = document.getElementById("company_id").value;
+  fail_on_error(await window.companyApi.edit({
+    id,
+    proof_of_registration_file_upload_id: undefined,
+    postal_address: {}
+  }));
+
+  const company = success_or_fail(await window.companyApi.detail(id));
+  console.log("removed uploaded file as company proof:", company);
 }
 
 function buildBlossomUrl() {
@@ -842,6 +856,15 @@ async function fetchBillHistory() {
 async function clearBillCache() {
   let measured = measure(async () => {
     return success_or_fail(await window.billApi.clear_bill_cache());
+  });
+  await measured();
+}
+
+async function getBitcoinKeys() {
+  let bill_id = document.getElementById("bill_id").value;
+  console.log("getBitcoinKeys", bill_id);
+  let measured = measure(async () => {
+    return success_or_fail(await window.billApi.bitcoin_keys(bill_id));
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -167,16 +167,16 @@ impl Bill {
         TSResult::res_to_js(res)
     }
 
-    #[wasm_bindgen(unchecked_return_type = "TSResult<BillCombinedBitcoinKeyWeb>")]
-    pub async fn bitcoin_key(&self, id: &str) -> JsValue {
-        let res: Result<BillCombinedBitcoinKeyWeb> = async {
+    #[wasm_bindgen(unchecked_return_type = "TSResult<BillCombinedBitcoinKeyWeb[]>")]
+    pub async fn bitcoin_keys(&self, id: &str) -> JsValue {
+        let res: Result<Vec<BillCombinedBitcoinKeyWeb>> = async {
             let bill_id = BillId::from_str(id).map_err(ProtocolValidationError::from)?;
             let (caller_public_data, caller_keys) = get_signer_public_data_and_keys().await?;
-            let combined_key = get_ctx()
+            let combined_keys = get_ctx()
                 .bill_service
-                .get_combined_bitcoin_key_for_bill(&bill_id, &caller_public_data, &caller_keys)
+                .get_combined_bitcoin_keys_for_bill(&bill_id, &caller_public_data, &caller_keys)
                 .await?;
-            Ok(combined_key.into())
+            Ok(combined_keys.into_iter().map(|ck| ck.into()).collect())
         }
         .await;
         TSResult::res_to_js(res)

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -146,6 +146,11 @@ pub struct RejectActionBillPayload {
 #[derive(Tsify, Debug, Clone, Serialize)]
 #[tsify(into_wasm_abi)]
 pub struct BillCombinedBitcoinKeyWeb {
+    #[tsify(type = "number")]
+    pub block_id: BlockId,
+    #[tsify(type = "number")]
+    pub signing_timestamp: Timestamp,
+    pub payment_op: BillOpCodeWeb,
     pub private_descriptor: String,
 }
 
@@ -159,6 +164,9 @@ pub struct ResyncBillPayload {
 impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {
     fn from(val: BillCombinedBitcoinKey) -> Self {
         BillCombinedBitcoinKeyWeb {
+            block_id: val.block_id,
+            signing_timestamp: val.signing_timestamp,
+            payment_op: val.payment_op.into(),
             private_descriptor: val.private_descriptor,
         }
     }

--- a/docs/esplora.md
+++ b/docs/esplora.md
@@ -21,7 +21,7 @@ For local regtest, set the config to use `regtest` as a bitcoin network:
     log_level: "debug",
     bitcoin_network: "regtest",
     esplora_base_urls: ["http://localhost:8094"],
-    nostr_relays: ["wss://bcr-relay-dev.minibill.tech"],
+    nostr_relays: ["wss://relay.wildcat0.clowder-dev.minibill.tech"],
     job_runner_initial_delay_seconds: 1,
     job_runner_check_interval_seconds: 60,
   };

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -55,7 +55,7 @@ import * as wasm from '../pkg/bcr_ebill_wasm.js';
 async function start() {
     let config = {
         bitcoin_network: "testnet",
-        nostr_relays: ["wss://bcr-relay-dev.minibill.tech"],
+        nostr_relays: ["wss://relay.wildcat0.clowder-dev.minibill.tech"],
         surreal_db_connection: "indxdb://default",
         job_runner_initial_delay_seconds: 1,
         job_runner_check_interval_seconds: 60,
@@ -266,7 +266,7 @@ import * as wasm from '@bitcredit/bcr-ebill-wasm';
 async function start() {
     let config = {
         bitcoin_network: "testnet",
-        nostr_relays: ["wss://bcr-relay-dev.minibill.tech"],
+        nostr_relays: ["wss://relay.wildcat0.clowder-dev.minibill.tech"],
         surreal_db_connection: "indxdb://default",
         job_runner_initial_delay_seconds: 1,
   job_runner_check_interval_seconds: 60,

--- a/docs/wasm_configuration.md
+++ b/docs/wasm_configuration.md
@@ -31,7 +31,7 @@ It contains the following options:
             "https://esplora.minibill.tech",
             "https://blockstream.info"
         ],
-        nostr_relays: ["wss://bcr-relay-dev.minibill.tech"],
+        nostr_relays: ["wss://relay.wildcat0.clowder-dev.minibill.tech"],
         surreal_db_connection: "indxdb://default",
         job_runner_initial_delay_seconds: 1,
         job_runner_check_interval_seconds: 60,


### PR DESCRIPTION
## 📝 Description

* Use and validate unique payment addresses per payment request (breaking Bills on a protocol level)
* Changed `get_combined_bitcoin_key_for_bill` to `get_combined_bitcoin_keys_for_bill`, returning all bitcoin keys for payments within this bill for the caller
* Update local dev defaults for relay

Relates to #774 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. sell a bill multiple times, make sure that each time, the address is different
3. same for req to pay and recourse

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #774 

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
