### PR TITLE
Maturity Date Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.6
+
+* Fix that request to pay can happen from maturity day 00:00:00 onwards
+* Fix a bug where bill cache didn't update when ticking over to maturity date
+
 # 0.5.5
 
 * Request to pay can only be done after maturity date end-of-day

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/BitcreditProtocol/Bitcredit-Core"

--- a/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/data_fetching.rs
@@ -259,6 +259,7 @@ impl BillService {
         if has_mint_requests {
             bill_mint_state = BillMintState::Requested;
         }
+        let is_mature = current_timestamp >= bill.maturity_date.to_timestamp().start_of_day();
         let mut paid = false;
         let mut requested_to_pay = false;
         let mut rejected_to_pay = false;
@@ -853,6 +854,7 @@ impl BillService {
             redeemed_funds_available,
             has_requested_funds,
             last_block_time,
+            is_mature,
         };
 
         let participants = BillParticipants {
@@ -1059,6 +1061,14 @@ impl BillService {
         current_timestamp: Timestamp,
     ) -> Result<bool> {
         let mut invalidate_and_recalculate = false;
+
+        // if bill was not mature before, but becomes mature now - recalculate
+        if !bill.status.is_mature
+            && current_timestamp >= bill.data.maturity_date.to_timestamp().start_of_day()
+        {
+            invalidate_and_recalculate = true;
+        }
+
         let acceptance = &bill.status.acceptance;
         // if it was requested, but not "finished" (accepted, rejected, or expired), we have to
         // check if the deadline expired and recalculate

--- a/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/test_utils.rs
@@ -148,6 +148,7 @@ pub fn get_baseline_cached_bill(id: BillId) -> BitcreditBillResult {
             redeemed_funds_available: false,
             has_requested_funds: false,
             last_block_time: test_ts(),
+            is_mature: false,
         },
         state: BillState {
             mint: BillMintState::None,

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -828,6 +828,7 @@ async fn get_bills_baseline_from_cache() {
     chain_bill.payee =
         BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap());
     let mut bill = get_baseline_cached_bill(bill_id_test());
+    bill.data.maturity_date = Date::new("2099-07-01").unwrap();
     // make sure the local identity is part of the bill
     bill.participants.payee =
         BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap());
@@ -1124,6 +1125,7 @@ async fn get_detail_bill_baseline_from_cache() {
     let mut ctx = get_ctx();
     let identity = get_baseline_identity();
     let mut bill = get_baseline_cached_bill(bill_id_test());
+    bill.data.maturity_date = Date::new("2099-07-01").unwrap();
     // make sure the local identity is part of the bill
     bill.participants.drawee = BillIdentParticipant::new(identity.identity.clone()).unwrap();
     let drawee_node_id = bill.participants.drawee.node_id.clone();
@@ -6497,6 +6499,7 @@ fn check_req_for_expiration_baseline() {
             Timestamp::new(1531593928).unwrap() + PAYMENT_DEADLINE_SECONDS,
         ),
     };
+    bill_payment.status.is_mature = true;
 
     // true, because payment deadline was several days ago
     assert!(
@@ -6518,19 +6521,39 @@ fn check_req_for_expiration_baseline() {
             .check_requests_for_expiration(&bill_payment, Timestamp::new(1431593928).unwrap())
             .unwrap()
     );
-    bill_payment.data.maturity_date = Date::new("2018-07-15").unwrap(); // before ts
-    // false, because maturity date is before the deadline
+    bill_payment.data.maturity_date = Date::new("2018-07-15").unwrap();
+    bill_payment.status.is_mature = false;
+    // false, because not mature and before maturity date
     assert!(
         !service
             .check_requests_for_expiration(&bill_payment, Timestamp::new(1531593929).unwrap())
             .unwrap()
     );
-    // true, because after maturity date
+    // true, because on maturity date and bill was not mature before
+    assert!(
+        service
+            .check_requests_for_expiration(&bill_payment, Timestamp::new(1531653929).unwrap())
+            .unwrap()
+    );
+    // true, because exactly maturity date start of day (00:00:00)
+    assert!(
+        service
+            .check_requests_for_expiration(&bill_payment, Timestamp::new(1531612800).unwrap())
+            .unwrap()
+    );
+    // false, because exactly one second before maturity date start of day (23:59:59)
+    assert!(
+        !service
+            .check_requests_for_expiration(&bill_payment, Timestamp::new(1531612799).unwrap())
+            .unwrap()
+    );
+    // true, because after maturity date and bill was not mature before
     assert!(
         service
             .check_requests_for_expiration(&bill_payment, Timestamp::new(1531978728).unwrap())
             .unwrap()
     );
+    bill_payment.status.is_mature = true;
     bill_payment.current_waiting_state = Some(BillCurrentWaitingState::Payment(
         BillWaitingForPaymentState {
             payer: empty_bill_identified_participant(),
@@ -6599,6 +6622,7 @@ fn check_req_for_expiration_baseline() {
             Timestamp::new(1531593928).unwrap() + ACCEPT_DEADLINE_SECONDS,
         ),
     };
+    bill_acceptance.status.is_mature = true;
 
     assert!(
         service
@@ -6645,6 +6669,7 @@ fn check_req_for_expiration_baseline() {
         rejected_offer_to_sell: false,
         buying_deadline_timestamp: Some(Timestamp::new(1531593928).unwrap() + DAY_IN_SECS),
     };
+    bill_sell.status.is_mature = true;
 
     assert!(
         service
@@ -6688,6 +6713,7 @@ fn check_req_for_expiration_baseline() {
             Timestamp::new(1531593928).unwrap() + RECOURSE_DEADLINE_SECONDS,
         ),
     };
+    bill_recourse.status.is_mature = true;
 
     assert!(
         service

--- a/crates/bcr-ebill-core/src/application/bill/mod.rs
+++ b/crates/bcr-ebill-core/src/application/bill/mod.rs
@@ -178,6 +178,7 @@ pub struct BillStatus {
     pub redeemed_funds_available: bool,
     pub has_requested_funds: bool,
     pub last_block_time: Timestamp,
+    pub is_mature: bool,
     pub mint: BillMintStatus,
 }
 

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/block.rs
@@ -169,6 +169,8 @@ pub struct BillRequestToPayBlockData {
 impl Validate for BillRequestToPayBlockData {
     fn validate(&self) -> std::result::Result<(), ProtocolValidationError> {
         // The deadline has to be at or after the end of the day of signing time plus 48h
+        // This means it's implicitly also at least 48h after end of day of maturity date
+        // Since request to pay can't happen before start of day of maturity date
         let signing_ts_plus_minimum_deadline = self.signing_timestamp + PAYMENT_DEADLINE_SECONDS;
         if !signing_ts_plus_minimum_deadline
             .deadline_is_at_or_after_end_of_day_of(&self.payment_data.payment_deadline)

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/validation.rs
@@ -101,7 +101,7 @@ impl Validate for BillValidateActionData {
             }
             BillOpCode::RequestToPay => {
                 // request to pay not before maturity date
-                if self.timestamp < self.maturity_date.to_timestamp().end_of_day() {
+                if self.timestamp < self.maturity_date.to_timestamp().start_of_day() {
                     return Err(ProtocolValidationError::RequestToPayBeforeMaturityDate);
                 }
                 self.bill_is_blocked()?;
@@ -1106,6 +1106,7 @@ mod tests {
     #[case::req_to_pay(BillValidateActionData { signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
     #[case::req_to_pay_after_maturity(BillValidateActionData { maturity_date: Date::new("2022-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Ok(()))]
     #[case::req_to_pay_on_maturity_at_end_of_day(BillValidateActionData { timestamp: Timestamp::new(4098211199).unwrap(), maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Ok(()))]
+    #[case::req_to_pay_on_maturity_before_end_of_day(BillValidateActionData { timestamp: Timestamp::new(4098211198).unwrap(), maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Ok(()))]
     fn test_validate_bill_req_to_pay_valid(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,
@@ -1125,7 +1126,6 @@ mod tests {
     #[case::req_to_pay_not_holder(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), signer_node_id: node_id_test(), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data(),)) }, Err(ProtocolValidationError::CallerIsNotHolder))]
     #[case::req_to_pay_already_req_to_payed(BillValidateActionData { mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(add_req_to_pay_block(valid_bill_blockchain_issue( valid_bill_issue_block_data(),))) }, Err(ProtocolValidationError::BillIsRequestedToPayAndWaitingForPayment))]
     #[case::req_to_pay_before_maturity(BillValidateActionData { maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Err(ProtocolValidationError::RequestToPayBeforeMaturityDate))]
-    #[case::req_to_pay_on_maturity_before_end_of_day(BillValidateActionData { timestamp: Timestamp::new(4098211198).unwrap(), maturity_date: Date::new("2099-11-12").unwrap(), signer_node_id: node_id_test_other(), mode: BillValidationActionMode::Deep(BillAction::RequestToPay(Currency::sat(), safe_deadline_ts(PAYMENT_DEADLINE_SECONDS))), ..valid_bill_validate_action_data(valid_bill_blockchain_issue( valid_bill_issue_block_data() ,)) }, Err(ProtocolValidationError::RequestToPayBeforeMaturityDate))]
     fn test_validate_bill_req_to_pay_errors(
         #[case] input: BillValidateActionData,
         #[case] expected: Result<(), ProtocolValidationError>,

--- a/crates/bcr-ebill-persistence/src/db/bill.rs
+++ b/crates/bcr-ebill-persistence/src/db/bill.rs
@@ -585,6 +585,8 @@ pub struct BillStatusDb {
     pub redeemed_funds_available: bool,
     pub has_requested_funds: bool,
     pub last_block_time: Timestamp,
+    #[serde(default)]
+    pub is_mature: bool,
 }
 
 impl From<BillStatusDb> for BillStatus {
@@ -598,6 +600,7 @@ impl From<BillStatusDb> for BillStatus {
             redeemed_funds_available: value.redeemed_funds_available,
             has_requested_funds: value.has_requested_funds,
             last_block_time: value.last_block_time,
+            is_mature: value.is_mature,
         }
     }
 }
@@ -613,6 +616,7 @@ impl From<&BillStatus> for BillStatusDb {
             redeemed_funds_available: value.redeemed_funds_available,
             has_requested_funds: value.has_requested_funds,
             last_block_time: value.last_block_time,
+            is_mature: value.is_mature,
         }
     }
 }

--- a/crates/bcr-ebill-persistence/src/tests/mod.rs
+++ b/crates/bcr-ebill-persistence/src/tests/mod.rs
@@ -172,6 +172,7 @@ pub mod tests {
                 redeemed_funds_available: false,
                 has_requested_funds: false,
                 last_block_time: test_ts(),
+                is_mature: false,
             },
             state: BillState {
                 mint: BillMintState::None,

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -504,6 +504,7 @@ async function triggerBill(t, blank) {
     const now = new Date();
     const issue_date = now.toISOString().split('T')[0];
     const nMonthsLater = new Date(now); // maturity date today end of day
+    // nMonthsLater.setMonth(nMonthsLater.getMonth() + 1);
     const maturity_date = nMonthsLater.toISOString().split('T')[0];
 
     let file_upload_id = document.getElementById("file_upload_id").value || undefined;


### PR DESCRIPTION
* Fix that request to pay can happen from maturity day 00:00:00 onwards
* Fix a bug where bill cache didn't update when ticking over to maturity date