### PR TITLE
Add a way to filter bills by participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     * Add logic for setting this custom payment address for mint-req to pays
     * Add placeholders for validating this payment address for the mint payment
     * Adapt past payment and check payment logic (`private_descriptor_to_spend` is now an `Option<T>`)
+* Add filter for participants to bill `search` endpoint
+    * Added a field `pub participants: Vec<NodeId>`, which defaults to empty and which, if set, filters for bills that contain all participants in the list
 
 # 0.5.6
 

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -65,6 +65,7 @@ pub trait BillServiceApi: ServiceTraitBounds {
         date_range_from: Option<Timestamp>,
         date_range_to: Option<Timestamp>,
         role: &BillsFilterRole,
+        participants: &[NodeId],
         caller_public_data: &BillParticipant,
         caller_keys: &BcrKeys,
     ) -> Result<Vec<LightBitcreditBillResult>>;

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -825,6 +825,7 @@ impl BillServiceApi for BillService {
         date_range_from: Option<Timestamp>,
         date_range_to: Option<Timestamp>,
         role: &BillsFilterRole,
+        participants: &[NodeId],
         caller_public_data: &BillParticipant,
         caller_keys: &BcrKeys,
     ) -> Result<Vec<LightBitcreditBillResult>> {
@@ -836,6 +837,7 @@ impl BillServiceApi for BillService {
         let bills = self.get_bills(caller_public_data, caller_keys).await?;
         let mut result = vec![];
 
+        let filter_set: HashSet<NodeId> = participants.iter().cloned().collect();
         // for now we do the search here - with the quick-fetch table, we can search in surrealDB
         // directly
         for bill in bills {
@@ -884,6 +886,20 @@ impl BillServiceApi for BillService {
                 && !bill.search_bill_for_search_term(st)
             {
                 continue;
+            }
+
+            // if we search for participants and not all of the given participants are part of the bill, continue
+            if !filter_set.is_empty() {
+                let bill_set: HashSet<NodeId> = bill
+                    .participants
+                    .all_participant_node_ids
+                    .iter()
+                    .cloned()
+                    .collect();
+                // every node id in filter is contained in the bill participants
+                if !filter_set.is_subset(&bill_set) {
+                    continue;
+                }
             }
 
             result.push(bill.into());

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -175,6 +175,7 @@ async fn get_search_bill() {
     let company_node_id = NodeId::new(company_keys.pub_key(), bitcoin::Network::Testnet);
 
     let mut bill1 = get_baseline_bill(&bill_id_test());
+    let bill1_payee = bill1.payee.clone();
     bill1.issue_date = Date::new("2020-05-01").unwrap();
     bill1.sum = Sum::new_sat(1000).expect("sat works");
     bill1.drawee = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
@@ -184,7 +185,7 @@ async fn get_search_bill() {
     bill2.drawee = bill_identified_participant_only_node_id(company_node_id.clone());
     let mut payee = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
     payee.name = Name::new("hayek").unwrap();
-    bill2.payee = BillParticipant::Ident(payee);
+    bill2.payee = BillParticipant::Ident(payee.clone());
     let mut bill3 = get_baseline_bill(&bill_id_test_other2());
     bill3.issue_date = Date::new("2030-05-01").unwrap();
     bill3.sum = Sum::new_sat(20000).expect("sat works");
@@ -231,6 +232,7 @@ async fn get_search_bill() {
             None,
             None,
             &BillsFilterRole::All,
+            &[],
             &BillParticipant::Ident(bill_identified_participant_only_node_id(
                 company_node_id.clone(),
             )),
@@ -246,6 +248,7 @@ async fn get_search_bill() {
             None,
             None,
             &BillsFilterRole::All,
+            &[],
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
         )
@@ -260,6 +263,7 @@ async fn get_search_bill() {
             None,
             None,
             &BillsFilterRole::All,
+            &[],
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
         )
@@ -276,6 +280,7 @@ async fn get_search_bill() {
             Some(from_ts),
             Some(to_ts),
             &BillsFilterRole::All,
+            &[],
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
         )
@@ -290,12 +295,58 @@ async fn get_search_bill() {
             None,
             None,
             &BillsFilterRole::Payer,
+            &[],
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
         )
         .await;
     assert!(res_role.is_ok());
     assert_eq!(res_role.as_ref().unwrap().len(), 1);
+
+    let res_part = service
+        .search_bills(
+            &Currency::sat(),
+            &None,
+            None,
+            None,
+            &BillsFilterRole::All,
+            std::slice::from_ref(&company_node_id),
+            &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
+            &identity.key_pair,
+        )
+        .await;
+    assert!(res_part.is_ok());
+    assert_eq!(res_part.as_ref().unwrap().len(), 2); // company is drawee in bill 2, payee in bill 3
+
+    let res_parts = service
+        .search_bills(
+            &Currency::sat(),
+            &None,
+            None,
+            None,
+            &BillsFilterRole::All,
+            &[company_node_id.clone(), bill1_payee.node_id()],
+            &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
+            &identity.key_pair,
+        )
+        .await;
+    assert!(res_parts.is_ok());
+    assert_eq!(res_parts.as_ref().unwrap().len(), 0); // bill 1 payer is only in bill 1, company is not in bill 1
+
+    let res_parts2 = service
+        .search_bills(
+            &Currency::sat(),
+            &None,
+            None,
+            None,
+            &BillsFilterRole::All,
+            &[company_node_id, payee.node_id],
+            &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
+            &identity.key_pair,
+        )
+        .await;
+    assert!(res_parts2.is_ok());
+    assert_eq!(res_parts2.as_ref().unwrap().len(), 2); // company and identity are in bill 2 and bill 3
 
     let res_comb = service
         .search_bills(
@@ -304,6 +355,7 @@ async fn get_search_bill() {
             Some(from_ts),
             Some(to_ts),
             &BillsFilterRole::Payee,
+            &[],
             &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
             &identity.key_pair,
         )

--- a/crates/bcr-ebill-api/src/service/search_service.rs
+++ b/crates/bcr-ebill-api/src/service/search_service.rs
@@ -77,6 +77,7 @@ impl SearchServiceApi for SearchService {
                     None,
                     None,
                     &BillsFilterRole::All,
+                    &[],
                     caller_public_data,
                     caller_keys,
                 )

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -843,7 +843,7 @@ async function fetchBillBalances() {
 
 async function fetchBillSearch() {
   let measured = measure(async () => {
-    return success_or_fail(await window.billApi.search({ filter: { currency: "SAT", role: "All" } }));
+    return success_or_fail(await window.billApi.search({ filter: { currency: "SAT", role: "All", participants: [] } }));
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -269,6 +269,7 @@ impl Bill {
                     from,
                     to,
                     &BillsFilterRole::from(filter.role),
+                    &filter.participants,
                     &caller_public_data,
                     &caller_keys,
                 )

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -374,6 +374,9 @@ pub struct BillsSearchFilter {
     pub search_term: Option<String>,
     pub date_range: Option<DateRange>,
     pub role: BillsFilterRoleWeb,
+    #[tsify(type = "string[]")]
+    #[serde(default)]
+    pub participants: Vec<NodeId>,
     #[allow(unused)]
     pub currency: String,
 }


### PR DESCRIPTION
## 📝 Description

* Add filter for participants to bill `search` endpoint (breaking API change)

Relates to #879 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test
2. test to filter bills by singular, zero and multiple participants

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #879 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
