### PR TITLE
Fix company invite messaging not sent

### DIFF
--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
@@ -294,6 +294,10 @@ impl CompanyChainEventProcessor {
             // save keys
             self.save_keys(&company_id, keys).await?;
 
+            self.transport
+                .add_identity(company_id.clone(), keys.clone())
+                .await?;
+
             // save the first block
             self.save_block(&company_id, chain.get_first_block())
                 .await?;
@@ -1066,7 +1070,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
-            transport,
+            mut transport,
             push_service,
         ) = create_mocks();
         let (node_id, (company, keys)) = get_company_data();
@@ -1114,6 +1118,12 @@ pub mod tests {
         store
             .expect_save_key_pair()
             .with(eq(node_id.clone()), always())
+            .returning(|_, _| Ok(()))
+            .once();
+
+        transport
+            .expect_add_identity()
+            .with(eq(node_id.clone()), eq(keys.clone()))
             .returning(|_, _| Ok(()))
             .once();
 


### PR DESCRIPTION
## 📝 Description

Fixes the sporadic authorized-signer acceptance failure described in #893 by registering invited company identities with the live shared Nostr client as soon as the company invite chain is on-boarded.

Relates to and closes #893

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Receive a company signatory invite on a client that does not yet have the invited company loaded into the running Nostr client state.
2. Accept the invite immediately after it appears, without refreshing/restarting the app.
3. Confirm the acceptance flow no longer fails with `no signer found for node id` and that signer/company state updates normally.

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #893
- #892

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?