### PR TITLE
Fix broken chains after restore

### DIFF
--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -388,6 +388,7 @@ pub mod tests {
             async fn find_by_block_hash(&self, hash: &Sha256Hash) -> Result<Option<NostrChainEvent>>;
             async fn add_chain_event(&self, event: NostrChainEvent) -> Result<()>;
             async fn by_event_id(&self, event_id: &str) -> Result<Option<NostrChainEvent>>;
+            async fn remove_chain_events(&self, chain_id: &str, chain_type: BlockchainType) -> Result<()>;
         }
     }
 

--- a/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
+++ b/crates/bcr-ebill-core/src/protocol/blockchain/bill/chain.rs
@@ -961,7 +961,7 @@ impl BillBlockchain {
 
         // sort by signing timestamp descending
         let mut list: Vec<PastEndorsee> = result.into_values().collect();
-        list.sort_by_key(|b| std::cmp::Reverse(b.signing_timestamp));
+        list.sort_by_key(|e| std::cmp::Reverse(e.signing_timestamp));
 
         Ok(list)
     }

--- a/crates/bcr-ebill-persistence/src/db/nostr_chain_event.rs
+++ b/crates/bcr-ebill-persistence/src/db/nostr_chain_event.rs
@@ -27,7 +27,6 @@ const BLOCK_HASH: &str = "block_hash";
 const BLOCK_HEIGHT: &str = "block_height";
 const ROOT_ID: &str = "root_id";
 const EVENT_ID: &str = "event_id";
-const VALID: &str = "valid";
 
 impl SurrealNostrChainEventStore {
     const TABLE: &'static str = "nostr_chain_event";
@@ -37,7 +36,7 @@ impl SurrealNostrChainEventStore {
         Self { db }
     }
 
-    async fn find_all_valid_chain_events(
+    async fn find_all_chain_events(
         &self,
         chain_id: String,
         chain_type: BlockchainType,
@@ -49,7 +48,7 @@ impl SurrealNostrChainEventStore {
 
         let result: Vec<NostrChainEventDb> = self.db
                 .query(format!(
-                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {CHAIN_ID} = ${CHAIN_ID} AND {CHAIN_TYPE} = ${CHAIN_TYPE} AND {VALID} = true ORDER BY {BLOCK_HEIGHT} DESC"
+                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {CHAIN_ID} = ${CHAIN_ID} AND {CHAIN_TYPE} = ${CHAIN_TYPE} ORDER BY {BLOCK_HEIGHT} DESC"
                 ).as_str(), bindings)
                 .await?;
         Ok(result)
@@ -61,29 +60,24 @@ impl ServiceTraitBounds for SurrealNostrChainEventStore {}
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
-    /// Finds all chain events for the given chain id and type. This will return all valid
-    /// events we ever received for a chain id.
     async fn find_chain_events(
         &self,
         chain_id: &str,
         chain_type: BlockchainType,
     ) -> Result<Vec<NostrChainEvent>> {
         let result: Vec<NostrChainEventDb> = self
-            .find_all_valid_chain_events(chain_id.to_owned(), chain_type)
+            .find_all_chain_events(chain_id.to_owned(), chain_type)
             .await?;
         Ok(result.into_iter().map(Into::into).collect())
     }
 
-    /// Finds the latest chain events for the given chain id and type. This can be considered the
-    /// tip of the current chain state on Nostr. Latest means the blocks with the highest block
-    /// height. In split chain scenarios this can return more than one event.
     async fn find_latest_block_events(
         &self,
         chain_id: &str,
         chain_type: BlockchainType,
     ) -> Result<Vec<NostrChainEvent>> {
         let result: Vec<NostrChainEventDb> = self
-            .find_all_valid_chain_events(chain_id.to_owned(), chain_type)
+            .find_all_chain_events(chain_id.to_owned(), chain_type)
             .await?;
         // Find the highest block_height
         let max_height = result.first().map(|e| e.block_height);
@@ -97,7 +91,6 @@ impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
         Ok(latest.into_iter().map(Into::into).collect())
     }
 
-    /// Finds a message with a specific block hash as extracted from the chain payload.
     async fn find_by_block_hash(&self, hash: &Sha256Hash) -> Result<Option<NostrChainEvent>> {
         let mut bindings = Bindings::default();
         bindings.add(DB_TABLE, Self::TABLE)?;
@@ -107,7 +100,7 @@ impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
             .db
             .query(
                 format!(
-                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {BLOCK_HASH} = ${BLOCK_HASH}"
+                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {BLOCK_HASH} = ${BLOCK_HASH} ORDER BY {BLOCK_HEIGHT} DESC, received DESC"
                 )
                 .as_str(),
                 bindings,
@@ -118,7 +111,6 @@ impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
         Ok(value)
     }
 
-    /// Adds a new chain event to the store.
     async fn add_chain_event(&self, event: NostrChainEvent) -> Result<()> {
         let db_data: NostrChainEventDb = event.clone().into();
         let _: Option<NostrChainEventDb> = self
@@ -128,14 +120,12 @@ impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
         Ok(())
     }
 
-    /// Finds an event by a specific Nostr event_id
     async fn by_event_id(&self, event_id: &str) -> Result<Option<NostrChainEvent>> {
         let event_id = event_id.to_owned();
         let result: Option<NostrChainEventDb> = self.db.select_one(Self::TABLE, event_id).await?;
         Ok(result.map(|r| r.into()))
     }
 
-    /// Finds the root (genesis) event for a given chain
     async fn find_root_event(
         &self,
         chain_id: &str,
@@ -148,10 +138,28 @@ impl NostrChainEventStoreApi for SurrealNostrChainEventStore {
 
         let result: Vec<NostrChainEventDb> = self.db
                 .query(format!(
-                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {CHAIN_ID} = ${CHAIN_ID} AND {CHAIN_TYPE} = ${CHAIN_TYPE} AND {EVENT_ID} = {ROOT_ID} AND {VALID} = true"
+                    "SELECT * FROM type::table(${DB_TABLE}) WHERE {CHAIN_ID} = ${CHAIN_ID} AND {CHAIN_TYPE} = ${CHAIN_TYPE} AND {EVENT_ID} = {ROOT_ID}"
                 ).as_str(), bindings)
                 .await?;
         Ok(result.first().map(|r| r.to_owned().into()))
+    }
+
+    async fn remove_chain_events(&self, chain_id: &str, chain_type: BlockchainType) -> Result<()> {
+        let mut bindings = Bindings::default();
+        bindings.add(DB_TABLE, Self::TABLE)?;
+        bindings.add(CHAIN_ID, chain_id.to_owned())?;
+        bindings.add(CHAIN_TYPE, chain_type)?;
+
+        self.db
+            .query_check(
+                format!(
+                    "DELETE FROM type::table(${DB_TABLE}) WHERE {CHAIN_ID} = ${CHAIN_ID} AND {CHAIN_TYPE} = ${CHAIN_TYPE}"
+                )
+                .as_str(),
+                bindings,
+            )
+            .await?;
+        Ok(())
     }
 }
 
@@ -180,8 +188,6 @@ pub struct NostrChainEventDb {
     pub time: Timestamp,
     /// The event as we received it via nostr.
     pub payload: Event,
-    /// We consider this event as part of the valid chain
-    pub valid: bool,
 }
 
 impl From<NostrChainEvent> for NostrChainEventDb {
@@ -198,7 +204,6 @@ impl From<NostrChainEvent> for NostrChainEventDb {
             received: event.received,
             time: event.time,
             payload: event.payload,
-            valid: event.valid,
         }
     }
 }
@@ -217,7 +222,6 @@ impl From<NostrChainEventDb> for NostrChainEvent {
             received: db.received,
             time: db.time,
             payload: db.payload,
-            valid: db.valid,
         }
     }
 }
@@ -376,14 +380,6 @@ mod tests {
             &root,
             Some(&child),
         );
-        let mut invalid = get_child_event(
-            "child_event_c",
-            3,
-            &Sha256Hash::new("child_hash_c"),
-            &root,
-            Some(&child),
-        );
-        invalid.valid = false;
 
         store
             .add_chain_event(root)
@@ -402,17 +398,11 @@ mod tests {
             .await
             .expect("target event creation failed");
 
-        store
-            .add_chain_event(invalid)
-            .await
-            .expect("failed to add invalid event");
-
         let all = store
             .find_chain_events("chain_id", BlockchainType::Bill)
             .await
             .expect("could not find all events");
 
-        // result should not include invalid event
         assert_eq!(all.len(), 4);
     }
     async fn get_store(db: &str) -> SurrealNostrChainEventStore {
@@ -470,7 +460,6 @@ mod tests {
             received: Timestamp::now(),
             time: Timestamp::now(),
             payload: get_test_event(),
-            valid: true,
         }
     }
 

--- a/crates/bcr-ebill-persistence/src/nostr.rs
+++ b/crates/bcr-ebill-persistence/src/nostr.rs
@@ -248,6 +248,8 @@ pub trait NostrChainEventStoreApi: ServiceTraitBounds {
 
     /// Finds an event by a specific Nostr event_id
     async fn by_event_id(&self, event_id: &str) -> Result<Option<NostrChainEvent>>;
+
+    async fn remove_chain_events(&self, chain_id: &str, chain_type: BlockchainType) -> Result<()>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -274,8 +276,6 @@ pub struct NostrChainEvent {
     pub time: Timestamp,
     /// The event as we received it via nostr.
     pub payload: Event,
-    /// We consider this event as part of the valid chain
-    pub valid: bool,
 }
 
 impl NostrChainEvent {

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -9,11 +9,13 @@ use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_api::service::transport_service::BlockTransportServiceApi;
 use bcr_ebill_core::application::ServiceTraitBounds;
 use bcr_ebill_core::application::company::Company;
+use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::blockchain::BlockchainType;
 use bcr_ebill_core::protocol::crypto::BcrKeys;
 use bcr_ebill_core::protocol::event::{
     BillChainEvent, CompanyChainEvent, EventEnvelope, IdentityChainEvent,
 };
+use bcr_ebill_persistence::nostr::NostrChainEvent;
 use bitcoin::base58;
 use log::{debug, error};
 
@@ -45,6 +47,32 @@ impl BlockTransportService {
 
 impl ServiceTraitBounds for BlockTransportService {}
 
+impl BlockTransportService {
+    /// Validates that a previous block event exists before publishing.
+    /// If no previous event is found and the block is not genesis,
+    /// returns an error to prevent publishing an orphaned block.
+    async fn validate_previous_event_exists(
+        &self,
+        previous_hash: &Sha256Hash,
+        chain_id: &str,
+        chain_type: BlockchainType,
+        block_height: usize,
+    ) -> Result<(Option<NostrChainEvent>, Option<NostrChainEvent>)> {
+        let (previous_event, root_event) = self
+            .nostr_transport
+            .find_root_and_previous_event(previous_hash, chain_id, chain_type)
+            .await?;
+
+        if previous_event.is_none() && block_height > 1 {
+            return Err(Error::Blockchain(format!(
+                "Cannot publish block: missing previous block for {chain_type:?} chain {chain_id} at height {block_height}"
+            )));
+        }
+
+        Ok((previous_event, root_event))
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl BlockTransportServiceApi for BlockTransportService {
@@ -58,11 +86,11 @@ impl BlockTransportServiceApi for BlockTransportService {
 
         if let Some(event) = events.generate_blockchain_message() {
             let (previous_event, root_event) = self
-                .nostr_transport
-                .find_root_and_previous_event(
+                .validate_previous_event_exists(
                     &event.data.block.previous_hash,
                     &event.data.node_id.to_string(),
                     BlockchainType::Identity,
+                    event.data.block.id.inner() as usize,
                 )
                 .await?;
             let nostr_event = node
@@ -113,11 +141,11 @@ impl BlockTransportServiceApi for BlockTransportService {
 
         if let Some(event) = events.generate_blockchain_message() {
             let (previous_event, root_event) = self
-                .nostr_transport
-                .find_root_and_previous_event(
+                .validate_previous_event_exists(
                     &event.data.block.previous_hash,
                     &event.data.node_id.to_string(),
                     BlockchainType::Company,
+                    event.data.block.id.inner() as usize,
                 )
                 .await?;
             let nostr_event = node
@@ -184,11 +212,11 @@ impl BlockTransportServiceApi for BlockTransportService {
 
         if let Some(block_event) = events.generate_blockchain_message() {
             let (previous_event, root_event) = self
-                .nostr_transport
-                .find_root_and_previous_event(
+                .validate_previous_event_exists(
                     &block_event.data.block.previous_hash,
                     &block_event.data.bill_id.to_string(),
                     BlockchainType::Bill,
+                    block_event.data.block.id.inner() as usize,
                 )
                 .await?;
 
@@ -276,5 +304,63 @@ impl BlockTransportServiceApi for BlockTransportService {
     /// Adds a new transport client for a company if it does not already exist
     async fn add_company_transport(&self, company: &Company, keys: &BcrKeys) -> Result<()> {
         self.nostr_transport.add_company_keys(company, keys).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bcr_ebill_core::protocol::Sha256Hash;
+
+    #[tokio::test]
+    async fn test_validate_previous_event_exists_allows_genesis() {
+        // Genesis block (height 1) should succeed even without previous event
+        // This is a unit test for the validation logic only
+        let previous_hash = Sha256Hash::new("genesis");
+        let block_height = 1;
+
+        // For genesis blocks, we don't need a previous event
+        assert!(block_height <= 1 || previous_hash != Sha256Hash::new("genesis"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_previous_event_exists_rejects_missing() {
+        // Non-genesis block without previous event should fail
+        let block_height = 2;
+
+        // Simulate the validation check
+        let previous_event_exists = false;
+        let is_genesis = block_height <= 1;
+
+        let result = if !previous_event_exists && !is_genesis {
+            Err(Error::Blockchain(
+                "Cannot publish block: missing previous block".to_string(),
+            ))
+        } else {
+            Ok(())
+        };
+
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Cannot publish block"));
+        assert!(err_msg.contains("missing previous block"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_previous_event_exists_accepts_with_previous() {
+        // Non-genesis block with previous event should succeed
+        let block_height = 2;
+        let previous_event_exists = true;
+        let is_genesis = block_height <= 1;
+
+        let result = if !previous_event_exists && !is_genesis {
+            Err(Error::Blockchain(
+                "Cannot publish block: missing previous block".to_string(),
+            ))
+        } else {
+            Ok(())
+        };
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -310,35 +310,101 @@ impl BlockTransportServiceApi for BlockTransportService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handler::{
+        MockBillChainEventProcessorApi, MockCompanyChainEventProcessorApi,
+        MockIdentityChainEventProcessorApi,
+    };
+    use crate::test_utils::{
+        MockContactStore, MockNostrChainEventStore, MockNostrContactStore,
+        MockNostrQueuedMessageStore, MockNotificationJsonTransport, get_nostr_transport,
+    };
     use bcr_ebill_core::protocol::Sha256Hash;
+    use bcr_ebill_core::protocol::blockchain::BlockchainType;
+    use bcr_ebill_persistence::nostr::NostrChainEvent;
+
+    fn create_test_chain_event(
+        chain_id: &str,
+        chain_type: BlockchainType,
+        block_height: usize,
+        block_hash: Sha256Hash,
+    ) -> NostrChainEvent {
+        NostrChainEvent {
+            event_id: format!("test_event_{block_height}"),
+            root_id: "test_event_1".to_string(),
+            reply_id: if block_height > 1 {
+                Some(format!("test_event_{}", block_height - 1))
+            } else {
+                None
+            },
+            author: "test_author".to_string(),
+            chain_id: chain_id.to_string(),
+            chain_type,
+            block_height,
+            block_hash,
+            received: bcr_ebill_core::protocol::Timestamp::now(),
+            time: bcr_ebill_core::protocol::Timestamp::now(),
+            payload: nostr::EventBuilder::text_note("test")
+                .sign_with_keys(&nostr::key::Keys::generate())
+                .unwrap(),
+        }
+    }
+
+    fn get_service(chain_event_store: MockNostrChainEventStore) -> BlockTransportService {
+        BlockTransportService::new(
+            Arc::new(get_nostr_transport(
+                MockNotificationJsonTransport::new(),
+                MockContactStore::new(),
+                MockNostrContactStore::new(),
+                MockNostrQueuedMessageStore::new(),
+                chain_event_store,
+            )),
+            Arc::new(MockBillChainEventProcessorApi::new()),
+            Arc::new(MockCompanyChainEventProcessorApi::new()),
+            Arc::new(MockIdentityChainEventProcessorApi::new()),
+        )
+    }
 
     #[tokio::test]
     async fn test_validate_previous_event_exists_allows_genesis() {
-        // Genesis block (height 1) should succeed even without previous event
-        // This is a unit test for the validation logic only
-        let previous_hash = Sha256Hash::new("genesis");
-        let block_height = 1;
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        // No previous event in store for genesis block
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(|_| Ok(None));
 
-        // For genesis blocks, we don't need a previous event
-        assert!(block_height <= 1 || previous_hash != Sha256Hash::new("genesis"));
+        let service = get_service(chain_event_store);
+        let result = service
+            .validate_previous_event_exists(
+                &Sha256Hash::new("genesis"),
+                "test_chain",
+                BlockchainType::Bill,
+                1,
+            )
+            .await;
+
+        assert!(result.is_ok());
+        let (previous, root) = result.unwrap();
+        assert!(previous.is_none());
+        assert!(root.is_none());
     }
 
     #[tokio::test]
     async fn test_validate_previous_event_exists_rejects_missing() {
-        // Non-genesis block without previous event should fail
-        let block_height = 2;
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        // No previous event in store for non-genesis block
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(|_| Ok(None));
 
-        // Simulate the validation check
-        let previous_event_exists = false;
-        let is_genesis = block_height <= 1;
-
-        let result = if !previous_event_exists && !is_genesis {
-            Err(Error::Blockchain(
-                "Cannot publish block: missing previous block".to_string(),
-            ))
-        } else {
-            Ok(())
-        };
+        let service = get_service(chain_event_store);
+        let result = service
+            .validate_previous_event_exists(
+                &Sha256Hash::new("missing_hash"),
+                "test_chain",
+                BlockchainType::Bill,
+                2,
+            )
+            .await;
 
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
@@ -348,19 +414,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_previous_event_exists_accepts_with_previous() {
-        // Non-genesis block with previous event should succeed
-        let block_height = 2;
-        let previous_event_exists = true;
-        let is_genesis = block_height <= 1;
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        let previous_hash = Sha256Hash::new("previous_hash");
+        let previous_event =
+            create_test_chain_event("test_chain", BlockchainType::Bill, 1, previous_hash.clone());
 
-        let result = if !previous_event_exists && !is_genesis {
-            Err(Error::Blockchain(
-                "Cannot publish block: missing previous block".to_string(),
-            ))
-        } else {
-            Ok(())
-        };
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(move |_| Ok(Some(previous_event.clone())));
+
+        let service = get_service(chain_event_store);
+        let result = service
+            .validate_previous_event_exists(&previous_hash, "test_chain", BlockchainType::Bill, 2)
+            .await;
 
         assert!(result.is_ok());
+        let (previous, root) = result.unwrap();
+        assert!(previous.is_some());
+        assert!(root.is_some());
     }
 }

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -59,8 +59,7 @@ impl NotificationHandlerApi for BillChainEventHandler {
         debug!("incoming bill chain event in chain event handler");
         if let Ok(decoded) = Event::<BillBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.bill_store.get_keys(&decoded.data.bill_id).await {
-                let valid = self
-                    .processor
+                self.processor
                     .process_chain_data(
                         &decoded.data.bill_id,
                         vec![decoded.data.block.clone()],
@@ -68,7 +67,7 @@ impl NotificationHandlerApi for BillChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .is_ok();
+                    .ok();
 
                 if let Some(original_event) = original_event {
                     self.store_event(
@@ -76,7 +75,6 @@ impl NotificationHandlerApi for BillChainEventHandler {
                         decoded.data.block_height,
                         &decoded.data.block.hash,
                         &decoded.data.bill_id.to_string(),
-                        valid,
                     )
                     .await?;
                 }
@@ -97,7 +95,6 @@ impl BillChainEventHandler {
         block_height: usize,
         block_hash: &Sha256Hash,
         chain_id: &str,
-        valid: bool,
     ) -> Result<()> {
         let (root, reply) = root_and_reply_id(&event);
         if let Err(e) = self
@@ -115,8 +112,7 @@ impl BillChainEventHandler {
                 block_hash: block_hash.to_owned(),
                 received: Timestamp::now(),
                 time: event.created_at.into(),
-                payload: *event.clone(),
-                valid,
+                payload: *event,
             })
             .await
         {

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_handler.rs
@@ -59,7 +59,8 @@ impl NotificationHandlerApi for BillChainEventHandler {
         debug!("incoming bill chain event in chain event handler");
         if let Ok(decoded) = Event::<BillBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.bill_store.get_keys(&decoded.data.bill_id).await {
-                self.processor
+                let valid = self
+                    .processor
                     .process_chain_data(
                         &decoded.data.bill_id,
                         vec![decoded.data.block.clone()],
@@ -67,9 +68,9 @@ impl NotificationHandlerApi for BillChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .ok();
+                    .is_ok();
 
-                if let Some(original_event) = original_event {
+                if valid && let Some(original_event) = original_event {
                     self.store_event(
                         original_event,
                         decoded.data.block_height,

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
@@ -22,7 +22,9 @@ use bcr_ebill_core::protocol::blockchain::bill::{
 use bcr_ebill_core::protocol::blockchain::{Block, Blockchain, BlockchainType};
 use bcr_ebill_core::protocol::crypto::{BcrKeys, btc};
 use bcr_ebill_core::protocol::{BitcoinAddress, BlockId, Sha256Hash};
-use bcr_ebill_persistence::{FileReferenceStoreApi, bill::BillChainStoreApi, bill::BillStoreApi};
+use bcr_ebill_persistence::{
+    FileReferenceStoreApi, NostrChainEventStoreApi, bill::BillChainStoreApi, bill::BillStoreApi,
+};
 use log::{debug, error, info, warn};
 use secp256k1::PublicKey;
 use std::sync::Arc;
@@ -131,6 +133,14 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                 )
                 .await
                 {
+                    if let Err(e) = self
+                        .chain_event_store
+                        .remove_chain_events(&bill_id.to_string(), BlockchainType::Bill)
+                        .await
+                    {
+                        error!("Failed to invalidate old bill chain events during resync: {e}");
+                    }
+
                     for data in chain_data.iter() {
                         let blocks: Vec<BillBlock> = data
                             .iter()
@@ -198,6 +208,21 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                                     return Err(e);
                                 }
 
+                                for event_container in data.iter() {
+                                    let event = event_container.as_chain_store_event(
+                                        &bill_id.to_string(),
+                                        BlockchainType::Bill,
+                                        event_container.block.get_block_height() as usize,
+                                    );
+                                    if let Err(e) =
+                                        self.chain_event_store.add_chain_event(event).await
+                                    {
+                                        error!(
+                                            "Failed to store bill chain event during resync: {e}"
+                                        );
+                                    }
+                                }
+
                                 debug!("resynced bill {bill_id} with {} remote events", data.len());
                                 return Ok(());
                             }
@@ -233,6 +258,7 @@ pub struct BillChainEventProcessor {
     bill_store: Arc<dyn BillStoreApi>,
     file_reference_store: Arc<dyn FileReferenceStoreApi>,
     nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+    chain_event_store: Arc<dyn NostrChainEventStoreApi>,
     transport: Arc<dyn TransportClientApi>,
     mint_client: Arc<dyn MintClientApi>,
     bitcoin_network: bitcoin::Network,
@@ -244,6 +270,7 @@ impl BillChainEventProcessor {
         bill_store: Arc<dyn BillStoreApi>,
         file_reference_store: Arc<dyn FileReferenceStoreApi>,
         nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+        chain_event_store: Arc<dyn NostrChainEventStoreApi>,
         transport: Arc<dyn TransportClientApi>,
         mint_client: Arc<dyn MintClientApi>,
         bitcoin_network: bitcoin::Network,
@@ -253,6 +280,7 @@ impl BillChainEventProcessor {
             bill_store,
             file_reference_store,
             nostr_contact_processor,
+            chain_event_store,
             transport,
             mint_client,
             bitcoin_network,
@@ -821,9 +849,10 @@ mod tests {
         handler::{
             MockNostrContactProcessorApi,
             test_utils::{
-                MockBillChainStore, MockBillStore, MockMintClient, bill_id_test, empty_address,
-                get_baseline_bill, get_baseline_identity, get_bill_keys, get_genesis_chain,
-                get_test_bitcredit_bill, node_id_test, node_id_test_other, private_key_test,
+                MockBillChainStore, MockBillStore, MockMintClient, MockNostrChainEventStore,
+                bill_id_test, empty_address, get_baseline_bill, get_baseline_identity,
+                get_bill_keys, get_genesis_chain, get_test_bitcredit_bill, node_id_test_other,
+                private_key_test,
             },
         },
         test_utils::{
@@ -837,12 +866,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_event_handler() {
-        let (bill_chain_store, bill_store, contact, transport) = create_mocks();
+        let (bill_chain_store, bill_store, contact, transport, chain_event_store) = create_mocks();
         BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -852,7 +882,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_chain_event_and_sender_invalid_on_no_keys_or_chain() {
         let keys = BcrKeys::new().get_nostr_keys();
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
         bill_store
             .expect_get_keys()
@@ -879,6 +909,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -892,12 +923,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_chain_event_and_sender() {
-        let bill = get_baseline_bill(&bill_id_test());
-        let node_id = node_id_test();
-        let npub = node_id.npub();
+    async fn test_validate_chain_event_and_sender_valid() {
+        let baseline = get_baseline_identity();
+        let npub = baseline.key_pair.get_nostr_keys().public_key();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let payer = BillIdentParticipant::new(baseline.identity.clone()).unwrap();
+        let payee = BillIdentParticipant::new(baseline.identity.clone()).unwrap();
+        let bill = get_test_bitcredit_bill(&bill_id_test(), &payer, &payee, None, None);
 
         bill_store
             .expect_get_keys()
@@ -915,6 +948,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -938,7 +972,7 @@ mod tests {
         let chain = get_genesis_chain(Some(bill.clone()));
         let keys = get_bill_keys();
 
-        let (mut bill_chain_store, mut bill_store, mut contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, mut contact, transport, _) = create_mocks();
 
         bill_chain_store
             .expect_get_chain()
@@ -970,6 +1004,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1012,7 +1047,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, mut bill_store, mut contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, mut contact, transport, _) = create_mocks();
 
         let chain_clone = chain.clone();
         bill_store
@@ -1041,6 +1076,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1126,7 +1162,13 @@ mod tests {
         // mock the nostr chain
         let nostr_chain = vec![event1.clone(), event2.clone(), event3.clone()];
 
-        let (mut bill_chain_store, mut bill_store, mut contact, mut transport) = create_mocks();
+        let (
+            mut bill_chain_store,
+            mut bill_store,
+            mut contact,
+            mut transport,
+            mut chain_event_store,
+        ) = create_mocks();
 
         let chain_clone = chain.clone();
         bill_store
@@ -1167,11 +1209,21 @@ mod tests {
 
         contact.expect_ensure_nostr_contact().returning(|_| ());
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()))
+            .times(0..);
+
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1243,7 +1295,7 @@ mod tests {
         .unwrap();
         assert!(chain.try_add_block(block));
 
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
         bill_chain_store
             .expect_get_chain()
@@ -1272,6 +1324,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1295,7 +1348,7 @@ mod tests {
         let chain = get_genesis_chain(Some(bill.clone()));
         let keys = get_bill_keys();
 
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
         bill_chain_store
             .expect_get_chain()
@@ -1322,6 +1375,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1358,7 +1412,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
         let chain_clone = chain.clone();
         bill_store
@@ -1380,6 +1434,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1421,7 +1476,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, mut bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, transport, _) = create_mocks();
 
         let chain_clone = chain.clone();
         bill_store
@@ -1443,6 +1498,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1485,7 +1541,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, bill_store, contact, transport) = create_mocks();
+        let (mut bill_chain_store, bill_store, contact, transport, _) = create_mocks();
 
         bill_chain_store
             .expect_get_chain()
@@ -1505,6 +1561,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1519,12 +1576,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_fails_to_add_block_for_bill_id_from_different_network() {
-        let (bill_chain_store, bill_store, contact, transport) = create_mocks();
+        let (bill_chain_store, bill_store, contact, transport, _) = create_mocks();
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1576,7 +1634,7 @@ mod tests {
         split_block.timestamp = chain.get_latest_block().timestamp - 1000; // Earlier timestamp
         split_block.hash = Sha256Hash::new("different_hash"); // Different hash
 
-        let (mut bill_chain_store, mut bill_store, contact, mut transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, mut transport, _) = create_mocks();
 
         // Setup existing chain
         let chain_clone = chain.clone();
@@ -1603,6 +1661,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1670,7 +1729,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, mut bill_store, contact, mut transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, mut transport, _) = create_mocks();
 
         // Setup existing chain
         let chain_clone = chain.clone();
@@ -1696,6 +1755,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1740,7 +1800,7 @@ mod tests {
         )
         .unwrap();
 
-        let (mut bill_chain_store, _, _, _) = create_mocks();
+        let (mut bill_chain_store, _, _, _, _) = create_mocks();
 
         // CRITICAL: add_block should NEVER be called during validation
         bill_chain_store
@@ -1753,6 +1813,7 @@ mod tests {
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1810,13 +1871,14 @@ mod tests {
         // Tamper with the block to make it invalid
         invalid_block.hash = Sha256Hash::new("tampered_hash");
 
-        let (bill_chain_store, _, _, _) = create_mocks();
+        let (bill_chain_store, _, _, _, _) = create_mocks();
 
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -1895,7 +1957,13 @@ mod tests {
         // All events (resolve_public_chain returns flat Vec<Event>)
         let all_events = vec![event1.clone(), event2.clone()];
 
-        let (mut bill_chain_store, mut bill_store, mut contact, mut transport) = create_mocks();
+        let (
+            mut bill_chain_store,
+            mut bill_store,
+            mut contact,
+            mut transport,
+            mut chain_event_store,
+        ) = create_mocks();
 
         let chain_clone = chain.clone();
         bill_store
@@ -1927,11 +1995,21 @@ mod tests {
 
         contact.expect_ensure_nostr_contact().returning(|_| ());
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()))
+            .times(0..);
+
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -2018,7 +2096,13 @@ mod tests {
 
         let nostr_events = vec![event0.clone(), event_remote.clone()];
 
-        let (mut bill_chain_store, mut bill_store, mut contact, mut transport) = create_mocks();
+        let (
+            mut bill_chain_store,
+            mut bill_store,
+            mut contact,
+            mut transport,
+            mut chain_event_store,
+        ) = create_mocks();
 
         bill_store
             .expect_invalidate_bill_in_cache()
@@ -2053,11 +2137,21 @@ mod tests {
 
         contact.expect_ensure_nostr_contact().returning(|_| ());
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()))
+            .times(0..);
+
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -2138,7 +2232,8 @@ mod tests {
 
         let nostr_events = vec![event0.clone(), event_remote.clone()];
 
-        let (mut bill_chain_store, mut bill_store, contact, mut transport) = create_mocks();
+        let (mut bill_chain_store, mut bill_store, contact, mut transport, mut chain_event_store) =
+            create_mocks();
 
         bill_store
             .expect_invalidate_bill_in_cache()
@@ -2163,11 +2258,16 @@ mod tests {
 
         bill_chain_store.expect_add_block().times(0);
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(bill_store),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -2253,6 +2353,7 @@ mod tests {
             Arc::new(bill_store),
             Arc::new(file_reference_store),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             bitcoin::Network::Testnet,
@@ -2268,12 +2369,14 @@ mod tests {
         MockBillStore,
         MockNostrContactProcessorApi,
         MockNotificationJsonTransport,
+        MockNostrChainEventStore,
     ) {
         (
             MockBillChainStore::new(),
             MockBillStore::new(),
             MockNostrContactProcessorApi::new(),
             MockNotificationJsonTransport::new(),
+            MockNostrChainEventStore::new(),
         )
     }
 
@@ -2294,13 +2397,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_payment_address_accepts_matching_address() {
-        let (bill_chain_store, _, _, _) = create_mocks();
+        let (bill_chain_store, _, _, _, _) = create_mocks();
         let network = bitcoin::Network::Testnet;
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             network,
@@ -2341,7 +2445,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_payment_address_mint_case() {
         init_test_cfg();
-        let (bill_chain_store, _, _, _) = create_mocks();
+        let (bill_chain_store, _, _, _, _) = create_mocks();
         let network = bitcoin::Network::Testnet;
         let mut mock_mint_client = MockMintClient::new();
         mock_mint_client
@@ -2353,9 +2457,10 @@ mod tests {
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(mock_mint_client),
-            network,
+            bitcoin::Network::Testnet,
         );
 
         let block_id = BlockId::first().add(6);
@@ -2386,13 +2491,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_payment_address_rejects_non_matching_address() {
-        let (bill_chain_store, _, _, _) = create_mocks();
+        let (bill_chain_store, _, _, _, _) = create_mocks();
         let network = bitcoin::Network::Testnet;
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             network,
@@ -2431,13 +2537,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_payment_address_rejects_when_op_changes() {
-        let (bill_chain_store, _, _, _) = create_mocks();
+        let (bill_chain_store, _, _, _, _) = create_mocks();
         let network = bitcoin::Network::Testnet;
         let handler = BillChainEventProcessor::new(
             Arc::new(bill_chain_store),
             Arc::new(MockBillStore::new()),
             Arc::new(MockFileReferenceStore::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             Arc::new(MockMintClient::new()),
             network,

--- a/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use bcr_common::core::{BillId, NodeId};
@@ -11,7 +11,7 @@ use bcr_ebill_core::{
         event::{ChainInvite, Event, EventEnvelope},
     },
 };
-use bcr_ebill_persistence::{NostrChainEventStoreApi, nostr::NostrChainEvent};
+use bcr_ebill_persistence::NostrChainEventStoreApi;
 use log::{debug, error, warn};
 
 use crate::{
@@ -115,27 +115,10 @@ impl BillInviteEventHandler {
         chain_id: &str,
         chain_type: BlockchainType,
         inserted_chain: Vec<EventContainer>,
-        chains: &[Vec<EventContainer>],
+        _chains: &[Vec<EventContainer>],
     ) -> Result<()> {
-        let mut to_insert: HashMap<String, NostrChainEvent> = HashMap::new();
-
-        // first store the inserted valid blocks
         for (idx, inserted) in inserted_chain.iter().enumerate() {
-            let data = inserted.as_chain_store_event(chain_id, chain_type, idx + 1, true);
-            to_insert.insert(data.event_id.to_owned(), data);
-        }
-
-        // then store all malicious or invalid blocks with their pretended block height
-        for chain in chains {
-            for (idx, data) in chain.iter().enumerate() {
-                if !to_insert.contains_key(&data.event.id.to_string()) {
-                    let data = data.as_chain_store_event(chain_id, chain_type, idx + 1, false);
-                    to_insert.insert(data.event_id.to_owned(), data);
-                }
-            }
-        }
-
-        for (_, data) in to_insert {
+            let data = inserted.as_chain_store_event(chain_id, chain_type, idx + 1);
             if let Err(e) = self.chain_event_store.add_chain_event(data).await {
                 debug!("Could not store chain event because {e}")
             }
@@ -240,7 +223,6 @@ mod tests {
             })
             .returning(|_, _, _| Ok(()));
 
-        // store events
         chain_event_store
             .expect_add_chain_event()
             .returning(|_| Ok(()))
@@ -342,19 +324,11 @@ mod tests {
             })
             .returning(|_, _, _| Ok(()));
 
-        // store valid events
+        // store events
         chain_event_store
             .expect_add_chain_event()
-            .withf(|e| e.valid)
             .returning(|_| Ok(()))
             .times(3);
-
-        // store invalid events
-        chain_event_store
-            .expect_add_chain_event()
-            .withf(|e| !e.valid)
-            .returning(|_| Ok(()))
-            .times(1);
 
         let event = generate_test_event(&BcrKeys::new(), None, None, 1);
         let invite = Event::new_bill_invite(ChainInvite::bill(

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
@@ -39,8 +39,7 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
         debug!("incoming company chain event");
         if let Ok(decoded) = Event::<CompanyBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.company_store.get_key_pair(&decoded.data.node_id).await {
-                let valid = self
-                    .processor
+                self.processor
                     .process_chain_data(
                         &decoded.data.node_id,
                         vec![decoded.data.block.clone()],
@@ -48,7 +47,7 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .is_ok();
+                    .ok();
 
                 if let Some(original_event) = original_event {
                     self.store_event(
@@ -56,7 +55,6 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
                         decoded.data.block_height,
                         &decoded.data.block.hash,
                         &decoded.data.node_id.to_string(),
-                        valid,
                     )
                     .await?;
                 }
@@ -90,7 +88,6 @@ impl CompanyChainEventHandler {
         block_height: usize,
         block_hash: &Sha256Hash,
         chain_id: &str,
-        valid: bool,
     ) -> Result<()> {
         let (root, reply) = root_and_reply_id(&event);
         if let Err(e) = self
@@ -108,8 +105,7 @@ impl CompanyChainEventHandler {
                 block_hash: block_hash.to_owned(),
                 received: Timestamp::now(),
                 time: event.created_at.into(),
-                payload: *event.clone(),
-                valid,
+                payload: *event,
             })
             .await
         {

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_handler.rs
@@ -39,7 +39,8 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
         debug!("incoming company chain event");
         if let Ok(decoded) = Event::<CompanyBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.company_store.get_key_pair(&decoded.data.node_id).await {
-                self.processor
+                let valid = self
+                    .processor
                     .process_chain_data(
                         &decoded.data.node_id,
                         vec![decoded.data.block.clone()],
@@ -47,9 +48,9 @@ impl NotificationHandlerApi for CompanyChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .ok();
+                    .is_ok();
 
-                if let Some(original_event) = original_event {
+                if valid && let Some(original_event) = original_event {
                     self.store_event(
                         original_event,
                         decoded.data.block_height,
@@ -109,7 +110,7 @@ impl CompanyChainEventHandler {
             })
             .await
         {
-            error!("Failed to store bill chain nostr event into event store {e}");
+            error!("Failed to store company chain nostr event into event store {e}");
         }
         Ok(())
     }

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
@@ -35,7 +35,7 @@ use bcr_ebill_core::{
     },
 };
 use bcr_ebill_persistence::{
-    FileReferenceStoreApi, NotificationStoreApi,
+    FileReferenceStoreApi, NostrChainEventStoreApi, NotificationStoreApi,
     company::{CompanyChainStoreApi, CompanyStoreApi},
     identity::IdentityStoreApi,
 };
@@ -53,6 +53,7 @@ pub struct CompanyChainEventProcessor {
     nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
     bill_invite_handler: Arc<dyn NotificationHandlerApi>,
     push_service: Arc<dyn PushApi>,
+    chain_event_store: Arc<dyn NostrChainEventStoreApi>,
     transport: Arc<dyn TransportClientApi>,
     bitcoin_network: bitcoin::Network,
 }
@@ -143,6 +144,14 @@ impl CompanyChainEventProcessorApi for CompanyChainEventProcessor {
                 )
                 .await
                 {
+                    if let Err(e) = self
+                        .chain_event_store
+                        .remove_chain_events(&company_id.to_string(), BlockchainType::Company)
+                        .await
+                    {
+                        error!("Failed to invalidate old company chain events during resync: {e}");
+                    }
+
                     for data in chain_data.iter() {
                         let blocks: Vec<CompanyBlock> = data
                             .iter()
@@ -210,6 +219,21 @@ impl CompanyChainEventProcessorApi for CompanyChainEventProcessor {
                                     return Err(e);
                                 }
 
+                                for event_container in data.iter() {
+                                    let event = event_container.as_chain_store_event(
+                                        &company_id.to_string(),
+                                        BlockchainType::Company,
+                                        event_container.block.get_block_height() as usize,
+                                    );
+                                    if let Err(e) =
+                                        self.chain_event_store.add_chain_event(event).await
+                                    {
+                                        error!(
+                                            "Failed to store company chain event during resync: {e}"
+                                        );
+                                    }
+                                }
+
                                 debug!(
                                     "resynced company {company_id} with {} remote events",
                                     data.len()
@@ -255,6 +279,7 @@ impl CompanyChainEventProcessor {
         nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
         bill_invite_handler: Arc<dyn NotificationHandlerApi>,
         push_service: Arc<dyn PushApi>,
+        chain_event_store: Arc<dyn NostrChainEventStoreApi>,
         transport: Arc<dyn TransportClientApi>,
         bitcoin_network: bitcoin::Network,
     ) -> Self {
@@ -267,6 +292,7 @@ impl CompanyChainEventProcessor {
             nostr_contact_processor,
             bill_invite_handler,
             push_service,
+            chain_event_store,
             bitcoin_network,
             transport,
         }
@@ -901,8 +927,8 @@ pub mod tests {
             CompanyChainEventProcessor, CompanyChainEventProcessorApi,
             MockNostrContactProcessorApi, MockNotificationHandlerApi,
             test_utils::{
-                MockCompanyChainStore, MockCompanyStore, MockIdentityStore, get_company_data,
-                node_id_test,
+                MockCompanyChainStore, MockCompanyStore, MockIdentityStore,
+                MockNostrChainEventStore, get_company_data, node_id_test,
             },
         },
         test_utils::{MockNotificationJsonTransport, get_baseline_identity},
@@ -918,6 +944,7 @@ pub mod tests {
             contact,
             bill,
             identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -930,6 +957,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -945,6 +973,7 @@ pub mod tests {
             contact,
             bill,
             identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -968,6 +997,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -989,6 +1019,7 @@ pub mod tests {
             contact,
             bill,
             identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1007,6 +1038,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1028,6 +1060,7 @@ pub mod tests {
             contact,
             bill,
             identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1050,6 +1083,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1070,11 +1104,12 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             mut transport,
             push_service,
         ) = create_mocks();
         let (node_id, (company, keys)) = get_company_data();
-        let blocks = vec![get_company_create_block(
+        let _blocks = [get_company_create_block(
             node_id.clone(),
             company.clone(),
             &keys,
@@ -1143,12 +1178,14 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
 
+        let block = get_company_create_block(node_id.clone(), company.clone(), &keys);
         handler
-            .process_chain_data(&node_id, blocks, Some(keys))
+            .process_chain_data(&node_id, vec![block], Some(keys.clone()))
             .await
             .expect("Process chain data should be handled");
     }
@@ -1162,6 +1199,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1252,6 +1290,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1271,6 +1310,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            mut chain_event_store,
             mut transport,
             push_service,
         ) = create_mocks();
@@ -1424,6 +1464,15 @@ pub mod tests {
             .returning(|_| ())
             .never();
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()))
+            .times(0..);
+
         let handler = CompanyChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
@@ -1433,6 +1482,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1483,6 +1533,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1588,6 +1639,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1607,6 +1659,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1708,6 +1761,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1727,6 +1781,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1828,6 +1883,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1847,6 +1903,7 @@ pub mod tests {
             mut contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -1950,6 +2007,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -1969,6 +2027,7 @@ pub mod tests {
             contact,
             bill,
             mut identity,
+            chain_event_store,
             transport,
             push_service,
         ) = create_mocks();
@@ -2070,6 +2129,7 @@ pub mod tests {
             Arc::new(contact),
             Arc::new(bill),
             Arc::new(push_service),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -2263,7 +2323,7 @@ pub mod tests {
     async fn test_process_company_block_effects_does_not_persist_block() {
         // Verify that process_company_block_effects updates company data
         // but does NOT call blockchain_store.add_block
-        let (mut chain_store, mut store, _, _, _, mut identity_store, _, _) = create_mocks();
+        let (mut chain_store, mut store, _, _, _, mut identity_store, _, _, _) = create_mocks();
 
         let (_, (company, _)) = get_company_data();
         let identity_full = get_baseline_identity();
@@ -2299,6 +2359,7 @@ pub mod tests {
             Arc::new(MockNostrContactProcessorApi::new()),
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(MockPushApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             bitcoin::Network::Testnet,
         );
@@ -2387,6 +2448,7 @@ pub mod tests {
             Arc::new(MockNostrContactProcessorApi::new()),
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(MockPushApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             bitcoin::Network::Testnet,
         );
@@ -2427,6 +2489,7 @@ pub mod tests {
         MockNostrContactProcessorApi,
         MockNotificationHandlerApi,
         MockIdentityStore,
+        MockNostrChainEventStore,
         MockNotificationJsonTransport,
         MockPushApi,
     ) {
@@ -2437,6 +2500,7 @@ pub mod tests {
             MockNostrContactProcessorApi::new(),
             MockNotificationHandlerApi::new(),
             MockIdentityStore::new(),
+            MockNostrChainEventStore::new(),
             MockNotificationJsonTransport::new(),
             MockPushApi::new(),
         )

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use bcr_common::core::NodeId;
@@ -12,7 +12,7 @@ use bcr_ebill_core::{
         event::{ChainInvite, Event},
     },
 };
-use bcr_ebill_persistence::{NostrChainEventStoreApi, nostr::NostrChainEvent};
+use bcr_ebill_persistence::NostrChainEventStoreApi;
 use log::{debug, error, trace, warn};
 
 use crate::{
@@ -127,27 +127,10 @@ impl CompanyInviteEventHandler {
         chain_id: &str,
         chain_type: BlockchainType,
         inserted_chain: Vec<EventContainer>,
-        chains: &[Vec<EventContainer>],
+        _chains: &[Vec<EventContainer>],
     ) -> Result<()> {
-        let mut to_insert: HashMap<String, NostrChainEvent> = HashMap::new();
-
-        // first store the inserted valid blocks
         for (idx, inserted) in inserted_chain.iter().enumerate() {
-            let data = inserted.as_chain_store_event(chain_id, chain_type, idx + 1, true);
-            to_insert.insert(data.event_id.to_owned(), data);
-        }
-
-        // then store all malicious or invalid blocks with their pretended block height
-        for chain in chains {
-            for (idx, data) in chain.iter().enumerate() {
-                if !to_insert.contains_key(&data.event.id.to_string()) {
-                    let data = data.as_chain_store_event(chain_id, chain_type, idx + 1, false);
-                    to_insert.insert(data.event_id.to_owned(), data);
-                }
-            }
-        }
-
-        for (_, data) in to_insert {
+            let data = inserted.as_chain_store_event(chain_id, chain_type, idx + 1);
             if let Err(e) = self.chain_event_store.add_chain_event(data).await {
                 debug!("Could not store chain event because {e}")
             }
@@ -352,19 +335,10 @@ mod tests {
             })
             .returning(|_, _, _| Ok(()));
 
-        // store valid events
         chain_event_store
             .expect_add_chain_event()
-            .withf(|e| e.valid)
             .returning(|_| Ok(()))
             .times(3);
-
-        // store invalid events
-        chain_event_store
-            .expect_add_chain_event()
-            .withf(|e| !e.valid)
-            .returning(|_| Ok(()))
-            .times(1);
 
         let event = generate_test_event(&BcrKeys::new(), None, None, 1);
         let invite = Event::new_company_invite(ChainInvite::company(

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
@@ -39,8 +39,7 @@ impl NotificationHandlerApi for IdentityChainEventHandler {
         debug!("incoming identity chain event");
         if let Ok(decoded) = Event::<IdentityBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.identity_store.get_key_pair().await {
-                let valid = self
-                    .processor
+                self.processor
                     .process_chain_data(
                         &decoded.data.node_id,
                         vec![decoded.data.block.clone()],
@@ -48,14 +47,13 @@ impl NotificationHandlerApi for IdentityChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .is_ok();
+                    .ok();
                 if let Some(original_event) = original_event {
                     self.store_event(
-                        original_event,
+                        &original_event,
                         decoded.data.block_height,
                         &decoded.data.block.hash,
                         &decoded.data.node_id.to_string(),
-                        valid,
                     )
                     .await?;
                 }
@@ -85,13 +83,12 @@ impl IdentityChainEventHandler {
     }
     async fn store_event(
         &self,
-        event: Box<nostr::Event>,
+        event: &nostr::Event,
         block_height: usize,
         block_hash: &Sha256Hash,
         chain_id: &str,
-        valid: bool,
     ) -> Result<()> {
-        let (root, reply) = root_and_reply_id(&event);
+        let (root, reply) = root_and_reply_id(event);
         if let Err(e) = self
             .chain_event_store
             .add_chain_event(NostrChainEvent {
@@ -107,8 +104,7 @@ impl IdentityChainEventHandler {
                 block_hash: block_hash.to_owned(),
                 received: Timestamp::now(),
                 time: event.created_at.into(),
-                payload: *event.clone(),
-                valid,
+                payload: event.clone(),
             })
             .await
         {

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_handler.rs
@@ -39,7 +39,8 @@ impl NotificationHandlerApi for IdentityChainEventHandler {
         debug!("incoming identity chain event");
         if let Ok(decoded) = Event::<IdentityBlockEvent>::try_from(event.clone()) {
             if let Ok(keys) = self.identity_store.get_key_pair().await {
-                self.processor
+                let valid = self
+                    .processor
                     .process_chain_data(
                         &decoded.data.node_id,
                         vec![decoded.data.block.clone()],
@@ -47,8 +48,9 @@ impl NotificationHandlerApi for IdentityChainEventHandler {
                     )
                     .await
                     .inspect_err(|e| error!("Received invalid block {e}"))
-                    .ok();
-                if let Some(original_event) = original_event {
+                    .is_ok();
+
+                if valid && let Some(original_event) = original_event {
                     self.store_event(
                         &original_event,
                         decoded.data.block_height,
@@ -108,7 +110,7 @@ impl IdentityChainEventHandler {
             })
             .await
         {
-            error!("Failed to store bill chain nostr event into event store {e}");
+            error!("Failed to store identity chain nostr event into event store {e}");
         }
         Ok(())
     }

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
@@ -22,6 +22,7 @@ use bcr_ebill_core::{
     },
     protocol::{BlockId, EditOptionalFieldMode},
 };
+use bcr_ebill_persistence::NostrChainEventStoreApi;
 use bcr_ebill_persistence::{
     FileReferenceStoreApi,
     identity::{IdentityChainStoreApi, IdentityStoreApi},
@@ -39,6 +40,7 @@ pub struct IdentityChainEventProcessor {
     company_invite_handler: Arc<dyn NotificationHandlerApi>,
     bill_invite_handler: Arc<dyn NotificationHandlerApi>,
     nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+    chain_event_store: Arc<dyn NostrChainEventStoreApi>,
     transport: Arc<dyn TransportClientApi>,
     bitcoin_network: bitcoin::Network,
 }
@@ -99,6 +101,17 @@ impl IdentityChainEventProcessorApi for IdentityChainEventProcessor {
                 )
                 .await
                 {
+                    if let Err(e) = self
+                        .chain_event_store
+                        .remove_chain_events(
+                            &identity.node_id.to_string(),
+                            BlockchainType::Identity,
+                        )
+                        .await
+                    {
+                        error!("Failed to invalidate old identity chain events during resync: {e}");
+                    }
+
                     for data in chain_data.iter() {
                         let blocks: Vec<IdentityBlock> = data
                             .iter()
@@ -154,6 +167,21 @@ impl IdentityChainEventProcessorApi for IdentityChainEventProcessor {
                                     return Err(e);
                                 }
 
+                                for event_container in data.iter() {
+                                    let event = event_container.as_chain_store_event(
+                                        &identity.node_id.to_string(),
+                                        BlockchainType::Identity,
+                                        event_container.block.get_block_height() as usize,
+                                    );
+                                    if let Err(e) =
+                                        self.chain_event_store.add_chain_event(event).await
+                                    {
+                                        error!(
+                                            "Failed to store identity chain event during resync: {e}"
+                                        );
+                                    }
+                                }
+
                                 debug!(
                                     "resynced identity {} with {} remote events",
                                     identity.node_id,
@@ -200,6 +228,7 @@ impl IdentityChainEventProcessor {
         company_invite_handler: Arc<dyn NotificationHandlerApi>,
         bill_invite_handler: Arc<dyn NotificationHandlerApi>,
         nostr_contact_processor: Arc<dyn NostrContactProcessorApi>,
+        chain_event_store: Arc<dyn NostrChainEventStoreApi>,
         transport: Arc<dyn TransportClientApi>,
         bitcoin_network: bitcoin::Network,
     ) -> Self {
@@ -210,6 +239,7 @@ impl IdentityChainEventProcessor {
             company_invite_handler,
             bill_invite_handler,
             nostr_contact_processor,
+            chain_event_store,
             transport,
             bitcoin_network,
         }
@@ -561,7 +591,8 @@ pub mod tests {
             MockNotificationHandlerApi,
             identity_chain_event_processor::IdentityChainEventProcessor,
             test_utils::{
-                MockIdentityChainStore, MockIdentityStore, get_baseline_identity, node_id_test,
+                MockIdentityChainStore, MockIdentityStore, MockNostrChainEventStore,
+                get_baseline_identity, node_id_test,
             },
         },
         test_utils::{MockFileReferenceStore, MockNotificationJsonTransport},
@@ -570,7 +601,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_create_event_handler() {
-        let (chain_store, store, contact, company_invite, bill_invite, transport) = create_mocks();
+        let (
+            chain_store,
+            store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
         IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
@@ -578,6 +617,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -586,8 +626,15 @@ pub mod tests {
     #[tokio::test]
     async fn test_validate_chain_event_and_sender_invalid_on_no_keys_or_chain() {
         let keys = BcrKeys::new().get_nostr_keys();
-        let (chain_store, mut store, contact, company_invite, bill_invite, transport) =
-            create_mocks();
+        let (
+            chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
 
         store.expect_get().returning(move || {
             Err(bcr_ebill_persistence::Error::NoSuchEntity(
@@ -603,6 +650,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -614,8 +662,15 @@ pub mod tests {
     #[tokio::test]
     async fn test_validate_chain_event_fails_if_not_own_node_id() {
         let keys = BcrKeys::new();
-        let (chain_store, mut store, contact, company_invite, bill_invite, transport) =
-            create_mocks();
+        let (
+            chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
         let identity = get_baseline_identity();
         store
             .expect_get()
@@ -628,6 +683,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -639,8 +695,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_validate_chain_event() {
-        let (chain_store, mut store, contact, company_invite, bill_invite, transport) =
-            create_mocks();
+        let (
+            chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
         let full = get_baseline_identity();
         let mut identity = full.identity.clone();
         identity.name = Name::new("new name").unwrap();
@@ -655,6 +718,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -668,8 +732,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_process_update_identity_data() {
-        let (mut chain_store, mut store, contact, company_invite, bill_invite, transport) =
-            create_mocks();
+        let (
+            mut chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
         let full = get_baseline_identity();
         let identity = full.identity.clone();
         let keys = full.key_pair.clone();
@@ -718,6 +789,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -730,8 +802,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_recovers_chain_on_missing_blocks() {
-        let (mut chain_store, mut store, contact, company_invite, bill_invite, mut transport) =
-            create_mocks();
+        let (
+            mut chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            mut chain_event_store,
+            mut transport,
+        ) = create_mocks();
         let full = get_baseline_identity();
         let identity = full.identity.clone();
         let keys = full.key_pair.clone();
@@ -833,6 +912,15 @@ pub mod tests {
             .returning(|_| Ok(()))
             .times(2);
 
+        chain_event_store
+            .expect_remove_chain_events()
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()))
+            .times(0..);
+
         let handler = IdentityChainEventProcessor::new(
             Arc::new(chain_store),
             Arc::new(store),
@@ -840,6 +928,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -883,8 +972,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_process_identity_proof() {
-        let (mut chain_store, mut store, contact, company_invite, bill_invite, transport) =
-            create_mocks();
+        let (
+            mut chain_store,
+            mut store,
+            contact,
+            company_invite,
+            bill_invite,
+            chain_event_store,
+            transport,
+        ) = create_mocks();
         let full = get_baseline_identity();
         let identity = full.identity.clone();
         let keys = full.key_pair.clone();
@@ -936,6 +1032,7 @@ pub mod tests {
             Arc::new(company_invite),
             Arc::new(bill_invite),
             Arc::new(contact),
+            Arc::new(chain_event_store),
             Arc::new(transport),
             bitcoin::Network::Testnet,
         );
@@ -976,9 +1073,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_process_identity_block_effects_does_not_persist_block() {
-        // Verify that process_identity_block_effects updates identity data
-        // but does NOT call blockchain_store.add_block
-        let (mut chain_store, mut store, contact, _, _, _) = create_mocks();
+        let (mut chain_store, mut store, contact, _, _, _, _) = create_mocks();
 
         let full = get_baseline_identity();
         let identity = full.identity.clone();
@@ -1000,6 +1095,7 @@ pub mod tests {
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(contact),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             bitcoin::Network::Testnet,
         );
@@ -1078,6 +1174,7 @@ pub mod tests {
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(MockNotificationHandlerApi::new()),
             Arc::new(MockNostrContactProcessorApi::new()),
+            Arc::new(MockNostrChainEventStore::new()),
             Arc::new(MockNotificationJsonTransport::new()),
             bitcoin::Network::Testnet,
         );
@@ -1112,6 +1209,7 @@ pub mod tests {
         MockNostrContactProcessorApi,
         MockNotificationHandlerApi,
         MockNotificationHandlerApi,
+        MockNostrChainEventStore,
         MockNotificationJsonTransport,
     ) {
         (
@@ -1120,6 +1218,7 @@ pub mod tests {
             MockNostrContactProcessorApi::new(),
             MockNotificationHandlerApi::new(),
             MockNotificationHandlerApi::new(),
+            MockNostrChainEventStore::new(),
             MockNotificationJsonTransport::new(),
         )
     }

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -729,6 +729,7 @@ mod test_utils {
           async fn find_by_block_hash(&self, hash: &bcr_ebill_core::protocol::Sha256Hash) -> Result<Option<bcr_ebill_persistence::nostr::NostrChainEvent>>;
           async fn add_chain_event(&self, event: bcr_ebill_persistence::nostr::NostrChainEvent) -> Result<()>;
           async fn by_event_id(&self, event_id: &str) -> Result<Option<bcr_ebill_persistence::nostr::NostrChainEvent>>;
+          async fn remove_chain_events(&self, chain_id: &str, chain_type: bcr_ebill_core::protocol::blockchain::BlockchainType) -> Result<()>;
         }
     }
 

--- a/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
+++ b/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
@@ -334,7 +334,6 @@ impl EventContainer {
         chain_id: &str,
         chain_type: BlockchainType,
         block_height: usize,
-        valid: bool,
     ) -> NostrChainEvent {
         NostrChainEvent {
             event_id: self.event.id.to_string(),
@@ -348,7 +347,6 @@ impl EventContainer {
             received: Timestamp::now(),
             time: self.event.created_at.into(),
             payload: self.event.clone(),
-            valid,
         }
     }
 }

--- a/crates/bcr-ebill-transport/src/handler/restore.rs
+++ b/crates/bcr-ebill-transport/src/handler/restore.rs
@@ -14,6 +14,7 @@ use log::{error, info};
 use nostr::filter::Filter;
 
 use crate::handler::DirectMessageEventProcessorApi;
+use bcr_ebill_persistence::NostrChainEventStoreApi;
 
 use super::{
     IdentityChainEventProcessorApi,
@@ -25,6 +26,7 @@ pub struct RestoreAccountService {
     nostr: Arc<dyn TransportClientApi>,
     identity_chain_processor: Arc<dyn IdentityChainEventProcessorApi>,
     dm_processor: Arc<dyn DirectMessageEventProcessorApi>,
+    chain_event_store: Arc<dyn NostrChainEventStoreApi>,
     keys: BcrKeys,
     node_id: NodeId,
 }
@@ -35,6 +37,7 @@ impl RestoreAccountService {
         nostr: Arc<dyn TransportClientApi>,
         identity_chain_processor: Arc<dyn IdentityChainEventProcessorApi>,
         dm_processor: Arc<dyn DirectMessageEventProcessorApi>,
+        chain_event_store: Arc<dyn NostrChainEventStoreApi>,
         keys: BcrKeys,
         node_id: NodeId,
     ) -> Self {
@@ -42,6 +45,7 @@ impl RestoreAccountService {
             nostr,
             identity_chain_processor,
             dm_processor,
+            chain_event_store,
             keys,
             node_id,
         }
@@ -96,6 +100,16 @@ impl RestoreAccountService {
                 self.identity_chain_processor
                     .process_chain_data(&self.node_id, blocks, Some(self.keys.clone()))
                     .await?;
+                for event_container in &chain {
+                    let event = event_container.as_chain_store_event(
+                        &self.node_id.to_string(),
+                        BlockchainType::Identity,
+                        event_container.block.get_block_height() as usize,
+                    );
+                    if let Err(e) = self.chain_event_store.add_chain_event(event).await {
+                        error!("Failed to store identity chain event during restore: {e}");
+                    }
+                }
                 info!("restored identity chain from {} events", chain.len());
             }
         }
@@ -142,7 +156,7 @@ mod tests {
     use crate::{
         handler::{
             MockDirectMessageEventProcessorApi, MockIdentityChainEventProcessorApi,
-            test_utils::{get_baseline_identity, private_key_test},
+            test_utils::{MockNostrChainEventStore, get_baseline_identity, private_key_test},
         },
         test_utils::{MockNotificationJsonTransport, node_id_test, test_ts},
         transport::create_public_chain_event,
@@ -155,6 +169,7 @@ mod tests {
         let mut nostr = MockNotificationJsonTransport::new();
         let processor = MockIdentityChainEventProcessorApi::new();
         let dm_processor = MockDirectMessageEventProcessorApi::new();
+        let chain_event_store = MockNostrChainEventStore::new();
         let keys = BcrKeys::new();
 
         nostr
@@ -171,6 +186,7 @@ mod tests {
             Arc::new(nostr),
             Arc::new(processor),
             Arc::new(dm_processor),
+            Arc::new(chain_event_store),
             keys,
             node_id_test(),
         )
@@ -188,13 +204,12 @@ mod tests {
         let mut nostr = MockNotificationJsonTransport::new();
         let mut processor = MockIdentityChainEventProcessorApi::new();
         let dm_processor = MockDirectMessageEventProcessorApi::new();
+        let mut chain_event_store = MockNostrChainEventStore::new();
 
-        // given some node id
-        let return_events = events.clone();
-        // and identity chain events
+        let _return_events = events.clone();
         nostr
             .expect_resolve_public_chain()
-            .returning(move |_, _| Ok(return_events.clone()))
+            .returning(move |_, _| Ok(_return_events.clone()))
             .once();
 
         // should validate the event sender
@@ -210,6 +225,12 @@ mod tests {
             .returning(|_, _, _| Ok(()))
             .once();
 
+        chain_event_store
+            .expect_add_chain_event()
+            .with(always())
+            .returning(|_| Ok(()))
+            .times(events.len());
+
         nostr
             .expect_resolve_private_events()
             .returning(|_| Ok(vec![]))
@@ -219,6 +240,7 @@ mod tests {
             Arc::new(nostr),
             Arc::new(processor),
             Arc::new(dm_processor),
+            Arc::new(chain_event_store),
             keys,
             node_id_test(),
         )

--- a/crates/bcr-ebill-transport/src/lib.rs
+++ b/crates/bcr-ebill-transport/src/lib.rs
@@ -144,6 +144,7 @@ pub async fn create_transport_service(
         db_context.bill_store.clone(),
         db_context.file_reference_store.clone(),
         nostr_contact_processor.clone(),
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         mint_client,
         get_config().bitcoin_network(),
@@ -161,6 +162,7 @@ pub async fn create_transport_service(
         nostr_contact_processor.clone(),
         bill_invite_handler.clone(),
         push_service,
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         get_config().bitcoin_network(),
     ));
@@ -176,6 +178,7 @@ pub async fn create_transport_service(
         Arc::new(company_invite_handler.clone()),
         bill_invite_handler.clone(),
         nostr_contact_processor.clone(),
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         get_config().bitcoin_network(),
     ));
@@ -244,6 +247,7 @@ pub async fn create_nostr_consumer(
         db_context.bill_store.clone(),
         db_context.file_reference_store.clone(),
         nostr_contact_processor.clone(),
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         mint_client,
         get_config().bitcoin_network(),
@@ -263,6 +267,7 @@ pub async fn create_nostr_consumer(
         nostr_contact_processor.clone(),
         bill_invite_handler.clone(),
         push_service.clone(),
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         get_config().bitcoin_network(),
     ));
@@ -280,6 +285,7 @@ pub async fn create_nostr_consumer(
         Arc::new(company_invite_handler.clone()),
         bill_invite_handler.clone(),
         nostr_contact_processor.clone(),
+        db_context.nostr_chain_event_store.clone(),
         transport.clone(),
         get_config().bitcoin_network(),
     ));
@@ -371,6 +377,7 @@ pub async fn create_restore_account_service(
         db_context.bill_store.clone(),
         db_context.file_reference_store.clone(),
         nostr_contact_processor.clone(),
+        db_context.nostr_chain_event_store.clone(),
         nostr_client.clone(),
         mint_client,
         get_config().bitcoin_network(),
@@ -390,6 +397,7 @@ pub async fn create_restore_account_service(
         nostr_contact_processor.clone(),
         bill_invite_handler.clone(),
         push_service,
+        db_context.nostr_chain_event_store.clone(),
         nostr_client.clone(),
         config.bitcoin_network(),
     ));
@@ -407,6 +415,7 @@ pub async fn create_restore_account_service(
         company_invite_handler.clone(),
         bill_invite_handler.clone(),
         nostr_contact_processor,
+        db_context.nostr_chain_event_store.clone(),
         nostr_client.clone(),
         config.bitcoin_network(),
     ));
@@ -425,8 +434,13 @@ pub async fn create_restore_account_service(
         .await,
     );
 
-    Ok(
-        RestoreAccountService::new(nostr_client, processor, dm_processor, keys.clone(), node_id)
-            .await,
+    Ok(RestoreAccountService::new(
+        nostr_client,
+        processor,
+        dm_processor,
+        db_context.nostr_chain_event_store.clone(),
+        keys.clone(),
+        node_id,
     )
+    .await)
 }

--- a/crates/bcr-ebill-transport/src/nostr_transport.rs
+++ b/crates/bcr-ebill-transport/src/nostr_transport.rs
@@ -296,7 +296,6 @@ impl NostrTransportService {
                 received: event.created_at.into(),
                 time: event.created_at.into(),
                 payload: event.clone(),
-                valid: true,
             })
             .await
             .map_err(|_| Error::Persistence("failed to write to chain events".to_owned()))?;

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -736,6 +736,7 @@ mockall::mock! {
         async fn find_by_block_hash(&self, hash: &Sha256Hash) -> bcr_ebill_persistence::Result<Option<NostrChainEvent>>;
         async fn add_chain_event(&self, event: NostrChainEvent) -> bcr_ebill_persistence::Result<()>;
         async fn by_event_id(&self, event_id: &str) -> bcr_ebill_persistence::Result<Option<NostrChainEvent>>;
+        async fn remove_chain_events(&self, chain_id: &str, chain_type: BlockchainType) -> bcr_ebill_persistence::Result<()>;
     }
 }
 


### PR DESCRIPTION
## 📝 Description

Fixes #902. Issue was that on restore we only restored the plain block but not the event chain cache. This leads to disconnected block published after restore. Now we write the cache when processing restore blocks. I discovered another issue (blockchains disconnect after re-sync for the same reason, cache can have invalid tips) which is also fixed with this PR. 

Relates to #902 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **Bug Fixes:**
  - Recover event chain together with blockchain
  - Also recover other event chains when a chain re-sync happens

- **Other Changes:**
  - Only store the selected valid chain in event chain (others are deleted on invalid)

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Create account, backup seed
2. Restore account from seed, create company
3. Restore account again and observe that all identity chain block (incl. company) are used on recover

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
