### PR TITLE
Restore contact invites on recover

### DIFF
--- a/crates/bcr-ebill-transport/src/lib.rs
+++ b/crates/bcr-ebill-transport/src/lib.rs
@@ -396,7 +396,7 @@ pub async fn create_restore_account_service(
         db_context.notification_store.clone(),
         nostr_contact_processor.clone(),
         bill_invite_handler.clone(),
-        push_service,
+        push_service.clone(),
         db_context.nostr_chain_event_store.clone(),
         nostr_client.clone(),
         config.bitcoin_network(),
@@ -406,6 +406,15 @@ pub async fn create_restore_account_service(
         nostr_client.clone(),
         company_processor.clone(),
         db_context.nostr_chain_event_store.clone(),
+    ));
+
+    let contact_share_handler = Arc::new(ContactShareEventHandler::new(
+        nostr_client.clone(),
+        db_context.contact_store.clone(),
+        db_context.nostr_contact_store.clone(),
+        db_context.file_reference_store.clone(),
+        db_context.notification_store.clone(),
+        push_service,
     ));
 
     let processor = Arc::new(IdentityChainEventProcessor::new(
@@ -426,7 +435,11 @@ pub async fn create_restore_account_service(
             contact_service.clone(),
             db_context.nostr_event_offset_store.clone(),
             chain_key_service.clone(),
-            vec![company_invite_handler, bill_invite_handler],
+            vec![
+                company_invite_handler,
+                bill_invite_handler,
+                contact_share_handler,
+            ],
             Arc::new(FileMetadataProcessor::new(
                 db_context.file_reference_store.clone(),
             )),


### PR DESCRIPTION
## 📝 Description

Adds contact share handler to recovery processor. This will add all previously shared contacts into pending contact shares again and allow the user to add them later from the list. We need to keep them pending as we do not know which ones where already accepted (or rejected) before the restore.

Relates to: #699 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Restore received contact invites

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
