### PR TITLE
Upgrade E-Bill bcr-common and cashu to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.5.11
 
+* Update to latest bcr-common and cashu 0.16
+
 # 0.5.10
 
 * Fix company creation with identity upload and missing nostr node id during block propagation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "f37981f209b9360ea03bd4dd0ede7e89cafeff78" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "b8c8fd0ff9de3b9fbe1bc5d7650af3f8f635591e" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-api/Cargo.toml
+++ b/crates/bcr-ebill-api/Cargo.toml
@@ -30,7 +30,6 @@ bcr-common.workspace = true
 tokio.workspace = true
 tokio_with_wasm.workspace = true
 secp256k1.workspace = true
-bcr-wallet-lib = { git = "https://github.com/BitcreditProtocol/Wallet-Core", tag = "v0.6.0" }
 rand = { version = "0.9" }
 strum.workspace = true
 hex = { version = "0.4" }

--- a/crates/bcr-ebill-api/src/external/mint.rs
+++ b/crates/bcr-ebill-api/src/external/mint.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use bcr_common::cashu::{self, ProofsMethods, State, nut01 as cdk01, nut02 as cdk02};
 use bcr_common::client::mint::Client as ExternalMintClient;
-use bcr_common::core::BillId;
+use bcr_common::core::{BillId, keys::to_fee_and_amounts};
+use bcr_common::wallet;
 use bcr_common::wire::quotes::{ResolveOffer, StatusReply};
 use bcr_ebill_core::protocol::{BitcoinAddress, BlockId, Sha256Hash, Sum};
 use bcr_ebill_core::{
@@ -51,6 +52,9 @@ pub enum Error {
     /// all errors originating from tokens and mints not matching
     #[error("External Mint Token and Mint don't match Error")]
     TokenAndMintDontMatch,
+    /// all errors originating from cashu amount generation
+    #[error("External Mint Amount Error")]
+    Amount,
     /// all errors originating from blind message generation
     #[error("External Mint BlindMessage Error")]
     BlindMessage,
@@ -171,8 +175,7 @@ impl MintClientApi for MintClient {
     ) -> Result<bool> {
         let token_mint_url =
             cashu::MintUrl::from_str(mint_url.as_str()).map_err(|_| Error::InvalidMintUrl)?;
-        let token =
-            bcr_wallet_lib::wallet::Token::from_str(proofs).map_err(|_| Error::InvalidToken)?;
+        let token = wallet::Token::from_str(proofs).map_err(|_| Error::InvalidToken)?;
 
         if token_mint_url != token.mint_url() {
             return Err(Error::InvalidToken.into());
@@ -253,12 +256,8 @@ impl MintClientApi for MintClient {
         })?;
 
         // generate token from proofs
-        let token = bcr_wallet_lib::wallet::Token::new_bitcr(
-            token_mint_url,
-            proofs,
-            Some(bill_id.to_string()),
-            currency,
-        );
+        let token =
+            wallet::Token::new_bitcr(token_mint_url, proofs, Some(bill_id.to_string()), currency);
 
         Ok(token.to_string())
     }
@@ -408,20 +407,23 @@ impl MintClientApi for MintClient {
 }
 
 pub fn generate_blinds(
-    keyset_id: cashu::Id,
+    keyset: &cdk02::KeySet,
     discounted_amount: Sum,
 ) -> Result<(
     Vec<cashu::BlindedMessage>,
     Vec<cashu::secret::Secret>,
     Vec<cashu::SecretKey>,
 )> {
-    let amounts: Vec<cashu::Amount> = cashu::Amount::from(discounted_amount.as_sat()).split();
+    let amount = cashu::Amount::from(discounted_amount.as_sat());
+    let amounts: Vec<cashu::Amount> = amount
+        .split(&to_fee_and_amounts(keyset))
+        .map_err(|_| Error::Amount)?;
     let mut blinded_messages = Vec::with_capacity(amounts.len());
     let mut secrets = Vec::with_capacity(amounts.len());
     let mut rs = Vec::with_capacity(amounts.len());
 
     for amount in amounts {
-        let blind = generate_blind(keyset_id, amount)?;
+        let blind = generate_blind(keyset.id, amount)?;
         blinded_messages.push(blind.0);
         secrets.push(blind.1);
         rs.push(blind.2);

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -384,7 +384,7 @@ impl BillService {
                             .await
                         {
                             // keyset info is available
-                            Ok(keyset_info) => {
+                            Ok(keyset) => {
                                 // fetch private key for requester
                                 let private_key = match self.identity_store.get_full().await {
                                     Ok(identity) => {
@@ -423,10 +423,7 @@ impl BillService {
                                 );
                                 // generate blinds
                                 let (blinded_messages, secrets, rs) =
-                                    external::mint::generate_blinds(
-                                        keyset_info.id,
-                                        offer.discounted_sum,
-                                    )?;
+                                    external::mint::generate_blinds(&keyset, offer.discounted_sum)?;
                                 // persist recovery data in case something goes wrong after minting
                                 // getting here a second time for this offer will fail, which is OK
                                 // since it means that either minting, or proof creation failed and we can't
@@ -457,7 +454,7 @@ impl BillService {
                                     .mint(
                                         &mint_request.bill_id,
                                         &mint_cfg.default_mint_url,
-                                        keyset_info,
+                                        keyset,
                                         &mint_request.mint_request_id,
                                         &private_key,
                                         blinded_messages,

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -7298,6 +7298,8 @@ async fn check_mint_state_minting_enabled_proofs() {
             unit: bcr_common::cashu::CurrencyUnit::Sat,
             keys: bcr_common::cashu::Keys::new(std::collections::BTreeMap::default()),
             final_expiry: None,
+            active: Some(true),
+            input_fee_ppk: 0,
         })
     });
     ctx.mint_client
@@ -7353,6 +7355,8 @@ async fn check_mint_state_minting_enabled_check_spent() {
             unit: bcr_common::cashu::CurrencyUnit::Sat,
             keys: bcr_common::cashu::Keys::new(std::collections::BTreeMap::default()),
             final_expiry: None,
+            active: Some(true),
+            input_fee_ppk: 0,
         })
     });
     ctx.mint_client


### PR DESCRIPTION
* Remove outdated `bcr_wallet_lib` library
* Upgrade to latest bcr-common with cashu 0.16.0 from https://github.com/BitcreditProtocol/bcr-common/pull/135

(TBD: update to bcr-common rev when merged)