### PR TITLE
Options on refresh bill, more active cache clears

### DIFF
--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -279,6 +279,10 @@ impl BillService {
             }
             _ => None,
         } {
+            if let Err(e) = self.store.invalidate_bill_in_cache(bill_id).await {
+                error!("Failed to invalidate cache for {bill_id} before timeout notification: {e}");
+            }
+
             // did we already send the notification
             let sent = self
                 .transport_service

--- a/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
@@ -21,8 +21,9 @@ pub trait BlockTransportServiceApi: ServiceTraitBounds {
     async fn send_company_chain_events(&self, events: CompanyChainEvent) -> Result<()>;
     /// Sent when: A bill chain is created or updated
     async fn send_bill_chain_events(&self, events: BillChainEvent) -> Result<()>;
-    /// Resync bill chain
-    async fn resync_bill_chain(&self, bill_id: &BillId) -> Result<()>;
+    /// Resync bill chain. If `from_nostr` is true, fetches missing blocks from Nostr first.
+    /// If false, only invalidates the local cache.
+    async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
     /// Resync company chain
     async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
     /// Resync identity chain

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -277,10 +277,11 @@ impl BlockTransportServiceApi for BlockTransportService {
         Ok(())
     }
 
-    /// Resync bill chain
-    async fn resync_bill_chain(&self, bill_id: &BillId) -> Result<()> {
+    /// Resync bill chain. If `from_nostr` is true, fetches missing blocks from Nostr first.
+    /// If false, only invalidates the local cache.
+    async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()> {
         self.bill_chain_event_processor
-            .resync_chain(bill_id)
+            .resync_chain(bill_id, from_nostr)
             .await?;
         Ok(())
     }

--- a/crates/bcr-ebill-transport/src/handler/bill_action_event_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_action_event_handler.rs
@@ -69,6 +69,17 @@ impl BillActionEventHandler {
             return Ok(());
         }
 
+        if let Err(e) = self
+            .processor
+            .invalidate_cache_for_bill(&event.bill_id)
+            .await
+        {
+            error!(
+                "Failed to invalidate cache for bill {} before notification: {e}",
+                event.bill_id
+            );
+        }
+
         let is_new_actionable = event
             .action_type
             .as_ref()
@@ -343,6 +354,12 @@ mod tests {
             .expect_validate_chain_event_and_sender()
             .with(eq(bill_id_test()), always())
             .returning(|_, _| Ok(true));
+
+        chain_processor
+            .expect_invalidate_cache_for_bill()
+            .with(eq(bill_id_test()))
+            .times(1)
+            .returning(|_| Ok(()));
 
         // check for deduplication
         notification_store

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
@@ -104,7 +104,12 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
         .await
     }
 
-    async fn resync_chain(&self, bill_id: &BillId) -> Result<()> {
+    async fn resync_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()> {
+        if !from_nostr {
+            debug!("invalidating cache for {bill_id} without Nostr refetch");
+            return self.invalidate_cache_for_bill(bill_id).await;
+        }
+
         match (
             self.bill_blockchain_store.get_chain(bill_id).await,
             self.bill_store.get_keys(bill_id).await,
@@ -252,6 +257,16 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
             }
         }
     }
+
+    async fn invalidate_cache_for_bill(&self, bill_id: &BillId) -> Result<()> {
+        if let Err(e) = self.bill_store.invalidate_bill_in_cache(bill_id).await {
+            error!("Failed to invalidate cache for bill {bill_id}: {e}");
+            return Err(Error::Persistence(
+                "Failed to invalidate cache for bill".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -331,7 +346,7 @@ impl BillChainEventProcessor {
                             "Split chain detected for bill {bill_id} at height {} - resyncing",
                             block.id
                         );
-                        self.resync_chain(bill_id).await?;
+                        self.resync_chain(bill_id, true).await?;
                         return Ok(());
                     }
                 }
@@ -366,7 +381,7 @@ impl BillChainEventProcessor {
                             "Received invalid block {} for bill {bill_id} - missing blocks - try to resync",
                             block.id
                         );
-                        self.resync_chain(bill_id).await?;
+                        self.resync_chain(bill_id, true).await?;
                         break;
                     } else {
                         error!("Error adding block for bill {bill_id}: {e}");
@@ -799,16 +814,6 @@ impl BillChainEventProcessor {
             error!("Failed to add block to blockchain store: {e}");
             return Err(Error::Persistence(
                 "Failed to add block to blockchain store".to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    async fn invalidate_cache_for_bill(&self, bill_id: &BillId) -> Result<()> {
-        if let Err(e) = self.bill_store.invalidate_bill_in_cache(bill_id).await {
-            error!("Failed to invalidate cache for bill {bill_id}: {e}");
-            return Err(Error::Persistence(
-                "Failed to invalidate cache for bill".to_string(),
             ));
         }
         Ok(())
@@ -2019,7 +2024,7 @@ mod tests {
 
         // This should process the valid chain and exit
         handler
-            .resync_chain(&bill_id)
+            .resync_chain(&bill_id, true)
             .await
             .expect("resync should succeed");
     }
@@ -2160,7 +2165,7 @@ mod tests {
         );
 
         handler
-            .resync_chain(&bill_id)
+            .resync_chain(&bill_id, true)
             .await
             .expect("resync should succeed with fork resolution");
     }
@@ -2275,7 +2280,7 @@ mod tests {
             bitcoin::Network::Testnet,
         );
 
-        let result = handler.resync_chain(&bill_id).await;
+        let result = handler.resync_chain(&bill_id, true).await;
 
         assert!(result.is_ok());
     }

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -99,10 +99,13 @@ pub trait BillChainEventProcessorApi: ServiceTraitBounds {
         bill_keys: &BcrKeys,
     ) -> Result<Vec<Vec<EventContainer>>>;
 
-    /// Tries to resync the chain for the given bill id. This will try to find the bill keys and
-    /// then try to find the chain data for the given bill id. Will add all potentially missing
-    /// blocks to the chain.
-    async fn resync_chain(&self, bill_id: &BillId) -> Result<()>;
+    /// Tries to resync the chain for the given bill id. If `from_nostr` is true, this will try to
+    /// find the bill keys and then try to find the chain data from Nostr. Will add all potentially
+    /// missing blocks to the chain. If `from_nostr` is false, only invalidates the local cache.
+    async fn resync_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
+
+    /// Invalidates the cached bill data for the given bill id.
+    async fn invalidate_cache_for_bill(&self, bill_id: &BillId) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -470,7 +470,7 @@ mockall::mock! {
         async fn send_identity_chain_events(&self, events: IdentityChainEvent) -> Result<()>;
         async fn send_company_chain_events(&self, events: CompanyChainEvent) -> Result<()>;
         async fn send_bill_chain_events(&self, events: BillChainEvent) -> Result<()>;
-        async fn resync_bill_chain(&self, bill_id: &BillId) -> Result<()>;
+        async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
         async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
         async fn resync_identity_chain(&self) -> Result<()>;
     }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -1077,7 +1077,7 @@ impl Bill {
             get_ctx()
                 .transport_service
                 .block_transport()
-                .resync_bill_chain(&payload.bill_id)
+                .resync_bill_chain(&payload.bill_id, payload.from_nostr)
                 .await?;
             Ok(())
         }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -1077,7 +1077,7 @@ impl Bill {
             get_ctx()
                 .transport_service
                 .block_transport()
-                .resync_bill_chain(&payload.bill_id, payload.from_nostr)
+                .resync_bill_chain(&payload.bill_id, payload.from_nostr.unwrap_or(false))
                 .await?;
             Ok(())
         }

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -252,8 +252,7 @@ impl From<SweepResult> for BillSweepBTCFundsResultWeb {
 pub struct ResyncBillPayload {
     #[tsify(type = "string")]
     pub bill_id: BillId,
-    #[serde(default)]
-    pub from_nostr: bool,
+    pub from_nostr: Option<bool>,
 }
 
 impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -252,6 +252,8 @@ impl From<SweepResult> for BillSweepBTCFundsResultWeb {
 pub struct ResyncBillPayload {
     #[tsify(type = "string")]
     pub bill_id: BillId,
+    #[serde(default)]
+    pub from_nostr: bool,
 }
 
 impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {


### PR DESCRIPTION
## 📝 Description

Allows cache clearing from ui via sync_bill_chain (default), allows re-fetch from Nostr with additional flag (from_nostr: true). Also clears bill cache before adding notifications.

Relates to #923 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
