### PR TITLE
Optimistic broadcast with retry queuing

### DIFF
--- a/crates/bcr-ebill-api/src/lib.rs
+++ b/crates/bcr-ebill-api/src/lib.rs
@@ -100,6 +100,9 @@ pub struct NostrConfig {
     /// Maximum number of contact relays to add (in addition to user relays which are always included).
     /// Defaults to 50 if not specified.
     pub max_relays: Option<usize>,
+    /// Number of relay acknowledgements required before an optimistic broadcast
+    /// returns to the caller. The remaining relays continue publishing in the background.
+    pub relay_ack_threshold: usize,
 }
 
 impl Default for NostrConfig {
@@ -109,6 +112,7 @@ impl Default for NostrConfig {
             relays: vec![],
             blossom_servers: vec![],
             max_relays: Some(50),
+            relay_ack_threshold: 1,
         }
     }
 }

--- a/crates/bcr-ebill-api/src/service/file_server_service.rs
+++ b/crates/bcr-ebill-api/src/service/file_server_service.rs
@@ -380,6 +380,7 @@ mod tests {
             relays: vec![url::Url::parse("wss://relay.example.com").unwrap()],
             blossom_servers: vec![],
             max_relays: Some(50),
+            relay_ack_threshold: 1,
         }
     }
 

--- a/crates/bcr-ebill-api/src/service/transport_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/mod.rs
@@ -175,6 +175,9 @@ pub struct NostrConfig {
     pub default_timeout: Duration,
     pub is_primary: bool,
     pub node_id: NodeId,
+    /// Number of relay acknowledgements required before an optimistic broadcast
+    /// returns to the caller. The remaining relays continue publishing in the background.
+    pub relay_ack_threshold: usize,
 }
 
 impl NostrConfig {
@@ -193,7 +196,13 @@ impl NostrConfig {
             default_timeout: Duration::from_secs(20),
             is_primary,
             node_id,
+            relay_ack_threshold: 1,
         }
+    }
+
+    pub fn with_relay_ack_threshold(mut self, threshold: usize) -> Self {
+        self.relay_ack_threshold = threshold.max(1);
+        self
     }
 
     pub fn get_npub(&self) -> String {

--- a/crates/bcr-ebill-api/src/service/transport_service/transport_client.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/transport_client.rs
@@ -42,6 +42,13 @@ pub trait TransportClientApi: ServiceTraitBounds {
     ) -> Result<Event>;
     /// Broadcasts a pre-signed event to all configured relays.
     async fn broadcast_event(&self, event: &Event) -> Result<()>;
+    /// Broadcasts a pre-signed event to all configured relays, returning as soon as
+    /// `min_acks` relays have acknowledged it. Remaining relays continue publishing
+    /// in the background.
+    async fn broadcast_event_optimistic(&self, event: &Event, min_acks: usize) -> Result<()>;
+    /// Returns the configured minimum number of relay acknowledgements required for
+    /// an optimistic broadcast to return early.
+    fn relay_ack_threshold(&self) -> usize;
     /// Resolves a nostr contact by node id.
     async fn resolve_contact(&self, node_id: &NodeId) -> Result<Option<NostrContactData>>;
     /// Given an id and chain type, tries to resolve the public chain events.

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -554,6 +554,7 @@ pub mod tests {
                         relays: vec![url::Url::parse("ws://localhost:8080").unwrap()],
                         blossom_servers: vec![],
                         max_relays: Some(50),
+                        relay_ack_threshold: 1,
                     },
                     mint_config: MintConfig {
                         default_mint_url: url::Url::parse("http://localhost:4242/").unwrap(),
@@ -767,12 +768,19 @@ pub mod tests {
         }
 
         #[test]
+        fn test_nostr_config_default_threshold() {
+            let config = NostrConfig::default();
+            assert_eq!(config.relay_ack_threshold, 1);
+        }
+
+        #[test]
         fn test_nostr_config_with_custom_max_relays() {
             let config = NostrConfig {
                 only_known_contacts: true,
                 relays: vec![],
                 blossom_servers: vec![],
                 max_relays: Some(100),
+                relay_ack_threshold: 1,
             };
             assert_eq!(config.max_relays, Some(100));
         }
@@ -784,8 +792,10 @@ pub mod tests {
                 relays: vec![],
                 blossom_servers: vec![],
                 max_relays: None,
+                relay_ack_threshold: 2,
             };
             assert_eq!(config.max_relays, None);
+            assert_eq!(config.relay_ack_threshold, 2);
         }
     }
 }

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -104,7 +104,11 @@ impl BlockTransportServiceApi for BlockTransportService {
                 )
                 .await?;
 
-            if let Err(e) = node.broadcast_event(&nostr_event).await {
+            let threshold = node.relay_ack_threshold();
+            if let Err(e) = node
+                .broadcast_event_optimistic(&nostr_event, threshold)
+                .await
+            {
                 error!("Failed to broadcast identity chain event, queuing for retry: {e}");
                 let payload = serde_json::to_string(&nostr_event)
                     .map_err(|e| Error::Message(e.to_string()))?;
@@ -159,7 +163,11 @@ impl BlockTransportServiceApi for BlockTransportService {
                 )
                 .await?;
 
-            if let Err(e) = node.broadcast_event(&nostr_event).await {
+            let threshold = node.relay_ack_threshold();
+            if let Err(e) = node
+                .broadcast_event_optimistic(&nostr_event, threshold)
+                .await
+            {
                 error!("Failed to broadcast company chain event, queuing for retry: {e}");
                 let payload = serde_json::to_string(&nostr_event)
                     .map_err(|e| Error::Message(e.to_string()))?;

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -323,6 +323,7 @@ mod tests {
     use crate::test_utils::{
         MockContactStore, MockNostrChainEventStore, MockNostrContactStore,
         MockNostrQueuedMessageStore, MockNotificationJsonTransport, get_nostr_transport,
+        get_test_company_chain_event, get_test_identity_chain_event,
     };
     use bcr_ebill_core::protocol::Sha256Hash;
     use bcr_ebill_core::protocol::blockchain::BlockchainType;
@@ -355,10 +356,13 @@ mod tests {
         }
     }
 
-    fn get_service(chain_event_store: MockNostrChainEventStore) -> BlockTransportService {
+    fn get_service_with_transport(
+        mock_transport: MockNotificationJsonTransport,
+        chain_event_store: MockNostrChainEventStore,
+    ) -> BlockTransportService {
         BlockTransportService::new(
             Arc::new(get_nostr_transport(
-                MockNotificationJsonTransport::new(),
+                mock_transport,
                 MockContactStore::new(),
                 MockNostrContactStore::new(),
                 MockNostrQueuedMessageStore::new(),
@@ -368,6 +372,10 @@ mod tests {
             Arc::new(MockCompanyChainEventProcessorApi::new()),
             Arc::new(MockIdentityChainEventProcessorApi::new()),
         )
+    }
+
+    fn get_service(chain_event_store: MockNostrChainEventStore) -> BlockTransportService {
+        get_service_with_transport(MockNotificationJsonTransport::new(), chain_event_store)
     }
 
     #[tokio::test]
@@ -438,5 +446,115 @@ mod tests {
         let (previous, root) = result.unwrap();
         assert!(previous.is_some());
         assert!(root.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_identity_chain_event_uses_optimistic_broadcast() {
+        let signed_event = nostr::EventBuilder::text_note("identity chain event")
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap();
+        let mut transport = MockNotificationJsonTransport::new();
+        transport
+            .expect_build_public_chain_event()
+            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+        transport.expect_relay_ack_threshold().returning(|| 1);
+        transport
+            .expect_broadcast_event_optimistic()
+            .withf(|_event, min_acks| *min_acks == 1)
+            .returning(|_, _| Ok(()));
+
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(|_| Ok(None));
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()));
+
+        let service = get_service_with_transport(transport, chain_event_store);
+        let event = get_test_identity_chain_event();
+
+        let result = service.send_identity_chain_events(event).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_company_chain_event_uses_optimistic_broadcast() {
+        let signed_event = nostr::EventBuilder::text_note("company chain event")
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap();
+        let mut transport = MockNotificationJsonTransport::new();
+        transport
+            .expect_build_public_chain_event()
+            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+        transport.expect_relay_ack_threshold().returning(|| 1);
+        transport
+            .expect_broadcast_event_optimistic()
+            .withf(|_event, min_acks| *min_acks == 1)
+            .returning(|_, _| Ok(()));
+
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(|_| Ok(None));
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()));
+
+        let service = get_service_with_transport(transport, chain_event_store);
+        let event = get_test_company_chain_event();
+
+        let result = service.send_company_chain_events(event).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_error_triggers_full_message_retry() {
+        let signed_event = nostr::EventBuilder::text_note("retry event")
+            .sign_with_keys(&nostr::Keys::generate())
+            .unwrap();
+        let mut transport = MockNotificationJsonTransport::new();
+        transport
+            .expect_build_public_chain_event()
+            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+        transport.expect_relay_ack_threshold().returning(|| 1);
+        transport
+            .expect_broadcast_event_optimistic()
+            .withf(|_event, min_acks| *min_acks == 1)
+            .returning(|_, _| Err(Error::Network("relay failed".to_string())));
+
+        let mut chain_event_store = MockNostrChainEventStore::new();
+        chain_event_store
+            .expect_find_by_block_hash()
+            .returning(|_| Ok(None));
+        chain_event_store
+            .expect_add_chain_event()
+            .returning(|_| Ok(()));
+
+        let mut queued_message_store = MockNostrQueuedMessageStore::new();
+        queued_message_store
+            .expect_add_message()
+            .times(1)
+            .returning(|_, _| Ok(()));
+        queued_message_store
+            .expect_get_retry_messages()
+            .returning(|_| Ok(vec![]));
+
+        let service = BlockTransportService::new(
+            Arc::new(get_nostr_transport(
+                transport,
+                MockContactStore::new(),
+                MockNostrContactStore::new(),
+                queued_message_store,
+                chain_event_store,
+            )),
+            Arc::new(MockBillChainEventProcessorApi::new()),
+            Arc::new(MockCompanyChainEventProcessorApi::new()),
+            Arc::new(MockIdentityChainEventProcessorApi::new()),
+        );
+        let event = get_test_identity_chain_event();
+
+        let result = service.send_identity_chain_events(event).await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -231,7 +231,11 @@ impl BlockTransportServiceApi for BlockTransportService {
                 )
                 .await?;
 
-            if let Err(e) = node.broadcast_event(&nostr_event).await {
+            let threshold = node.relay_ack_threshold();
+            if let Err(e) = node
+                .broadcast_event_optimistic(&nostr_event, threshold)
+                .await
+            {
                 error!("Failed to broadcast bill chain event, queuing for retry: {e}");
                 let payload = serde_json::to_string(&nostr_event)
                     .map_err(|e| Error::Message(e.to_string()))?;

--- a/crates/bcr-ebill-transport/src/lib.rs
+++ b/crates/bcr-ebill-transport/src/lib.rs
@@ -109,6 +109,7 @@ pub async fn create_nostr_clients(
         config.nostr_config.blossom_servers.clone(),
         std::time::Duration::from_secs(20),
         config.nostr_config.max_relays,
+        config.nostr_config.relay_ack_threshold,
         Some(nostr_contact_store),
     )
     .await?;

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -2461,12 +2461,14 @@ mod relay_calculation_tests {
 
 #[cfg(test)]
 mod optimistic_broadcast_tests {
-    use super::super::test_utils::get_mock_relay;
+    use super::super::test_utils::{MockNostrContactStore, get_mock_relay};
     use super::{NostrClient, NostrConfig};
     use bcr_common::core::NodeId;
     use bcr_ebill_api::service::transport_service::transport_client::TransportClientApi;
     use bcr_ebill_core::protocol::crypto::BcrKeys;
     use nostr::EventBuilder;
+    use std::sync::Arc;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_relay_ack_threshold_returns_configured_value() {
@@ -2545,6 +2547,47 @@ mod optimistic_broadcast_tests {
             result.is_ok(),
             "optimistic broadcast should clamp threshold to relay count: {:?}",
             result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pre_threshold_relay_failure_is_queued_for_resync() {
+        let relay = get_mock_relay().await;
+        let real_url = url::Url::parse(&relay.url()).unwrap();
+        let unreachable_url = url::Url::parse("ws://127.0.0.1:1").unwrap();
+        let keys = BcrKeys::new();
+        let node_id = NodeId::new(keys.pub_key(), bitcoin::Network::Testnet);
+
+        let mut mock_store = MockNostrContactStore::new();
+        let unreachable_url_for_assert = unreachable_url.clone();
+        mock_store
+            .expect_add_failed_relay_sync()
+            .withf(move |url, _event| url.as_str() == unreachable_url_for_assert.as_str())
+            .times(1..)
+            .returning(|_, _| Ok(()));
+
+        let client = NostrClient::new(
+            vec![(node_id, keys.clone())],
+            vec![real_url, unreachable_url],
+            vec![],
+            Duration::from_secs(2),
+            Some(10),
+            2,
+            Some(Arc::new(mock_store)),
+        )
+        .await
+        .expect("failed to create nostr client");
+
+        client.connect().await.expect("failed to connect");
+
+        let event = EventBuilder::text_note("pre-threshold failure")
+            .sign_with_keys(&keys.get_nostr_keys())
+            .unwrap();
+
+        let result = client.broadcast_event_optimistic(&event, 2).await;
+        assert!(
+            result.is_err(),
+            "threshold should not be met because one relay is unreachable"
         );
     }
 }

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -43,6 +43,10 @@ use bcr_ebill_api::{
 };
 use bcr_ebill_core::{application::ServiceTraitBounds, protocol::event::EventEnvelope};
 use bcr_ebill_persistence::{NostrEventOffset, NostrEventOffsetStoreApi, NostrStoreApi};
+use futures::{
+    StreamExt,
+    channel::mpsc::{UnboundedReceiver, unbounded},
+};
 
 use tokio::task::JoinSet;
 use tokio_with_wasm::alias as tokio;
@@ -97,6 +101,7 @@ pub struct NostrClient {
     connected: Arc<AtomicBool>,
     sync_running: Arc<AtomicBool>, // Prevents concurrent sync
     max_relays: Option<usize>,
+    relay_ack_threshold: usize,
     nostr_contact_store: Option<Arc<dyn NostrStoreApi>>, // Keep for backwards compatibility
     nostr_store: Option<Arc<dyn NostrStoreApi>>,
 }
@@ -109,6 +114,7 @@ impl NostrClient {
         blossom_servers: Vec<url::Url>,
         default_timeout: Duration,
         max_relays: Option<usize>,
+        relay_ack_threshold: usize,
         nostr_store: Option<Arc<dyn NostrStoreApi>>,
     ) -> Result<Self> {
         if identities.is_empty() {
@@ -146,6 +152,7 @@ impl NostrClient {
             connected: Arc::new(AtomicBool::new(false)),
             sync_running: Arc::new(AtomicBool::new(false)),
             max_relays,
+            relay_ack_threshold: relay_ack_threshold.max(1),
             nostr_contact_store: nostr_store.clone(), // Keep for backwards compatibility
             nostr_store,
         })
@@ -160,6 +167,7 @@ impl NostrClient {
             config.blossom_servers.clone(),
             config.default_timeout,
             None, // max_relays not available in old config
+            config.relay_ack_threshold,
             None, // store not available
         )
         .await
@@ -533,6 +541,44 @@ impl NostrClient {
 
 impl ServiceTraitBounds for NostrClient {}
 
+async fn collect_remaining_broadcast_results(
+    mut rx: UnboundedReceiver<(RelayUrl, std::result::Result<EventId, Error>)>,
+    mut success: HashSet<RelayUrl>,
+    mut failed: HashMap<RelayUrl, String>,
+    event: Event,
+    nostr_store: Option<Arc<dyn NostrStoreApi>>,
+) {
+    while let Some((relay, result)) = rx.next().await {
+        match result {
+            Ok(_) => {
+                success.insert(relay);
+            }
+            Err(e) => {
+                failed.insert(relay.clone(), e.to_string());
+                if let Some(store) = &nostr_store {
+                    let relay_url = match url::Url::parse(relay.as_str()) {
+                        Ok(url) => url,
+                        Err(parse_err) => {
+                            error!("Failed to parse relay url {relay}: {parse_err}");
+                            continue;
+                        }
+                    };
+                    if let Err(store_err) =
+                        store.add_failed_relay_sync(&relay_url, event.clone()).await
+                    {
+                        error!("Failed to queue failed relay sync for {relay}: {store_err}");
+                    }
+                }
+            }
+        }
+    }
+    debug!(
+        "Optimistic broadcast background completion: {} succeeded, {} failed",
+        success.len(),
+        failed.len()
+    );
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TransportClientApi for NostrClient {
@@ -593,6 +639,91 @@ impl TransportClientApi for NostrClient {
         })?;
         check_send_output(output, "broadcast_event")?;
         Ok(())
+    }
+
+    async fn broadcast_event_optimistic(&self, event: &Event, min_acks: usize) -> Result<()> {
+        let client = self.client().await?;
+        let event = event.clone();
+
+        let relays: Vec<RelayUrl> = client
+            .relays()
+            .await
+            .into_values()
+            .filter(|relay| relay.flags().has_write())
+            .map(|relay| relay.url().clone())
+            .collect();
+
+        if relays.is_empty() {
+            return Err(Error::Network(
+                "No write relays available for optimistic broadcast".to_string(),
+            ));
+        }
+
+        let threshold = min_acks.max(1).min(relays.len());
+        let nostr_store = self.nostr_store.clone();
+
+        let (tx, mut rx) = unbounded::<(RelayUrl, std::result::Result<EventId, Error>)>();
+
+        for relay in relays {
+            let client = client.clone();
+            let event = event.clone();
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let result = client.send_event_to(vec![relay.clone()], &event).await;
+                let mapped = match result {
+                    Ok(output) => {
+                        if output.success.contains(&relay) {
+                            Ok(output.val)
+                        } else {
+                            let err = output
+                                .failed
+                                .get(&relay)
+                                .cloned()
+                                .unwrap_or_else(|| "unknown relay error".to_string());
+                            Err(Error::Network(format!("relay {relay} failed: {err}")))
+                        }
+                    }
+                    Err(e) => Err(Error::Network(format!("relay {relay} error: {e}"))),
+                };
+                let _ = tx.unbounded_send((relay, mapped));
+            });
+        }
+        drop(tx);
+
+        let mut success = HashSet::new();
+        let mut failed = HashMap::new();
+
+        while let Some((relay, result)) = rx.next().await {
+            match result {
+                Ok(_) => {
+                    success.insert(relay);
+                    if success.len() >= threshold {
+                        tokio::spawn(collect_remaining_broadcast_results(
+                            rx,
+                            success,
+                            failed,
+                            event,
+                            nostr_store,
+                        ));
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    failed.insert(relay, e.to_string());
+                }
+            }
+        }
+
+        Err(Error::Network(format!(
+            "broadcast_event_optimistic: only {} of {} required acks received ({} failed)",
+            success.len(),
+            threshold,
+            failed.len()
+        )))
+    }
+
+    fn relay_ack_threshold(&self) -> usize {
+        self.relay_ack_threshold
     }
 
     async fn resolve_contact(&self, node_id: &NodeId) -> Result<Option<NostrContactData>> {
@@ -1710,6 +1841,7 @@ mod tests {
             vec![],
             Duration::from_secs(20),
             None,
+            1,
             None,
         )
         .await
@@ -1745,6 +1877,7 @@ mod tests {
             vec![],
             Duration::from_secs(20),
             None,
+            1,
             None,
         )
         .await
@@ -2025,6 +2158,7 @@ mod tests {
                 vec![],
                 Duration::from_secs(20),
                 None,
+                1,
                 None,
             )
             .await
@@ -2323,5 +2457,95 @@ mod relay_calculation_tests {
 
         // Should handle gracefully
         assert_eq!(result.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod optimistic_broadcast_tests {
+    use super::super::test_utils::get_mock_relay;
+    use super::{NostrClient, NostrConfig};
+    use bcr_common::core::NodeId;
+    use bcr_ebill_api::service::transport_service::transport_client::TransportClientApi;
+    use bcr_ebill_core::protocol::crypto::BcrKeys;
+    use nostr::EventBuilder;
+
+    #[tokio::test]
+    async fn test_relay_ack_threshold_returns_configured_value() {
+        let relay = get_mock_relay().await;
+        let url = url::Url::parse(&relay.url()).unwrap();
+        let keys = BcrKeys::new();
+        let config = NostrConfig::new(
+            keys.clone(),
+            vec![url],
+            vec![],
+            true,
+            NodeId::new(keys.pub_key(), bitcoin::Network::Testnet),
+        )
+        .with_relay_ack_threshold(3);
+        let client = NostrClient::default(&config)
+            .await
+            .expect("failed to create nostr client");
+
+        assert_eq!(client.relay_ack_threshold(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_event_optimistic_returns_after_ack() {
+        let relay = get_mock_relay().await;
+        let url = url::Url::parse(&relay.url()).unwrap();
+        let keys = BcrKeys::new();
+        let config = NostrConfig::new(
+            keys.clone(),
+            vec![url],
+            vec![],
+            true,
+            NodeId::new(keys.pub_key(), bitcoin::Network::Testnet),
+        );
+        let client = NostrClient::default(&config)
+            .await
+            .expect("failed to create nostr client");
+
+        client.connect().await.expect("failed to connect");
+
+        let event = EventBuilder::text_note("test optimistic broadcast")
+            .sign_with_keys(&keys.get_nostr_keys())
+            .unwrap();
+
+        let result = client.broadcast_event_optimistic(&event, 1).await;
+        assert!(
+            result.is_ok(),
+            "optimistic broadcast should return after first ack: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_event_optimistic_clamps_threshold_to_relay_count() {
+        let relay = get_mock_relay().await;
+        let url = url::Url::parse(&relay.url()).unwrap();
+        let keys = BcrKeys::new();
+        let config = NostrConfig::new(
+            keys.clone(),
+            vec![url],
+            vec![],
+            true,
+            NodeId::new(keys.pub_key(), bitcoin::Network::Testnet),
+        );
+        let client = NostrClient::default(&config)
+            .await
+            .expect("failed to create nostr client");
+
+        client.connect().await.expect("failed to connect");
+
+        let event = EventBuilder::text_note("test threshold clamping")
+            .sign_with_keys(&keys.get_nostr_keys())
+            .unwrap();
+
+        let result = client.broadcast_event_optimistic(&event, 5).await;
+        assert!(
+            result.is_ok(),
+            "optimistic broadcast should clamp threshold to relay count: {:?}",
+            result.err()
+        );
     }
 }

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -541,12 +541,24 @@ impl NostrClient {
 
 impl ServiceTraitBounds for NostrClient {}
 
+async fn queue_failed_relay_sync(store: &Arc<dyn NostrStoreApi>, relay: &RelayUrl, event: &Event) {
+    let relay_url = match url::Url::parse(relay.as_str()) {
+        Ok(url) => url,
+        Err(parse_err) => {
+            error!("Failed to parse relay url {relay}: {parse_err}");
+            return;
+        }
+    };
+    if let Err(store_err) = store.add_failed_relay_sync(&relay_url, event.clone()).await {
+        error!("Failed to queue failed relay sync for {relay}: {store_err}");
+    }
+}
+
 async fn collect_remaining_broadcast_results(
     mut rx: UnboundedReceiver<(RelayUrl, std::result::Result<EventId, Error>)>,
     mut success: HashSet<RelayUrl>,
-    mut failed: HashMap<RelayUrl, String>,
-    event: Event,
     nostr_store: Option<Arc<dyn NostrStoreApi>>,
+    event: Event,
 ) {
     while let Some((relay, result)) = rx.next().await {
         match result {
@@ -554,28 +566,16 @@ async fn collect_remaining_broadcast_results(
                 success.insert(relay);
             }
             Err(e) => {
-                failed.insert(relay.clone(), e.to_string());
                 if let Some(store) = &nostr_store {
-                    let relay_url = match url::Url::parse(relay.as_str()) {
-                        Ok(url) => url,
-                        Err(parse_err) => {
-                            error!("Failed to parse relay url {relay}: {parse_err}");
-                            continue;
-                        }
-                    };
-                    if let Err(store_err) =
-                        store.add_failed_relay_sync(&relay_url, event.clone()).await
-                    {
-                        error!("Failed to queue failed relay sync for {relay}: {store_err}");
-                    }
+                    queue_failed_relay_sync(store, &relay, &event).await;
                 }
+                debug!("Optimistic broadcast background failure for {relay}: {e}");
             }
         }
     }
     debug!(
-        "Optimistic broadcast background completion: {} succeeded, {} failed",
-        success.len(),
-        failed.len()
+        "Optimistic broadcast background completion: {} succeeded",
+        success.len()
     );
 }
 
@@ -691,7 +691,6 @@ impl TransportClientApi for NostrClient {
         drop(tx);
 
         let mut success = HashSet::new();
-        let mut failed = HashMap::new();
 
         while let Some((relay, result)) = rx.next().await {
             match result {
@@ -701,24 +700,24 @@ impl TransportClientApi for NostrClient {
                         tokio::spawn(collect_remaining_broadcast_results(
                             rx,
                             success,
-                            failed,
-                            event,
                             nostr_store,
+                            event,
                         ));
                         return Ok(());
                     }
                 }
-                Err(e) => {
-                    failed.insert(relay, e.to_string());
+                Err(_) => {
+                    if let Some(store) = &nostr_store {
+                        queue_failed_relay_sync(store, &relay, &event).await;
+                    }
                 }
             }
         }
 
         Err(Error::Network(format!(
-            "broadcast_event_optimistic: only {} of {} required acks received ({} failed)",
+            "broadcast_event_optimistic: only {} of {} required acks received",
             success.len(),
             threshold,
-            failed.len()
         )))
     }
 

--- a/crates/bcr-ebill-transport/src/relay_sync.rs
+++ b/crates/bcr-ebill-transport/src/relay_sync.rs
@@ -314,6 +314,7 @@ mod tests {
             vec![],
             std::time::Duration::from_secs(10),
             None,
+            1,
             Some(store.clone()),
         )
         .await
@@ -364,6 +365,7 @@ mod tests {
             vec![],
             std::time::Duration::from_secs(10),
             None,
+            1,
             Some(store.clone()),
         )
         .await

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -28,12 +28,14 @@ use bcr_ebill_core::{
     application::notification::{Notification, NotificationLevel},
     protocol::blockchain::BlockchainType,
     protocol::blockchain::{
+        Blockchain,
         bill::{
             BitcreditBill,
             block::ContactType,
             participant::{BillIdentParticipant, BillParticipant},
         },
-        identity::IdentityType,
+        company::{CompanyBlockchain, block::CompanyCreateBlockData},
+        identity::{IdentityBlockchain, IdentityCreateBlockData, IdentityType},
     },
     protocol::event::{ActionType, BillEventType},
     protocol::{OptionalPostalAddress, PostalAddress},
@@ -397,6 +399,44 @@ pub fn signed_identity_proof_test() -> (SignedIdentityProof, EmailIdentityProofD
     };
     let proof = data.sign(&node_id_test(), &private_key_test()).unwrap();
     (proof, data)
+}
+
+pub fn get_test_identity_chain_event() -> IdentityChainEvent {
+    let identity = get_baseline_identity();
+    let create_data = IdentityCreateBlockData::from(identity.identity.clone());
+    let chain = IdentityBlockchain::new(&create_data, &identity.key_pair, test_ts())
+        .expect("failed to create identity chain");
+    let block = chain.get_first_block().clone();
+    IdentityChainEvent::new(&identity.identity.node_id, &block, &identity.key_pair)
+}
+
+pub fn get_test_company_chain_event() -> CompanyChainEvent {
+    let identity_keys = BcrKeys::new();
+    let company_keys = BcrKeys::new();
+    let company_id = NodeId::new(company_keys.pub_key(), bitcoin::Network::Testnet);
+    let creator_id = NodeId::new(identity_keys.pub_key(), bitcoin::Network::Testnet);
+    let company_data = CompanyCreateBlockData {
+        id: company_id.clone(),
+        name: Name::new("Test Company").unwrap(),
+        country_of_registration: Some(Country::AT),
+        city_of_registration: Some(City::new("Vienna").unwrap()),
+        postal_address: PostalAddress {
+            country: Country::AT,
+            city: City::new("Vienna").unwrap(),
+            zip: None,
+            address: Address::new("Some address").unwrap(),
+        },
+        email: Email::new("test@example.com").unwrap(),
+        registration_number: None,
+        registration_date: None,
+        proof_of_registration_file: None,
+        logo_file: None,
+        creation_time: test_ts(),
+        creator: creator_id,
+    };
+    let chain = CompanyBlockchain::new(&company_data, &identity_keys, &company_keys, test_ts())
+        .expect("failed to create company chain");
+    CompanyChainEvent::new(&company_id, &chain, &company_keys, None, true)
 }
 
 pub fn node_id_test_other2() -> NodeId {

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -137,6 +137,7 @@ pub fn init_test_cfg() {
                     relays: vec![url::Url::parse("ws://localhost:8080").unwrap()],
                     blossom_servers: vec![],
                     max_relays: Some(50),
+                    relay_ack_threshold: 1,
                 },
                 mint_config: bcr_ebill_api::MintConfig {
                     default_mint_url: url::Url::parse("http://localhost:4242/").unwrap(),
@@ -585,6 +586,12 @@ mockall::mock! {
             previous_event: Option<nostr::event::Event>,
             root_event: Option<nostr::event::Event>) -> Result<nostr::event::Event>;
         async fn broadcast_event(&self, event: &nostr::event::Event) -> Result<()>;
+        async fn broadcast_event_optimistic(
+            &self,
+            event: &nostr::event::Event,
+            min_acks: usize,
+        ) -> Result<()>;
+        fn relay_ack_threshold(&self) -> usize;
         async fn resolve_contact(&self, node_id: &NodeId) -> Result<Option<NostrContactData>>;
         async fn resolve_public_chain(&self, id: &str, chain_type: BlockchainType) -> Result<Vec<nostr::event::Event>>;
         async fn add_contact_subscription(&self, contact: &NodeId) -> Result<()>;

--- a/crates/bcr-ebill-wasm/src/lib.rs
+++ b/crates/bcr-ebill-wasm/src/lib.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub blossom_servers: Option<Vec<String>>,
     pub nostr_only_known_contacts: Option<bool>,
     pub nostr_max_relays: Option<usize>,
+    pub nostr_relay_ack_threshold: Option<usize>,
     pub job_runner_initial_delay_seconds: u32,
     pub job_runner_check_interval_seconds: u32,
     pub transport_initial_subscription_delay_seconds: Option<u32>,
@@ -231,6 +232,7 @@ pub async fn initialize_api(
             blossom_servers,
             only_known_contacts: config.nostr_only_known_contacts.unwrap_or(false),
             max_relays: config.nostr_max_relays.or(Some(50)),
+            relay_ack_threshold: config.nostr_relay_ack_threshold.unwrap_or(1),
         },
         mint_config: MintConfig::new(config.default_mint_url, mint_node_id)?,
         payment_config: PaymentConfig {


### PR DESCRIPTION
## 📝 Description

When publishing blocks we return after first success and let the rest of the fan out run in a background job. Errors from the bg job will still be collected and moved in relay re-sync queue. 

Relates to and closes #930 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Message fan out as bg job should speed up block publishing in unreliable relay scenarios

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
