### PR TITLE
Remove encryption Layer, Add Shared Bill Chain Validation Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.5.13
+
+* Removed an encryption layer on the nostr public events
+    * This is implemented backwards-compatible in that new apps can still process old chains, but old apps won't be able to process new chains
+        * Cases to Test:
+            * Old client with identity/companies/bills
+                * => continuiing works on new clients (add blocks to bills/companies/identitiy)
+                * => restore works on new clients (before/after adding new blocks to existing things)
+                * => fresh new clients work with data from old clients
+    * The block metadata (e.g. block id, hash, signature etc.) will now be unencrypted in the chains on Nostr - just the block data will be encrypted with the corresponding key (e.g. bill key)
+* Add bill-service function to get the bill chain
+* Add block transport function to check a set of blocks against a published set of nostr public chain events for a given bill
+* Optimistically publish to Nostr relays - once we successfully publish to a configured threshold (e.g. 1), the other relays are pushed to asynchronously, so it's not blocked by the slowest relay anymore
+
 # 0.5.12
 
 * Upgrade bcr-common

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.12"
+version = "0.5.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/BitcreditProtocol/Bitcredit-Core"
@@ -68,7 +68,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "bb5e380c2de166692a1a339a4d98029aec3f983f" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "f103d4762da16126aac60d8641bc1832a5a3455f" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-api/src/external/mint.rs
+++ b/crates/bcr-ebill-api/src/external/mint.rs
@@ -488,6 +488,9 @@ pub enum QuoteStatusReply {
     Expired {
         tstamp: DateTimeUtc,
     },
+    FailedEbillValidation {
+        keyset_id: cdk02::Id,
+    },
 }
 
 impl From<StatusReply> for QuoteStatusReply {
@@ -509,6 +512,9 @@ impl From<StatusReply> for QuoteStatusReply {
             StatusReply::Rejected { tstamp, .. } => QuoteStatusReply::Rejected { tstamp },
             StatusReply::Canceled { tstamp } => QuoteStatusReply::Cancelled { tstamp },
             StatusReply::OfferExpired { tstamp, .. } => QuoteStatusReply::Expired { tstamp },
+            StatusReply::FailedEbillValidation { keyset_id, .. } => {
+                QuoteStatusReply::FailedEbillValidation { keyset_id }
+            }
             StatusReply::MintingEnabled {
                 keyset_id,
                 minted_amount,

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -253,6 +253,7 @@ pub trait BillServiceApi: ServiceTraitBounds {
         court_node_id: &NodeId,
     ) -> Result<()>;
 
+    /// Return a bill's history
     async fn get_bill_history(
         &self,
         bill_id: &BillId,
@@ -261,6 +262,13 @@ pub trait BillServiceApi: ServiceTraitBounds {
         caller_keys: &BcrKeys,
         current_timestamp: Timestamp,
     ) -> Result<BillHistory>;
+
+    /// Return a bill's Blockchain
+    async fn get_local_bill_chain(
+        &self,
+        bill_id: &BillId,
+        caller_public_data: &BillParticipant,
+    ) -> Result<BillBlockchain>;
 
     fn mempool_link(&self, address: &BitcoinAddress) -> String;
 

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -531,6 +531,9 @@ impl BillService {
                     QuoteStatusReply::Pending => {
                         // it's already pending, or offered, or accepted and can't go from Accepted to Offered to Pending - nothing to do
                     }
+                    QuoteStatusReply::FailedEbillValidation { .. } => {
+                        // it's already endorsed and failed validation - nothing to do
+                    }
                     QuoteStatusReply::Offered {
                         keyset_id,
                         expiration_date,
@@ -1969,6 +1972,30 @@ impl BillServiceApi for BillService {
             )
             .await?;
         Ok(detail.history)
+    }
+
+    async fn get_local_bill_chain(
+        &self,
+        bill_id: &BillId,
+        caller_public_data: &BillParticipant,
+    ) -> Result<BillBlockchain> {
+        validate_bill_id_network(bill_id)?;
+        validate_node_id_network(&caller_public_data.node_id())?;
+        let chain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
+
+        // if caller is not part of the bill, they can't access it
+        if !chain
+            .get_all_nodes_from_bill(&bill_keys)
+            .map_err(|e| Error::Protocol(e.into()))?
+            .iter()
+            .any(|p| p == &caller_public_data.node_id())
+        {
+            debug!("caller is not a participant of bill {bill_id}");
+            return Err(Error::NotFound);
+        }
+
+        Ok(chain)
     }
 
     fn mempool_link(&self, address: &BitcoinAddress) -> String {

--- a/crates/bcr-ebill-api/src/service/bill_service/tests.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/tests.rs
@@ -7846,3 +7846,31 @@ async fn get_bill_history_baseline() {
         drawer_node_id
     );
 }
+
+#[tokio::test]
+async fn get_local_bill_chain_baseline() {
+    let mut ctx = get_ctx();
+    let identity = get_baseline_identity();
+    let mut bill = get_baseline_bill(&bill_id_test());
+    bill.drawee = bill_identified_participant_only_node_id(identity.identity.node_id.clone());
+    ctx.bill_store.expect_exists().returning(|_| Ok(true));
+    let chain = get_genesis_chain(Some(bill.clone()));
+    let chain_clone = chain.clone();
+    ctx.bill_blockchain_store
+        .expect_get_chain()
+        .returning(move |_| Ok(chain_clone.clone()));
+    ctx.transport_service.expect_on_notification_transport(|t| {
+        t.expect_get_active_bill_notification()
+            .with(eq(bill_id_test()))
+            .returning(|_| None);
+    });
+
+    let res = get_service(ctx)
+        .get_local_bill_chain(
+            &bill_id_test(),
+            &BillParticipant::Ident(BillIdentParticipant::new(identity.identity.clone()).unwrap()),
+        )
+        .await;
+    assert!(res.is_ok());
+    assert_eq!(res.as_ref().unwrap().blocks(), chain.blocks());
+}

--- a/crates/bcr-ebill-api/src/service/company_service.rs
+++ b/crates/bcr-ebill-api/src/service/company_service.rs
@@ -2492,9 +2492,6 @@ pub mod tests {
                 test_ts(),
             )
             .await;
-        if let Err(ref e) = res {
-            eprintln!("create_company error: {:?}", e);
-        }
         assert!(res.is_ok());
     }
 

--- a/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
@@ -3,7 +3,10 @@ use async_trait::async_trait;
 use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_core::{
     application::ServiceTraitBounds,
-    protocol::event::{BillChainEvent, CompanyChainEvent, IdentityChainEvent},
+    protocol::{
+        blockchain::bill::BillBlock,
+        event::{BillChainEvent, CompanyChainEvent, IdentityChainEvent},
+    },
 };
 
 #[cfg(test)]
@@ -28,6 +31,12 @@ pub trait BlockTransportServiceApi: ServiceTraitBounds {
     async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
     /// Resync identity chain
     async fn resync_identity_chain(&self) -> Result<()>;
+    /// Validates that the given list of blocks exist in the resolved chain from Nostr
+    async fn validate_bill_blocks_exist_on_nostr_chain(
+        &self,
+        bill_id: &BillId,
+        blocks: &[BillBlock],
+    ) -> Result<bool>;
 }
 
 #[cfg(test)]

--- a/crates/bcr-ebill-api/src/service/transport_service/transport_client.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/transport_client.rs
@@ -35,7 +35,6 @@ pub trait TransportClientApi: ServiceTraitBounds {
         id: &str,
         blockchain: BlockchainType,
         block_time: Timestamp,
-        keys: BcrKeys,
         event: EventEnvelope,
         previous_event: Option<Event>,
         root_event: Option<Event>,

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::handler::public_chain_helpers::{BlockData, resolve_event_chains};
 use crate::handler::{
     BillChainEventProcessorApi, CompanyChainEventProcessorApi, IdentityChainEventProcessorApi,
 };
@@ -10,6 +11,7 @@ use bcr_ebill_api::service::transport_service::BlockTransportServiceApi;
 use bcr_ebill_core::application::ServiceTraitBounds;
 use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::blockchain::BlockchainType;
+use bcr_ebill_core::protocol::blockchain::bill::BillBlock;
 use bcr_ebill_core::protocol::event::{
     BillChainEvent, CompanyChainEvent, EventEnvelope, IdentityChainEvent,
 };
@@ -97,7 +99,6 @@ impl BlockTransportServiceApi for BlockTransportService {
                     &event.data.node_id.to_string(),
                     BlockchainType::Identity,
                     event.data.block.timestamp,
-                    events.keys.clone(),
                     event.clone().try_into()?,
                     previous_event.clone().map(|e| e.payload),
                     root_event.clone().map(|e| e.payload),
@@ -156,7 +157,6 @@ impl BlockTransportServiceApi for BlockTransportService {
                     &event.data.node_id.to_string(),
                     BlockchainType::Company,
                     event.data.block.timestamp,
-                    events.keys.clone(),
                     event.clone().try_into()?,
                     previous_event.clone().map(|e| e.payload),
                     root_event.clone().map(|e| e.payload),
@@ -232,7 +232,6 @@ impl BlockTransportServiceApi for BlockTransportService {
                     &block_event.data.bill_id.to_string(),
                     BlockchainType::Bill,
                     block_event.data.block.timestamp,
-                    events.bill_keys.clone(),
                     block_event.clone().try_into()?,
                     previous_event.clone().map(|e| e.payload),
                     root_event.clone().map(|e| e.payload),
@@ -311,6 +310,57 @@ impl BlockTransportServiceApi for BlockTransportService {
         self.identity_chain_event_processor.resync_chain().await?;
         Ok(())
     }
+
+    /// Fetch all chains for this bill id from nostr and attempt to find one which exactly matches the given blocks
+    async fn validate_bill_blocks_exist_on_nostr_chain(
+        &self,
+        bill_id: &BillId,
+        blocks: &[BillBlock],
+    ) -> Result<bool> {
+        if blocks.is_empty() {
+            return Ok(true);
+        }
+        let mut sorted_blocks = blocks.to_vec();
+        sorted_blocks.sort_by(|x, y| x.bill_id.cmp(&y.bill_id).then_with(|| x.id.cmp(&y.id)));
+
+        let transport = self.nostr_transport.get_first_transport();
+        // chains are sorted by longest first, so we start there and move down until we have a success
+        let chains =
+            resolve_event_chains(transport, &bill_id.to_string(), BlockchainType::Bill, &None)
+                .await?;
+        for chain in chains.iter() {
+            // ignore empty chains
+            if chain.is_empty() {
+                continue;
+            }
+
+            let mut chain_blocks: Vec<BillBlock> = chain
+                .iter()
+                .filter_map(|d| match d.block.clone() {
+                    BlockData::Bill(block) => Some(block),
+                    _ => None,
+                })
+                .collect();
+            chain_blocks.sort_by(|x, y| x.bill_id.cmp(&y.bill_id).then_with(|| x.id.cmp(&y.id)));
+
+            // ignore chains with no bill blocks
+            if chain_blocks.is_empty() {
+                continue;
+            }
+
+            // chain has to match exactly
+            if chain_blocks.len() != sorted_blocks.len() {
+                continue;
+            }
+
+            // if it matches exactly, it's valid
+            if sorted_blocks == chain_blocks {
+                return Ok(true);
+            }
+        }
+        // didn't find all blocks exactly in any chain - invalid
+        Ok(false)
+    }
 }
 
 #[cfg(test)]
@@ -322,11 +372,15 @@ mod tests {
     };
     use crate::test_utils::{
         MockContactStore, MockNostrChainEventStore, MockNostrContactStore,
-        MockNostrQueuedMessageStore, MockNotificationJsonTransport, get_nostr_transport,
-        get_test_company_chain_event, get_test_identity_chain_event,
+        MockNostrQueuedMessageStore, MockNotificationJsonTransport, bill_id_test,
+        get_genesis_chain, get_nostr_transport, get_test_company_chain_event,
+        get_test_identity_chain_event, private_key_test,
     };
-    use bcr_ebill_core::protocol::Sha256Hash;
-    use bcr_ebill_core::protocol::blockchain::BlockchainType;
+    use crate::transport::create_public_chain_event;
+    use bcr_ebill_core::protocol::blockchain::{Blockchain, BlockchainType};
+    use bcr_ebill_core::protocol::crypto::BcrKeys;
+    use bcr_ebill_core::protocol::event::{BillBlockEvent, Event};
+    use bcr_ebill_core::protocol::{BlockId, Sha256Hash, Timestamp};
     use bcr_ebill_persistence::nostr::NostrChainEvent;
 
     fn create_test_chain_event(
@@ -456,7 +510,7 @@ mod tests {
         let mut transport = MockNotificationJsonTransport::new();
         transport
             .expect_build_public_chain_event()
-            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+            .returning(move |_, _, _, _, _, _, _| Ok(signed_event.clone()));
         transport.expect_relay_ack_threshold().returning(|| 1);
         transport
             .expect_broadcast_event_optimistic()
@@ -486,7 +540,7 @@ mod tests {
         let mut transport = MockNotificationJsonTransport::new();
         transport
             .expect_build_public_chain_event()
-            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+            .returning(move |_, _, _, _, _, _, _| Ok(signed_event.clone()));
         transport.expect_relay_ack_threshold().returning(|| 1);
         transport
             .expect_broadcast_event_optimistic()
@@ -516,7 +570,7 @@ mod tests {
         let mut transport = MockNotificationJsonTransport::new();
         transport
             .expect_build_public_chain_event()
-            .returning(move |_, _, _, _, _, _, _, _| Ok(signed_event.clone()));
+            .returning(move |_, _, _, _, _, _, _| Ok(signed_event.clone()));
         transport.expect_relay_ack_threshold().returning(|| 1);
         transport
             .expect_broadcast_event_optimistic()
@@ -556,5 +610,145 @@ mod tests {
 
         let result = service.send_identity_chain_events(event).await;
         assert!(result.is_ok());
+    }
+
+    fn generate_test_event(
+        previous: Option<nostr::Event>,
+        root: Option<nostr::Event>,
+        height: usize,
+        block: BillBlock,
+    ) -> nostr::Event {
+        let keys = BcrKeys::from_private_key(&private_key_test());
+        let block_event = Event::new_bill_chain(BillBlockEvent {
+            bill_id: bill_id_test(),
+            block: block.clone(),
+            block_height: height,
+        })
+        .try_into()
+        .expect("could not create envelope");
+        create_public_chain_event(
+            &bill_id_test().to_string(),
+            block_event,
+            Timestamp::new(1000).unwrap(),
+            BlockchainType::Bill,
+            previous,
+            root,
+        )
+        .expect("could not create chain event")
+        .sign_with_keys(&keys.get_nostr_keys())
+        .expect("could not sign event")
+    }
+
+    #[tokio::test]
+    async fn test_validate_bill_blocks_exist_on_nostr_chain_empty() {
+        let mut transport = MockNotificationJsonTransport::new();
+        transport.expect_resolve_public_chain().never();
+        let service = get_service_with_transport(transport, MockNostrChainEventStore::new());
+        let bill_id = bill_id_test();
+
+        let res = service
+            .validate_bill_blocks_exist_on_nostr_chain(&bill_id, &[])
+            .await;
+        assert!(res.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_validate_bill_blocks_exist_on_nostr_chain_invalid() {
+        let mut transport = MockNotificationJsonTransport::new();
+        // create a block
+        let block = get_genesis_chain(None)
+            .blocks()
+            .first()
+            .expect("could not get block")
+            .clone();
+        transport
+            .expect_resolve_public_chain()
+            .times(1)
+            .returning(move |_, _| Ok(vec![generate_test_event(None, None, 1, block.clone())]));
+        let service = get_service_with_transport(transport, MockNostrChainEventStore::new());
+        let bill_id = bill_id_test();
+
+        // create a different block
+        let block = get_genesis_chain(None)
+            .blocks()
+            .first()
+            .expect("could not get block")
+            .clone();
+
+        let res = service
+            .validate_bill_blocks_exist_on_nostr_chain(&bill_id, &[block])
+            .await;
+        assert!(!res.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_validate_bill_blocks_exist_on_nostr_chain_valid() {
+        // create a block
+        let block = get_genesis_chain(None)
+            .blocks()
+            .first()
+            .expect("could not get block")
+            .clone();
+        let mut transport = MockNotificationJsonTransport::new();
+        let block_clone = block.clone();
+        transport
+            .expect_resolve_public_chain()
+            .times(1)
+            .returning(move |_, _| {
+                Ok(vec![generate_test_event(
+                    None,
+                    None,
+                    1,
+                    block_clone.clone(),
+                )])
+            });
+        let service = get_service_with_transport(transport, MockNostrChainEventStore::new());
+        let bill_id = bill_id_test();
+
+        let res = service
+            .validate_bill_blocks_exist_on_nostr_chain(&bill_id, &[block])
+            .await;
+        assert!(res.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_validate_bill_blocks_exist_on_nostr_chain_multi() {
+        // create a block
+        let block = get_genesis_chain(None)
+            .blocks()
+            .first()
+            .expect("could not get block")
+            .clone();
+        // create another block
+        let mut block_2 = get_genesis_chain(None)
+            .blocks()
+            .first()
+            .expect("could not get block")
+            .clone();
+        block_2.id = BlockId::first().add(1);
+        let mut transport = MockNotificationJsonTransport::new();
+        let block_clone = block.clone();
+        let block_2_clone = block_2.clone();
+        transport
+            .expect_resolve_public_chain()
+            .times(1)
+            .returning(move |_, _| {
+                let first_event = generate_test_event(None, None, 1, block_clone.clone());
+                let second_event = generate_test_event(
+                    Some(first_event.clone()),
+                    Some(first_event.clone()),
+                    2,
+                    block_2_clone.clone(),
+                );
+                Ok(vec![first_event, second_event])
+            });
+        let service = get_service_with_transport(transport, MockNostrChainEventStore::new());
+        let bill_id = bill_id_test();
+
+        // works if it's not sorted correctly as well
+        let res = service
+            .validate_bill_blocks_exist_on_nostr_chain(&bill_id, &[block_2, block])
+            .await;
+        assert!(res.unwrap());
     }
 }

--- a/crates/bcr-ebill-transport/src/chain_keys.rs
+++ b/crates/bcr-ebill-transport/src/chain_keys.rs
@@ -10,7 +10,7 @@ use bcr_ebill_core::{
 use bcr_ebill_persistence::{
     bill::BillStoreApi, company::CompanyStoreApi, identity::IdentityStoreApi,
 };
-use log::warn;
+use log::{debug, warn};
 
 /// Resolver for generic chain keys that are needed to decrypt
 /// public chain events.
@@ -87,7 +87,17 @@ impl ChainKeyServiceApi for ChainKeyService {
                 }
             }
             BlockchainType::Identity => match self.identity_store.get_key_pair().await {
-                Ok(keys) => Some(keys),
+                Ok(keys) => {
+                    // for identity, we have to additionally check if the chain id match our identity
+                    let node_id =
+                        NodeId::from_str(chain_id).map_err(ProtocolValidationError::from)?;
+                    if node_id.pub_key() != keys.pub_key() {
+                        debug!("skipping identity block for other identity");
+                        None
+                    } else {
+                        Some(keys)
+                    }
+                }
                 Err(e) => {
                     warn!("failed to get identity keys with {e}");
                     None

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
@@ -94,12 +94,11 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
         bill_id: &BillId,
         bill_keys: &BcrKeys,
     ) -> Result<Vec<Vec<EventContainer>>> {
-        let bcr_keys = BcrKeys::from_private_key(&bill_keys.get_private_key());
         resolve_event_chains(
             self.transport.clone(),
             &bill_id.to_string(),
             BlockchainType::Bill,
-            &bcr_keys,
+            &Some(bill_keys.to_owned()),
         )
         .await
     }
@@ -117,7 +116,6 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
             (Ok(mut existing_chain), Ok(bill_keys)) => {
                 debug!("starting bill chain resync for {bill_id}");
                 let bcr_keys = BcrKeys::from_private_key(&bill_keys.get_private_key());
-
                 // Pre-fetch validation data needed for all chain candidates
                 let is_paid = self.bill_store.is_paid(bill_id).await.map_err(|e| {
                     error!("Could not resync bill {bill_id} because getting paid status failed");
@@ -134,7 +132,7 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                     self.transport.clone(),
                     &bill_id.to_string(),
                     BlockchainType::Bill,
-                    &bcr_keys,
+                    &Some(bcr_keys.to_owned()),
                 )
                 .await
                 {
@@ -1264,7 +1262,6 @@ mod tests {
             data,
             Timestamp::new(1000).unwrap(),
             BlockchainType::Bill,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_invite_handler.rs
@@ -150,12 +150,12 @@ mod tests {
 
     #[test]
     fn test_single_block() {
-        let (keys, chain) = generate_test_chain(1, false);
+        let (_keys, chain) = generate_test_chain(1, false);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &keys,
+            &None,
         );
         assert_eq!(chains.len(), 1, "should contain a single valid chain");
         let result_chain = chains.first().unwrap();
@@ -164,12 +164,12 @@ mod tests {
 
     #[test]
     fn test_multiple_valid_blocks() {
-        let (keys, chain) = generate_test_chain(3, false);
+        let (_keys, chain) = generate_test_chain(3, false);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &keys,
+            &None,
         );
 
         assert_eq!(chains.len(), 1, "should contain a single valid chain");
@@ -179,12 +179,12 @@ mod tests {
 
     #[test]
     fn test_multiple_chains() {
-        let (keys, chain) = generate_test_chain(3, true);
+        let (_keys, chain) = generate_test_chain(3, true);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &keys,
+            &None,
         );
 
         assert_eq!(chains.len(), 2, "should contain two valid chains");
@@ -198,12 +198,12 @@ mod tests {
         let (mut processor, mut chain_event_store) = get_mocks();
 
         let node_id = node_id_test();
-        let (bcr_keys, chain) = generate_test_chain(1, false);
+        let (_bcr_keys, chain) = generate_test_chain(1, false);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &bcr_keys,
+            &None,
         );
 
         // get events from nostr
@@ -248,12 +248,12 @@ mod tests {
         let (mut processor, mut chain_event_store) = get_mocks();
 
         let node_id = node_id_test();
-        let (bcr_keys, chain) = generate_test_chain(3, false);
+        let (_bcr_keys, chain) = generate_test_chain(3, false);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &bcr_keys,
+            &None,
         );
 
         // get events from nostr
@@ -299,12 +299,12 @@ mod tests {
         let (mut processor, mut chain_event_store) = get_mocks();
 
         let node_id = node_id_test();
-        let (bcr_keys, chain) = generate_test_chain(3, true);
+        let (_bcr_keys, chain) = generate_test_chain(3, true);
         let chains = collect_event_chains(
             &chain,
             &bill_id_test().to_string(),
             BlockchainType::Bill,
-            &bcr_keys,
+            &None,
         );
 
         // get events from nostr
@@ -406,7 +406,6 @@ mod tests {
             generate_test_block(height),
             Timestamp::new(1000).unwrap(),
             BlockchainType::Bill,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_chain_event_processor.rs
@@ -140,7 +140,7 @@ impl CompanyChainEventProcessorApi for CompanyChainEventProcessor {
                     self.transport.clone(),
                     &company_id.to_string(),
                     BlockchainType::Company,
-                    &company_keys,
+                    &Some(company_keys.to_owned()),
                 )
                 .await
                 {
@@ -1705,7 +1705,6 @@ pub mod tests {
             data,
             Timestamp::new(1000).unwrap(),
             BlockchainType::Company,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
+++ b/crates/bcr-ebill-transport/src/handler/company_invite_handler.rs
@@ -48,13 +48,12 @@ impl NotificationHandlerApi for CompanyInviteEventHandler {
         debug!("incoming company chain invite for {node_id}");
         if let Ok(decoded) = Event::<ChainInvite>::try_from(event.clone()) {
             let keys = BcrKeys::from_private_key(&decoded.data.keys.private_key);
-
             let mut inserted_chain: Vec<EventContainer> = Vec::new();
             if let Ok(chain_data) = resolve_event_chains(
                 self.transport.clone(),
                 &decoded.data.chain_id,
                 decoded.data.chain_type,
-                &keys,
+                &Some(keys.to_owned()),
             )
             .await
             {
@@ -169,12 +168,12 @@ mod tests {
 
     #[test]
     fn test_single_block() {
-        let (keys, chain) = generate_test_chain(1, false);
+        let (_keys, chain) = generate_test_chain(1, false);
         let chains = collect_event_chains(
             &chain,
             &node_id_test().to_string(),
             BlockchainType::Company,
-            &keys,
+            &None,
         );
         assert_eq!(chains.len(), 1, "should contain a single valid chain");
         let result_chain = chains.first().unwrap();
@@ -183,12 +182,12 @@ mod tests {
 
     #[test]
     fn test_multiple_valid_blocks() {
-        let (keys, chain) = generate_test_chain(3, false);
+        let (_keys, chain) = generate_test_chain(3, false);
         let chains = collect_event_chains(
             &chain,
             &node_id_test().to_string(),
             BlockchainType::Company,
-            &keys,
+            &None,
         );
 
         assert_eq!(chains.len(), 1, "should contain a single valid chain");
@@ -198,12 +197,12 @@ mod tests {
 
     #[test]
     fn test_multiple_chains() {
-        let (keys, chain) = generate_test_chain(3, true);
+        let (_keys, chain) = generate_test_chain(3, true);
         let chains = collect_event_chains(
             &chain,
             &node_id_test().to_string(),
             BlockchainType::Company,
-            &keys,
+            &None,
         );
 
         assert_eq!(chains.len(), 2, "should contain two valid chains");
@@ -425,7 +424,6 @@ mod tests {
             generate_test_block(height),
             Timestamp::new(1000).unwrap(),
             BlockchainType::Company,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/identity_chain_event_processor.rs
@@ -97,7 +97,7 @@ impl IdentityChainEventProcessorApi for IdentityChainEventProcessor {
                     self.transport.clone(),
                     &identity.node_id.to_string(),
                     BlockchainType::Identity,
-                    &key_pair,
+                    &Some(key_pair.to_owned()),
                 )
                 .await
                 {
@@ -963,7 +963,6 @@ pub mod tests {
             data,
             Timestamp::new(1000).unwrap(),
             BlockchainType::Identity,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -27,7 +27,7 @@ mod identity_chain_event_handler;
 mod identity_chain_event_processor;
 mod inbound_file_anchor;
 mod nostr_contact_processor;
-mod public_chain_helpers;
+pub(crate) mod public_chain_helpers;
 mod restore;
 
 pub use bill_action_event_handler::BillActionEventHandler;

--- a/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
+++ b/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
 use bcr_ebill_api::service::transport_service::transport_client::TransportClientApi;
-use bcr_ebill_core::{
-    protocol::BlockId,
-    protocol::Sha256Hash,
-    protocol::Timestamp,
-    protocol::blockchain::{
+use bcr_ebill_core::protocol::{
+    BlockId, Sha256Hash, Timestamp,
+    blockchain::{
         Block, BlockchainType, bill::BillBlock, company::CompanyBlock, identity::IdentityBlock,
     },
-    protocol::crypto::BcrKeys,
-    protocol::event::{BillBlockEvent, CompanyBlockEvent, IdentityBlockEvent},
+    crypto::BcrKeys,
+    event::{BillBlockEvent, CompanyBlockEvent, IdentityBlockEvent},
 };
 use bcr_ebill_persistence::nostr::NostrChainEvent;
 use nostr::{
@@ -17,7 +15,7 @@ use nostr::{
     nips::nip10::Marker,
 };
 
-use crate::transport::{decrypt_public_chain_event, unwrap_public_chain_event};
+use crate::transport::{decrypt_or_decode_public_chain_event, unwrap_public_chain_event};
 use bcr_ebill_api::service::transport_service::{Error, Result};
 
 /// Compares two chains for sorting. Ordering is:
@@ -117,7 +115,7 @@ pub async fn resolve_event_chains(
     transport: Arc<dyn TransportClientApi>,
     chain_id: &str,
     chain_type: BlockchainType,
-    keys: &BcrKeys,
+    keys: &Option<BcrKeys>,
 ) -> Result<Vec<Vec<EventContainer>>> {
     let events = transport.resolve_public_chain(chain_id, chain_type).await?;
     let mut chains = collect_event_chains(&events, chain_id, chain_type, keys);
@@ -131,7 +129,7 @@ pub fn collect_event_chains(
     events: &[nostr_sdk::Event],
     chain_id: &str,
     chain_type: BlockchainType,
-    keys: &BcrKeys,
+    keys: &Option<BcrKeys>,
 ) -> Vec<Vec<EventContainer>> {
     let mut result = Vec::new();
     let markers: Vec<EventContainer> = events
@@ -157,9 +155,9 @@ pub fn ids_and_markers(
     event: &nostr_sdk::Event,
     chain_id: &str,
     chain_type: BlockchainType,
-    keys: &BcrKeys,
+    keys: &Option<BcrKeys>,
 ) -> Option<EventContainer> {
-    if let Ok(block) = decrypt_block(event.clone(), chain_id, chain_type, keys) {
+    if let Ok(block) = decode_block(event.clone(), chain_id, chain_type, keys) {
         let mut result = EventContainer::new(event.clone(), None, None, block);
         event.tags.filter_standardized(TagKind::e()).for_each(|t| {
             if let TagStandard::Event {
@@ -179,25 +177,25 @@ pub fn ids_and_markers(
     }
 }
 
-pub fn decrypt_block(
+pub fn decode_block(
     event: nostr_sdk::Event,
     chain_id: &str,
     chain_type: BlockchainType,
-    keys: &BcrKeys,
+    keys: &Option<BcrKeys>,
 ) -> Result<BlockData> {
     if let Ok(Some(payload)) = unwrap_public_chain_event(Box::new(event.clone())) {
         if (payload.id == chain_id) && (payload.chain_type == chain_type) {
-            let decrypted = decrypt_public_chain_event(&payload.payload, keys)?;
+            let decoded = decrypt_or_decode_public_chain_event(&payload.payload, keys)?;
             let data = match chain_type {
                 BlockchainType::Bill => {
-                    BlockData::Bill(borsh::from_slice::<BillBlockEvent>(&decrypted.data)?.block)
+                    BlockData::Bill(borsh::from_slice::<BillBlockEvent>(&decoded.data)?.block)
                 }
                 BlockchainType::Identity => BlockData::Identity(
-                    borsh::from_slice::<IdentityBlockEvent>(&decrypted.data)?.block,
+                    borsh::from_slice::<IdentityBlockEvent>(&decoded.data)?.block,
                 ),
-                BlockchainType::Company => BlockData::Company(
-                    borsh::from_slice::<CompanyBlockEvent>(&decrypted.data)?.block,
-                ),
+                BlockchainType::Company => {
+                    BlockData::Company(borsh::from_slice::<CompanyBlockEvent>(&decoded.data)?.block)
+                }
             };
             Ok(data)
         } else {

--- a/crates/bcr-ebill-transport/src/handler/restore.rs
+++ b/crates/bcr-ebill-transport/src/handler/restore.rs
@@ -84,7 +84,7 @@ impl RestoreAccountService {
             self.nostr.clone(),
             &self.node_id.to_string(),
             BlockchainType::Identity,
-            &self.keys,
+            &Some(self.keys.to_owned()),
         )
         .await?;
         info!("found {} chains for primary account", chains.len());
@@ -287,7 +287,6 @@ mod tests {
             generate_test_block(height),
             Timestamp::new(1000).unwrap(),
             BlockchainType::Identity,
-            keys.clone(),
             previous,
             root,
         )

--- a/crates/bcr-ebill-transport/src/nostr.rs
+++ b/crates/bcr-ebill-transport/src/nostr.rs
@@ -2,8 +2,8 @@ use crate::{
     chain_keys::ChainKeyServiceApi,
     handler::{FileMetadataProcessorApi, NotificationHandlerApi},
     transport::{
-        chain_filter, create_nip04_event, create_public_chain_event, decrypt_public_chain_event,
-        unwrap_direct_message, unwrap_public_chain_event,
+        chain_filter, create_nip04_event, create_public_chain_event,
+        decrypt_or_decode_public_chain_event, unwrap_direct_message, unwrap_public_chain_event,
     },
 };
 use async_trait::async_trait;
@@ -604,7 +604,6 @@ impl TransportClientApi for NostrClient {
         id: &str,
         blockchain: BlockchainType,
         block_time: Timestamp,
-        keys: BcrKeys,
         event: EventEnvelope,
         previous_event: Option<Event>,
         root_event: Option<Event>,
@@ -617,7 +616,6 @@ impl TransportClientApi for NostrClient {
             event,
             block_time,
             blockchain,
-            keys,
             previous_event,
             root_event,
         )?;
@@ -1156,8 +1154,8 @@ impl NostrConsumer {
             #[allow(clippy::arc_with_non_send_sync)]
             event_handlers,
             contact_service,
-            offset_store,
             chain_key_service,
+            offset_store,
             file_metadata_processor,
         }
     }
@@ -1495,19 +1493,23 @@ async fn handle_public_event(
     chain_key_store: &Arc<dyn ChainKeyServiceApi>,
     handlers: &[Arc<dyn NotificationHandlerApi>],
 ) -> Result<bool> {
-    if let Some(encrypted_data) = unwrap_public_chain_event(event.clone())? {
+    if let Some(encoded_or_encrypted) = unwrap_public_chain_event(event.clone())? {
         debug!(
             "Received public chain event: {} {}",
-            encrypted_data.chain_type, encrypted_data.id
+            encoded_or_encrypted.chain_type, encoded_or_encrypted.id
         );
-        if let Ok(Some(chain_keys)) = chain_key_store
-            .get_chain_keys(&encrypted_data.id, encrypted_data.chain_type)
+        // make sure we have the correct keys for this event
+        if let Ok(Some(keys)) = chain_key_store
+            .get_chain_keys(&encoded_or_encrypted.id, encoded_or_encrypted.chain_type)
             .await
         {
-            let decrypted = decrypt_public_chain_event(&encrypted_data.payload, &chain_keys)?;
-            debug!("Handling public chain event: {:?}", decrypted.event_type);
+            let decoded = decrypt_or_decode_public_chain_event(
+                &encoded_or_encrypted.payload,
+                &Some(keys.to_owned()),
+            )?;
+            debug!("Handling public chain event: {:?}", decoded.event_type);
             handle_event(
-                decrypted.clone(),
+                decoded.clone(),
                 node_id,
                 handlers,
                 Some(event.pubkey),
@@ -1618,11 +1620,11 @@ mod tests {
     use nostr::EventBuilder;
     use tokio::time;
 
-    use crate::handler::MockNotificationHandlerApi;
     use crate::test_utils::{
-        MockChainKeyService, MockContactService, MockFileMetadataProcessor,
-        MockNostrEventOffsetStore, TestEventPayload, create_test_event, get_identity_public_data,
+        MockContactService, MockFileMetadataProcessor, MockNostrEventOffsetStore, TestEventPayload,
+        create_test_event, get_identity_public_data,
     };
+    use crate::{handler::MockNotificationHandlerApi, test_utils::MockChainKeyService};
 
     use super::super::test_utils::get_mock_relay;
     use super::{NostrClient, NostrConfig, NostrConsumer, prioritized_signers_for_event};
@@ -2551,6 +2553,7 @@ mod optimistic_broadcast_tests {
     }
 
     #[tokio::test]
+    #[ignore] // slow test - enable on-demand
     async fn test_pre_threshold_relay_failure_is_queued_for_resync() {
         let relay = get_mock_relay().await;
         let real_url = url::Url::parse(&relay.url()).unwrap();

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -15,8 +15,8 @@ use bcr_ebill_core::protocol::Name;
 use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::Sum;
 use bcr_ebill_core::protocol::Timestamp;
-use bcr_ebill_core::protocol::blockchain::bill::BillBlockchain;
 use bcr_ebill_core::protocol::blockchain::bill::block::BillIssueBlockData;
+use bcr_ebill_core::protocol::blockchain::bill::{BillBlock, BillBlockchain};
 use bcr_ebill_core::protocol::crypto::BcrKeys;
 use bcr_ebill_core::protocol::event::{EventEnvelope, EventType};
 use bcr_ebill_core::protocol::{EmailIdentityProofData, SignedIdentityProof};
@@ -514,6 +514,11 @@ mockall::mock! {
         async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
         async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
         async fn resync_identity_chain(&self) -> Result<()>;
+        async fn validate_bill_blocks_exist_on_nostr_chain(
+            &self,
+            bill_id: &BillId,
+            blocks: &[BillBlock],
+        ) -> Result<bool>;
     }
 }
 
@@ -621,7 +626,6 @@ mockall::mock! {
             id: &str,
             blockchain: bcr_ebill_core::protocol::blockchain::BlockchainType,
             block_time: Timestamp,
-            keys: BcrKeys,
             event: EventEnvelope,
             previous_event: Option<nostr::event::Event>,
             root_event: Option<nostr::event::Event>) -> Result<nostr::event::Event>;

--- a/crates/bcr-ebill-transport/src/transport.rs
+++ b/crates/bcr-ebill-transport/src/transport.rs
@@ -1,9 +1,9 @@
-use bcr_ebill_core::{
-    protocol::Timestamp,
-    protocol::blockchain::BlockchainType,
-    protocol::constants::BCR_NOSTR_CHAIN_PREFIX,
-    protocol::crypto::{BcrKeys, decrypt_ecies, encrypt_ecies},
-    protocol::event::EventEnvelope,
+use bcr_ebill_core::protocol::{
+    Timestamp,
+    blockchain::BlockchainType,
+    constants::BCR_NOSTR_CHAIN_PREFIX,
+    crypto::{BcrKeys, decrypt_ecies},
+    event::EventEnvelope,
 };
 
 use bcr_ebill_api::service::transport_service::{Error, Result};
@@ -83,10 +83,12 @@ async fn unwrap_nip17_envelope<T: NostrSigner>(
     result
 }
 
-/// Unwraps a Nostr chain event with its metadata. Will return the encrypted payload and
+/// Unwraps a Nostr chain event with its metadata. Will return the encrypted, or encoded payload and
 /// the metadata if the event matches a public chain event. Otherwise it returns None.
-pub fn unwrap_public_chain_event(event: Box<Event>) -> Result<Option<EncryptedPublicEventData>> {
-    let data: Vec<EncryptedPublicEventData> = event
+pub fn unwrap_public_chain_event(
+    event: Box<Event>,
+) -> Result<Option<EncryptedOrEncodedPublicEventData>> {
+    let data: Vec<EncryptedOrEncodedPublicEventData> = event
         .tags
         .filter_standardized(TagKind::SingleLetter(SingleLetterTag::lowercase(
             Alphabet::I,
@@ -101,7 +103,7 @@ pub fn unwrap_public_chain_event(event: Box<Event>) -> Result<Option<EncryptedPu
             } => chain_id
                 .as_ref()
                 .and_then(|id| BlockchainType::try_from(id.as_ref()).ok())
-                .map(|chain_type| EncryptedPublicEventData {
+                .map(|chain_type| EncryptedOrEncodedPublicEventData {
                     id: address.to_owned(),
                     chain_type,
                     payload: event.content.clone(),
@@ -158,16 +160,46 @@ pub fn root_and_reply_id(event: &Event) -> (Option<EventId>, Option<EventId>) {
     (root, reply)
 }
 
+/// Given an encoded payload, decodes the payload and returns its content as an EventEnvelope.
+fn decode_public_chain_event(data: &str) -> Result<EventEnvelope> {
+    let decoded = base58::decode(data)?;
+    let payload = borsh::from_slice::<EventEnvelope>(&decoded)?;
+    Ok(payload)
+}
+
 /// Given an encrypted payload and a private key, decrypts the payload and returns
 /// its content as an EventEnvelope.
-pub fn decrypt_public_chain_event(data: &str, keys: &BcrKeys) -> Result<EventEnvelope> {
+/// => For the deprecated chains, where metadata is encrypted (PR #938)
+fn decrypt_and_decode_public_chain_event(data: &str, keys: &BcrKeys) -> Result<EventEnvelope> {
     let decrypted = decrypt_ecies(&base58::decode(data)?, &keys.get_private_key())?;
     let payload = borsh::from_slice::<EventEnvelope>(&decrypted)?;
     Ok(payload)
 }
 
+/// Attempts to decrypt and then decode the payload (old, deprecated payload)
+/// If it's not encrypted, just decodes the payload
+/// If no key is supplied, it also only decodes
+pub fn decrypt_or_decode_public_chain_event(
+    data: &str,
+    keys: &Option<BcrKeys>,
+) -> Result<EventEnvelope> {
+    match keys {
+        Some(keys) => match decrypt_and_decode_public_chain_event(data, keys) {
+            Ok(decrypted) => Ok(decrypted),
+            Err(decrypt_err) => match decode_public_chain_event(data) {
+                Ok(decoded) => Ok(decoded),
+                Err(decode_err) => Err(Error::Blockchain(format!(
+                    "Could not decrypt or decode public chain event. Decrypt error: {decrypt_err}; decode error: {decode_err}"
+                ))),
+            },
+        },
+        // no keys - just decode - this is the code path to check the nostr chain based on the unencrypted metadata
+        None => decode_public_chain_event(data),
+    }
+}
+
 #[derive(Clone, Debug)]
-pub struct EncryptedPublicEventData {
+pub struct EncryptedOrEncodedPublicEventData {
     pub id: String,
     pub chain_type: BlockchainType,
     pub payload: String,
@@ -192,18 +224,17 @@ pub async fn create_nip04_event<T: NostrSigner>(
     .tag(Tag::public_key(*public_key)))
 }
 
-/// Takes an event envelope and creates a public chain event with appropriate tags and encrypted
-/// base58 encoded payload.
+/// Takes an event envelope and creates a public chain event with appropriate tags and base58
+/// encoded payload.
 pub fn create_public_chain_event(
     id: &str,
     event: EventEnvelope,
     block_time: Timestamp,
     blockchain: BlockchainType,
-    keys: BcrKeys,
     previous_event: Option<Event>,
     root_event: Option<Event>,
 ) -> Result<EventBuilder> {
-    let payload = base58::encode(&encrypt_ecies(&borsh::to_vec(&event)?, &keys.pub_key())?);
+    let payload = base58::encode(&borsh::to_vec(&event)?);
     let event = match previous_event {
         Some(evt) => EventBuilder::text_note_reply(payload, &evt, root_event.as_ref(), None)
             .tag(bcr_nostr_tag(id, blockchain)),
@@ -232,5 +263,118 @@ fn extract_event_envelope(rumor: UnsignedEvent) -> Option<EventEnvelope> {
         Some(envelope)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bcr_ebill_core::protocol::{crypto::encrypt_ecies, event::EventType};
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+    struct TestPayload {
+        id: u64,
+        message: String,
+    }
+
+    fn test_payload() -> TestPayload {
+        TestPayload {
+            id: 42,
+            message: "hello public chain".to_string(),
+        }
+    }
+
+    fn test_envelope() -> EventEnvelope {
+        let payload = test_payload();
+
+        EventEnvelope {
+            event_type: EventType::Bill,
+            version: "1.0".to_string(),
+            data: borsh::to_vec(&payload).unwrap(),
+        }
+    }
+
+    fn encode_envelope_base58(envelope: &EventEnvelope) -> String {
+        let encoded = borsh::to_vec(envelope).unwrap();
+        base58::encode(&encoded)
+    }
+
+    fn assert_envelope_eq(actual: &EventEnvelope, expected: &EventEnvelope) {
+        assert_eq!(actual.event_type, expected.event_type);
+        assert_eq!(actual.version, expected.version);
+        assert_eq!(actual.data, expected.data);
+        let actual_payload = TestPayload::try_from_slice(&actual.data).unwrap();
+        let expected_payload = TestPayload::try_from_slice(&expected.data).unwrap();
+        assert_eq!(actual_payload, expected_payload);
+    }
+
+    #[test]
+    fn decode_public_chain_event_decodes_base58_borsh_envelope() {
+        let envelope = test_envelope();
+        let encoded = encode_envelope_base58(&envelope);
+        let decoded = decode_public_chain_event(&encoded).unwrap();
+        assert_envelope_eq(&decoded, &envelope);
+    }
+
+    #[test]
+    fn decode_public_chain_event_returns_error_for_invalid_base58() {
+        let result = decode_public_chain_event("invvalid base58");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_public_chain_event_returns_error_for_non_envelope_payload() {
+        let encoded = base58::encode(b"valid base58 data but not a borsh envelope");
+        let result = decode_public_chain_event(&encoded);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decrypt_or_decode_public_chain_event_decodes_plain_payload_when_no_keys_are_supplied() {
+        let envelope = test_envelope();
+        let encoded = encode_envelope_base58(&envelope);
+        let decoded = decrypt_or_decode_public_chain_event(&encoded, &None).unwrap();
+        assert_envelope_eq(&decoded, &envelope);
+    }
+
+    #[test]
+    fn decrypt_or_decode_public_chain_event_falls_back_to_decode_when_decryption_fails() {
+        let envelope = test_envelope();
+        let encoded = encode_envelope_base58(&envelope);
+        let keys = BcrKeys::new();
+        let decoded = decrypt_or_decode_public_chain_event(&encoded, &Some(keys)).unwrap();
+        assert_envelope_eq(&decoded, &envelope);
+    }
+
+    #[test]
+    fn decrypt_or_decode_public_chain_event_returns_combined_error_when_decrypt_and_decode_fail() {
+        let invalid_payload = base58::encode(b"invalid payload");
+        let keys = BcrKeys::new();
+        let result = decrypt_or_decode_public_chain_event(&invalid_payload, &Some(keys));
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Could not decrypt or decode public chain event"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("Decrypt error:"),
+            "expected decrypt error in: {err}"
+        );
+        assert!(
+            err.contains("decode error:"),
+            "expected decode error in: {err}"
+        );
+    }
+
+    #[test]
+    fn decrypt_and_decode_public_chain_event_decodes_encrypted_payload() {
+        let envelope = test_envelope();
+        let serialized = borsh::to_vec(&envelope).unwrap();
+        let keys = BcrKeys::new();
+        let encrypted = encrypt_ecies(&serialized, &keys.pub_key()).unwrap();
+        let encoded = base58::encode(&encrypted);
+        let decoded = decrypt_and_decode_public_chain_event(&encoded, &keys).unwrap();
+        assert_envelope_eq(&decoded, &envelope);
     }
 }

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -245,6 +245,7 @@
             <button type="button" id="bill_search">Search Bills</button>
             <button type="button" id="bitcoin_keys">Get BTC Keys</button>
             <button type="button" id="sync_bill_chain">Sync Bill Chain</button>
+            <button type="button" id="sync_bill_chain_from_nostr">Sync Bill Chain From Nostr</button>
             <div>Execution Time: <span id="bill_execution_time"></div>
             <div>Results: <span id="bill_results"></div>
             <img id="bill_attached_file"/>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -83,6 +83,7 @@ document.getElementById("bill_test_promissory_blank").addEventListener("click", 
 document.getElementById("clear_bill_cache").addEventListener("click", clearBillCache);
 document.getElementById("bitcoin_keys").addEventListener("click", getBitcoinKeys);
 document.getElementById("sync_bill_chain").addEventListener("click", syncBillChain);
+document.getElementById("sync_bill_chain_from_nostr").addEventListener("click", syncBillChainFromNostr);
 document.getElementById("dev_mode_get_bill_chain").addEventListener("click", devModeGetBillChain);
 document.getElementById("share_bill_with_court").addEventListener("click", shareBillWithCourt);
 document.getElementById("mempool_link").addEventListener("click", mempoolLink);
@@ -897,6 +898,15 @@ async function getBitcoinKeys() {
 async function syncBillChain() {
   let bill_id = document.getElementById("bill_id").value;
   console.log("syncBillChain", bill_id);
+  let measured = measure(async () => {
+    return success_or_fail(await window.billApi.sync_bill_chain({ bill_id: bill_id, from_nostr: false }));
+  });
+  await measured();
+}
+
+async function syncBillChainFromNostr() {
+  let bill_id = document.getElementById("bill_id").value;
+  console.log("syncBillChain from Nostr", bill_id);
   let measured = measure(async () => {
     return success_or_fail(await window.billApi.sync_bill_chain({ bill_id: bill_id, from_nostr: true }));
   });


### PR DESCRIPTION
* Removes the additional encryption layer on Nostr for public chain events
  * Now only the block `data` is encrypted, but the block metadata (id, hashes, signature etc.) are publicly available
  * This is unfortunately a breaking network protocol change, so we need to be careful in rolling this out, but it's necessary to enable external parties to validate a shared bill
* Add logic for checking a set of blocks against the publishes blocks on nostr (for Wildcat)

(Pending changing refs to merged version)