### PR TITLE
Improve BTC network parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.15
 
 * Use latest bcr-common with new bitcr Token format including the btc network
+* Adapt `bitcoin network` parsing - `bitcoin` is now a valid value for `mainnet`
 
 # 0.5.14
 

--- a/crates/bcr-ebill-api/src/lib.rs
+++ b/crates/bcr-ebill-api/src/lib.rs
@@ -56,10 +56,17 @@ impl Config {
     pub fn bitcoin_network(&self) -> Network {
         match self.bitcoin_network.as_str() {
             "mainnet" => Network::Bitcoin,
+            "bitcoin" => Network::Bitcoin,
             "testnet" => Network::Testnet,
             "testnet4" => Network::Testnet4,
             "regtest" => Network::Regtest,
-            _ => Network::Testnet,
+            _ => {
+                log::warn!(
+                    "Triggered fallback for config bitcoin network, network is set to {}, but defaulted to Testnet",
+                    self.bitcoin_network
+                );
+                Network::Testnet
+            }
         }
     }
 }

--- a/crates/bcr-ebill-wasm/src/lib.rs
+++ b/crates/bcr-ebill-wasm/src/lib.rs
@@ -245,6 +245,7 @@ pub async fn initialize_api(
                 .expect("court url is not a valid URL"),
         },
     };
+    debug!("Config: {api_config:?}");
     init(api_config.clone())?;
     // make sure the configured default mint node id is valid for the configured network
     validate_node_id_network(&api_config.mint_config.default_mint_node_id)?;
@@ -268,7 +269,6 @@ pub async fn initialize_api(
             .expect("invalid npub from node id")
     );
     info!("Local npub as hex: {}", node_id.npub().to_hex());
-    debug!("Config: {api_config:?}");
 
     // init context as static reference
     let ctx = Context::new(api_config.clone(), db).await?;


### PR DESCRIPTION
* Shows a warning if we fall back because of a wrongly set network (for debugging)
* Add a case for "bitcoin" => Network::Bitcoin to support the default bitcoin core naming