### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:30"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    assignees:
+      - "cleot" # devops
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    groups:
+      rust-patch:
+        update-types:
+          - "patch"
+      rust-minor:
+        update-types:
+          - "minor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:30"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 7
+    labels:
+      - "dependencies"
+      - "rust"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
This repository has no `.github/dependabot.yml`, so Dependabot runs on its defaults: no grouping, no schedule, no labels, updates aimed at the default branch.

That is what produced `docs-bitcr#2` — *"Bump the npm_and_yarn group across 1 directory with 9 updates"* — which was closed unread. Nine unrelated bumps in one pull request is not reviewable.

**Ecosystems configured:** github-actions, cargo

Matching the nine repositories that already have a config:

- action updates monthly, all grouped into one pull request
- language updates weekly, split into separate patch and minor groups
- a cooldown before major bumps (30 days major, 7 minor, 3 patch)
- `dependencies` plus the ecosystem label, both already managed by the organisation label sync

Only ecosystems with a real manifest in this repository are configured. Vendored third-party manifests and other people's compose files are deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)