### PR TITLE
Assign Dependabot pull requests to zupzup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       - "dependencies"
       - "github-actions"
     assignees:
-      - "cleot" # devops
+      - "zupzup"
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -40,3 +40,5 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    assignees:
+      - "zupzup"


### PR DESCRIPTION
`assignees` was set on the `github-actions` block only, so every `cargo` pull request has been opening with no assignee at all. There are 8 open right now.

This sets the assignee to `zupzup` on every update block, per the mapping in [`dependabot-assignees.yml`](https://github.com/BitcreditProtocol/.github/blob/master/dependabot-assignees.yml). The weekly settings audit now reports any repository whose configuration disagrees with that file, so it cannot drift back unnoticed — and a repository added later shows up in the report instead of silently starting with no reviewer.

Nothing else changes: same schedule, same grouping, same ignore rules.
