### PR TITLE
Cooldown on action updates, and pin actions by commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    cooldown:
+      default-days: 3
     assignees:
       - "zupzup"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
           wasm-pack build --target web
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
Two changes, one commit each. This replaces the pull request closed earlier today, which carried an invalid cooldown key.

## Cooldown on the `github-actions` block

Every package block in this organisation has carried a cooldown for months. The `github-actions` block never had one, which is backwards: an action runs inside the job with the job's token and secrets, while an npm package usually just sits in `node_modules`.

`default-days: 3` — the only cooldown key this ecosystem accepts. The `semver-*` keys are rejected, and Dependabot rejects the **whole file** when any property is invalid, which is exactly what broke the first attempt. Verified against Dependabot's own validator this time.

## Actions pinned by commit

A tag is mutable. The author can repoint it at different code, and CI runs that code with the job's token and secrets without a single change here. That is how `tj-actions/changed-files` leaked CI secrets from some 23,000 repositories in March 2025 — everything pinned by commit was untouched.

Each commit is the one its tag points at **today**, so nothing changes about what runs. The version stays in a trailing comment, which is what Dependabot reads to keep offering updates.

## Verification

Both files parse. Diffs were checked line by line before pushing: the config diff contains only `cooldown` and group lines, the workflow diff only `uses:` lines, and no moving tag is left behind in any file touched.