### PR TITLE
Delete CONTRIBUTING.md and inherit the organisation version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,0 @@
-## How to Contribute
-
-Please follow the processes in our general [Contributing Code][contributing]
-guidelines.
-
-[contributing]: https://docs.google.com/document/d/18468Jb_PT4Sn1YoiwsEIZmWXUb2opxEQzFyGGnwH5VQ/edit?usp=sharing


### PR DESCRIPTION
## What

Deletes `CONTRIBUTING.md` so the repository inherits the organisation version from `BitcreditProtocol/.github` instead of carrying its own copy.

## Why it is safe

The content is **identical**. Diffed against the organisation version: the only difference was that this copy ended with a newline and the organisation one did not.

[`.github#25`](https://github.com/BitcreditProtocol/.github/pull/25) adds that missing newline to the organisation file first, so after both merge the inherited file is byte-for-byte what this repository has today. **Nothing is lost, not even a byte.**

Merge order does not strictly matter, but `.github#25` first is tidier — the other way round leaves the organisation file briefly without a final newline.

## Why bother

A duplicated file that is identical today is a file that drifts tomorrow, and nothing reports it. `CONTRIBUTING.md` is 224 bytes pointing at a Google Doc; there is no reason for three copies of it to exist.

This is not a blanket rule against overrides. `SECURITY.md` in `AI-Credit` and `bitcr-chat-widget` stays — that is genuine repository-specific policy. So do the stack-specific pull request templates in this organisation, which turned out to be frontend and Rust adaptations rather than drift.
