### PR TITLE
ci: do not fail Rust CI when the SARIF upload cannot attach

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        continue-on-error: true
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
## What

One line: `continue-on-error: true` on the `Upload analysis results to GitHub` step in `.github/workflows/rust.yml`. **+1 line, nothing else touched.**

## Why

The step fails whenever a pull request is merged while its CI is still running:

```
##[error]ref 'refs/heads/<branch>' not found in this repository
```

Branch cleanup on merge (`delete_branch_on_merge` is `true` here) removes the ref before the upload runs at the end of the job. Nothing is wrong with the code — the analysis simply has nowhere to attach.

Measured across the seven Rust repositories:

| Repository | Has this line | ref-not-found failures |
|---|---|---|
| `Wildcat` | **yes** | **0** |
| `bcr-common` | **yes** | **0** |
| `Bitcredit-Core` | no | **7** of 11 recent failures |
| `Clowder` | no | **5** of 12 |
| `Wildcat-Auxiliary` | no | **2** of 7 |
| `Wallet-Core`, `nostr-postgres-db` | no | 0 — have not hit the race yet |

Fourteen false failures, every one in a repository lacking the line. **This is not a new idea — it propagates a fix that already exists in two repositories here and was never spread.**

## And it removes a contradiction inside the file

`rust.yml` already marks three steps `continue-on-error: true`: *Check formatting*, *Clippy*, *Cargo deny*. Clippy does not fail the build. Failing the build because the **upload** of a non-fatal step's results could not be attached is incoherent with the file's own convention.

Clippy findings still reach the security tab on every run where the ref exists — which is every run that is not racing a merge.

## Verified

Parsed before and after: triggers, `permissions`, the job set and every step are identical except that one step gains one key, and the file is exactly one line longer. Confirmed by parsing rather than by line number.

## The real fix lives elsewhere

`rust.yml` is duplicated across seven repositories and is the file the planned shared Rust workflow consolidates. That shared workflow must carry this line; these five one-line pull requests are the interim so the noise stops now.
