### PR TITLE
ci: cancel superseded runs instead of paying for them

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "**" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "**" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
## What

One `concurrency` block per workflow. **+4 lines per file, nothing else touched.**

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Why — measured, not assumed

These workflows trigger on `push: branches: ["**"]` and set no `concurrency`, so pushing twice to a branch runs the whole thing twice in parallel. The earlier run's result can never matter.

Across the seven Rust repositories, last 14 days:

| | |
|---|---|
| Runs of `rust.yml` + `test.yml` | **808** across 286 (repo, workflow, branch) combinations |
| Total wall-clock | **115 hours** |
| **Superseded before finishing** | **172 — 21%** |
| Wall-clock spent on those | **21 hours** |

The minutes are the smaller half. Those 172 runs also occupy the queue ahead of the runs people are actually waiting on, and `Clowder`'s end-to-end build takes 37 minutes on its own.

## Not a new idea

This block already exists **verbatim** in `Wildcat/build.yml`, `Wildcat/nightly.yml`, `Wildcat-Auxiliary/build.yml`, `Clowder/build.yml` and `E-Bill-frontend/ci.yml`. Diffed against `Clowder/build.yml` — byte for byte identical, not a variant. This puts it in the 15 files that lack it.

## What it deliberately does not do

It cancels on the default branch as well. Guarding that — `cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}` — would stop a `master` run ever being cancelled and always leave a recorded result, which is what I would normally write. **None of the five existing copies do that**, and matching the house pattern beats being marginally cleverer in fifteen new places. If the guard is wanted, it is wanted in all twenty at once.

## Verified

Parsed before and after: `concurrency` equals the house pattern exactly, and `name`, triggers, `permissions`, `env`, the job set and every step are unchanged. Each file is exactly four lines longer.

## How to tell it worked

Not from the diff — from behaviour. Push twice in quick succession to a branch here: the first run should show as **cancelled**, not completed. And the 21% figure should approach zero when re-measured in a fortnight.
