### PR TITLE
ci: give each job a timeout derived from its own measured duration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   test:
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What

A `timeout-minutes` on each job, placed where this repository's siblings already put it — immediately before `runs-on:`. **One added line per job, nothing else.**

| Workflow | Job | median | p95 (trimmed) | worst seen | timeout |
|---|---|---|---|---|---|
| `rust.yml` | `build` | 18.0 min | 18.8 min | 19.0 min | **40 min** |
| `test.yml` | `test` | 10.7 min | 11.2 min | 11.7 min | **25 min** |

## Why

Without it a hung job runs to GitHub's default of **six hours**. Across the organisation **67 of 74 workflows set no timeout at all**, and the risk is not hypothetical — `Clowder/e2e.yml`, whose healthy runs take 37 minutes, has a 119-minute run on record.

## Where the numbers come from

Measured per job, not guessed: 212 job samples over the last two months, from each job's own `started_at` and `completed_at`.

**And the obvious formula is wrong.** Setting a timeout from p95 means that with few samples the hang you are trying to cut *becomes* the p95. One job in this organisation has a median of 42 seconds and a raw p95 of 110 minutes — a p95-driven rule would have given it a **220-minute** timeout, set by the single hang it exists to catch.

So: drop the largest sample when there are fewer than ten, take the p95 of what remains, double it, floor at 15 minutes, round up to 5. Every value here is **at least twice its job's healthy p95** — asserted programmatically rather than eyeballed — so it cannot fire on a good run while capping a hang in minutes rather than hours.

## Verified

Parsed before and after: the job set, every job body, triggers, `permissions`, `env` and `concurrency` are identical. The only difference is one `timeout-minutes` key per job listed above, and jobs with too few samples were **left alone** rather than given a guessed number.

## How to tell it worked

Not from the diff. **A timeout that fires on a healthy build is worse than no timeout**, so the check is that the next ordinary run of each workflow above completes without hitting its limit.
