### PR TITLE
dependabot: one group per ecosystem instead of separate patch and minor groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,9 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     groups:
-      rust-patch:
+      rust:
         update-types:
           - "patch"
-      rust-minor:
-        update-types:
           - "minor"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What

Merges each `<lang>-patch` / `<lang>-minor` pair into a single group. Groups changed here: **cargo:rust**.

```yaml
# before                              # after
groups:                               groups:
  rust-patch:                           rust:
    update-types: ["patch"]               update-types: ["patch", "minor"]
  rust-minor:
    update-types: ["minor"]
```

`all-github-actions` is untouched — it already groups everything with `patterns: ["*"]`.

## Why, and why now

Two groups per ecosystem means two pull requests a week where one would do. Owner directive: fewer Dependabot pull requests.

**This is not a guess — the canary already proved it.** [`nostr-postgres-db#31`](https://github.com/BitcreditProtocol/nostr-postgres-db/pull/31) made exactly this change and merged this morning at 07:49. Within a minute:

- `#14` (the `rust-patch` group, 4 updates) and `#15` (`rust-minor`, 1 update) both **closed**
- **`#36` "Bump the rust group with 5 updates"** opened at 07:50, carrying all five, CI green

Across the estate this is 19 pairs in 16 repositories, and it lands **20 of 23 repositories on at most one grouped pull request a week** — because `github-actions` is monthly and most repositories have exactly one code ecosystem.

## Majors deliberately stay outside the group

A group covering majors too would let one broken breaking upgrade block every safe update behind it. The measurement that settled this: **six repositories currently hold both green and failing Dependabot pull requests**, worst case 10 green against 1 failing. Bundling would hold the ten hostage to the one.

A single pull request per *repository* — spanning ecosystems — was considered and rejected: `multi-ecosystem-groups` does not accept `update-types`, so it cannot keep majors separate.

## Two things to expect after merge

- **Existing grouped pull requests will be superseded, not updated.** Renaming a group changes the branch name, so the current `*-patch` / `*-minor` pull requests close and reopen as one. That is a net reduction — each pair becomes one — but it does churn.
- **`Update X requirement` pull requests stay individual.** Cargo manifest-range updates carry no `update-type: version-update:semver-*` marker, so an `update-types` group cannot match them by construction. Catching them would need a `patterns`-only group, which would swallow majors too.

## Verification

- Parsed before and after and deep-diffed across **every path**: the only changed paths are the group definitions. `schedule`, `cooldown`, `open-pull-requests-limit`, `labels`, `assignees`, `target-branch` and every other ecosystem entry are byte-identical — asserted programmatically, not eyeballed.
- The differ was negative-tested first: given a copy with a changed `open-pull-requests-limit` and a removed assignee it reported both and flagged them as outside the `groups:` block.
- The strict formatting assumption was **re-asserted against live state** rather than replayed from yesterday's run: all 19 pairs still match one pattern, and the already-merged canary correctly shows zero.
- Based on `master`, taken from this repository's own convention across all authors. Where that is `dev`, the file was confirmed **byte-identical on `dev` and the default branch** first, so there is no divergence to reconcile.
