### PR TITLE
chore(release): categorise generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,38 @@
+# Shapes the notes GitHub generates for a release: the "Generate release notes"
+# button, softprops/action-gh-release, and the release train in
+# BitcreditProtocol/.github. Without this file the generator emits one flat list.
+#
+# Categories are matched in order and the first match wins, so `breaking` is
+# first on purpose -- a pull request labelled both `breaking` and `enhancement`
+# is a breaking change, and that is the line a reader is scanning for.
+#
+# Every label named here is in the `required` tier of labels.yml, so it exists in
+# all 29 repositories and sync-labels recreates it if it is deleted. A category
+# keyed on a label that exists in one repository would be a decoration.
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - question
+      - awaiting triage
+  categories:
+    - title: ⚠️ Breaking changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,10 @@
 # first on purpose -- a pull request labelled both `breaking` and `enhancement`
 # is a breaking change, and that is the line a reader is scanning for.
 #
-# Every label named here is in the `required` tier of labels.yml, so it exists in
-# all 29 repositories and sync-labels recreates it if it is deleted. A category
-# keyed on a label that exists in one repository would be a decoration.
+# Every label named here, except the `*` wildcard, is in the `required` tier of
+# labels.yml at the root of BitcreditProtocol/.github; sync-labels there creates it
+# in every repository weekly and recreates it if deleted. A category keyed on a
+# label that exists in one repository would be a decoration.
 changelog:
   exclude:
     labels:


### PR DESCRIPTION
Without `.github/release.yml` GitHub's generator emits one flat list of pull request titles. With it the same generated notes come out grouped, and a breaking change gets its own heading at the top.

This is the other half of #37, which moved the `breaking` label from `managed` to `required` so `sync-labels` creates it in all 29 repositories. Every label the file names is in that tier, checked as parsed data.

**GitHub reads this file from the release's `target_commitish`, not from the default branch** — the opposite of `.github/ISSUE_TEMPLATE/config.yml`. That is not in the documentation, so it was tested: with the file on a branch the generator emits `### Other changes` and stamps `<!-- Release notes generated using configuration in .github/release.yml at … -->` into the output; without it, the same call returns the flat list. This targets the default branch because every release here is cut from it or from a commit on it.

Nothing changes until somebody generates notes. No existing release is touched.
