### PR TITLE
docs: explain WASM publication approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Check out the project [contributing guide](./CONTRIBUTING.md).
 ## WASM publication approval
 
 The manual `WASM Release` workflow uses the `release-wasm` GitHub environment.
-Publication requires approval from one of `cleot`, `zupzup` or `mtbitcr`.
+Publication requires approval from one of the reviewers configured for that
+environment. GitHub environment settings are the source of truth for the list.
 Self-approval is allowed, administrators retain their bypass, and there is no
 additional wait timer. The workflow's existing initiator allowlist still applies.
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ RUST_LOG=info cargo test -- --nocapture
 ## Contribute
 
 Check out the project [contributing guide](./CONTRIBUTING.md).
+
+## WASM publication approval
+
+The manual `WASM Release` workflow uses the `release-wasm` GitHub environment.
+Publication requires approval from one of `cleot`, `zupzup` or `mtbitcr`.
+Self-approval is allowed, administrators retain their bypass, and there is no
+additional wait timer. The workflow's existing initiator allowlist still applies.
+
+Only the `master` branch and branches matching `hotfix/*` may use this
+environment. Use names such as `hotfix/0.5.7-1` for new hotfix branches. Historical
+branches keep their names; they do not gain publication permission from an older
+naming convention. No tag policies are configured.
+
+Validate WASM builds with the normal `Rust CI` workflow. Do not run the publication
+workflow merely to test environment settings: it creates a release and publishes
+the npm package.


### PR DESCRIPTION
Documents the native protection rules applied to the `release-wasm` environment: approval from a reviewer configured in the environment settings; self-approval allowed; administrator bypass retained; no wait timer. Only branch policies for `master` and `hotfix/*` are configured, with no tag policies.

New hotfix branches use names such as `hotfix/0.5.7-1`. Historical branches are not renamed. The publication workflow's existing initiator allowlist is unchanged.

Validation: the environment was read before the change and read back through the GitHub REST API afterward. Assertions verified the configured approval rule, self-review and bypass flags, the exact two branch policies, and absence of a wait timer. The README was checked against that configuration and the existing workflow; independent review found no issues and `git diff --check` passed.

This PR changes documentation only. No secrets were changed, and no package, GitHub release or deployment was published. Cargo tool pinning is outside this change.
