### PR TITLE
fix(release): resume saved WASM publications

### DIFF
--- a/.github/scripts/release_wasm.py
+++ b/.github/scripts/release_wasm.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Prepare immutable WASM bytes and reconcile one native Actions run."""
+
+import base64
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+from urllib.parse import quote
+import zipfile
+
+ARTIFACT = "release-package"
+REGISTRY = "https://registry.npmjs.org"
+PLAN = "release-plan.json"
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+def command(args, **kwargs):
+    return subprocess.run(args, capture_output=True, **kwargs)
+
+
+def gh(endpoint, *, method="GET", data=None, missing=False, raw=False, paginate=False):
+    args = ["gh", "api", endpoint, "--method", method]
+    if paginate:
+        args += ["--paginate", "--slurp"]
+    if raw:
+        args += ["-H", "Accept: application/octet-stream"]
+    payload = None
+    if data is not None:
+        args += ["--input", "-"]
+        payload = json.dumps(data).encode()
+    result = command(args, input=payload)
+    if result.returncode:
+        status = re.search(rb"HTTP (\d+)", result.stderr)
+        status = status[1].decode() if status else "unknown"
+        if missing and status == "404":
+            return None
+        raise ReleaseError(f"GitHub {method} failed (HTTP {status})")
+    if raw:
+        return result.stdout
+    try:
+        return json.loads(result.stdout)
+    except (ValueError, TypeError) as error:
+        raise ReleaseError("GitHub returned invalid JSON") from error
+
+
+def pages(endpoint, key=None):
+    result = gh(endpoint + "?per_page=100", paginate=True)
+    if not isinstance(result, list) or not result:
+        raise ReleaseError("Invalid paginated response")
+    values = []
+    for page in result:
+        rows = page.get(key) if key and isinstance(page, dict) else page
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            raise ReleaseError("Incomplete paginated response")
+        values.extend(rows)
+    return values
+
+
+def context():
+    repo, sha, run = (os.environ[name] for name in ("GITHUB_REPOSITORY", "GITHUB_SHA", "GITHUB_RUN_ID"))
+    if repo != "BitcreditProtocol/Bitcredit-Core" or not re.fullmatch(r"[0-9a-f]{40}", sha) or not run.isdigit():
+        raise ReleaseError("Invalid release run identity")
+    version = tomllib.loads(Path("Cargo.toml").read_text())["workspace"]["package"]["version"]
+    crate = tomllib.loads(Path("crates/bcr-ebill-wasm/Cargo.toml").read_text())["package"]["name"]
+    return dict(repository=repo, sha=sha, run_id=run, version=version, tag="v" + version,
+                package_name="@bitcredit/" + crate.replace("_", "-"))
+
+
+def canonical_version(version):
+    # npm validates the version; equality rejects npm's loose coercions.
+    if not isinstance(version, str) or not re.fullmatch(r"[0-9][0-9A-Za-z.+-]*", version):
+        raise ReleaseError("Invalid version syntax")
+    base, separator, build = version.partition("+")
+    if separator and not re.fullmatch(r"[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*", build):
+        raise ReleaseError("Invalid SemVer build metadata")
+    with tempfile.TemporaryDirectory() as tmp:
+        package = Path(tmp) / "package.json"
+        package.write_text('{"name":"release-version-check","version":"0.0.0"}')
+        result = command(["npm", "version", version, "--allow-same-version", "--no-git-tag-version", "--ignore-scripts",
+                          "--cache", str(Path(tmp) / "cache")], cwd=tmp)
+        normalized = json.loads(package.read_text())["version"]
+        if result.returncode or normalized != base:
+            raise ReleaseError("Version is not strict SemVer")
+    return normalized
+
+
+def npm_integrity(name, version):
+    result = command(["npm", "view", f"{name}@{version}", "dist.integrity", "--json", "--registry", REGISTRY])
+    try:
+        value = json.loads(result.stdout)
+    except ValueError as error:
+        raise ReleaseError("npm returned invalid JSON") from error
+    if result.returncode:
+        if isinstance(value, dict) and value.get("error", {}).get("code") == "E404":
+            return None
+        raise ReleaseError("npm metadata read failed")
+    if not isinstance(value, str) or not value.startswith("sha512-"):
+        raise ReleaseError("npm did not return a SHA-512 integrity value")
+    return value
+
+
+def tag_sha(ctx):
+    value = gh(f"repos/{ctx['repository']}/git/ref/tags/{quote(ctx['tag'], safe='')}", missing=True)
+    if value is None:
+        return None
+    obj = value["object"]
+    for _ in range(20):
+        if obj.get("type") == "commit" and re.fullmatch(r"[0-9a-f]{40}", obj.get("sha", "")):
+            return obj["sha"]
+        if obj.get("type") != "tag" or not re.fullmatch(r"[0-9a-f]{40}", obj.get("sha", "")):
+            break
+        obj = gh(f"repos/{ctx['repository']}/git/tags/{obj['sha']}")["object"]
+    raise ReleaseError("Invalid or excessively nested tag")
+
+
+def release(ctx):
+    rows = pages(f"repos/{ctx['repository']}/releases")
+    if any(type(row.get("id")) is not int or row["id"] <= 0
+           or not isinstance(row.get("tag_name"), str) or not row["tag_name"]
+           or type(row.get("draft")) is not bool for row in rows):
+        raise ReleaseError("Invalid release list")
+    found = [row for row in rows if row["tag_name"] == ctx["tag"]]
+    if len(found) > 1:
+        raise ReleaseError("Multiple releases match the tag")
+    if not found:
+        return None
+    value = found[0]
+    if type(value.get("id")) is not int or value["id"] <= 0 or type(value.get("draft")) is not bool:
+        raise ReleaseError("Invalid release identity")
+    return value
+
+
+def digest(path, algorithm="sha256"):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, algorithm).digest()
+
+
+def safe_file(name):
+    return name == "package.tgz" or bool(re.fullmatch(r"assets/[A-Za-z0-9][A-Za-z0-9._+-]*", name))
+
+
+def validate(folder, ctx):
+    plan = json.loads((folder / PLAN).read_text())
+    if plan.get("schema") != 1 or any(plan.get(key) != value for key, value in ctx.items()):
+        raise ReleaseError("Saved package belongs to a different source or run")
+    files = plan.get("files")
+    if not isinstance(files, dict) or "package.tgz" not in files or not files:
+        raise ReleaseError("Invalid saved file inventory")
+    for name, info in files.items():
+        if not safe_file(name) or not isinstance(info, dict):
+            raise ReleaseError("Invalid saved package path")
+        path = folder / name
+        if path.is_symlink() or not path.is_file() or path.stat().st_size != info.get("size") or digest(path).hex() != info.get("sha256"):
+            raise ReleaseError(f"Saved file failed checksum validation: {name}")
+    actual = {p.relative_to(folder).as_posix() for p in folder.rglob("*") if p.is_file()}
+    if actual != set(files) | {PLAN}:
+        raise ReleaseError("Saved package contains unexpected files")
+    integrity = "sha512-" + base64.b64encode(digest(folder / "package.tgz", "sha512")).decode()
+    if plan.get("integrity") != integrity or plan.get("registry_version") != canonical_version(ctx["version"]):
+        raise ReleaseError("Invalid package integrity or registry version")
+    with tarfile.open(folder / "package.tgz", "r:gz") as archive:
+        package = json.load(archive.extractfile("package/package.json"))
+        for name in ("index.js", "index.d.ts", "index_bg.wasm"):
+            member = archive.getmember("package/" + name)
+            if not member.isfile() or member.size == 0:
+                raise ReleaseError("Required WASM package file is missing or empty")
+    if package.get("name") != ctx["package_name"] or package.get("version") != ctx["version"]:
+        raise ReleaseError("Saved npm manifest does not match source metadata")
+    return plan
+
+
+def restore(folder, ctx):
+    rows = pages(f"repos/{ctx['repository']}/actions/runs/{ctx['run_id']}/artifacts", "artifacts")
+    if any(type(row.get("id")) is not int or row["id"] <= 0
+           or not isinstance(row.get("name"), str) or not row["name"]
+           or type(row.get("expired")) is not bool for row in rows):
+        raise ReleaseError("Invalid artifact list")
+    candidates = [a for a in rows if a["name"] == ARTIFACT]
+    if not candidates:
+        version = canonical_version(ctx["version"])
+        # Without saved bytes, existing external state must never be adopted.
+        if tag_sha(ctx) is not None or release(ctx) is not None or npm_integrity(ctx["package_name"], version) is not None:
+            raise ReleaseError("Publication exists but the immutable package artifact is missing")
+        return False
+    if len(candidates) != 1:
+        raise ReleaseError("Ambiguous package artifact")
+    artifact = candidates[0]
+    if artifact.get("expired") is not False or type(artifact.get("id")) is not int or artifact["id"] <= 0:
+        raise ReleaseError("Package artifact is expired or invalid")
+    payload = gh(f"repos/{ctx['repository']}/actions/artifacts/{artifact['id']}/zip", raw=True)
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        names = [item.filename for item in archive.infolist() if not item.is_dir()]
+        if len(names) != len(set(names)) or PLAN not in names or any(name != PLAN and not safe_file(name) for name in names):
+            raise ReleaseError("Unsafe or invalid artifact archive")
+        folder.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            destination = folder / name
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(archive.read(name))
+    validate(folder, ctx)
+    note(f"Restored artifact {artifact['id']} from original run {ctx['run_id']}.")
+    return True
+
+
+def prepare(folder, source, ctx):
+    package = json.loads((source / "package.json").read_text())
+    if package.get("version") != ctx["version"] or package.get("name") != ctx["package_name"]:
+        raise ReleaseError("Built WASM package does not match the source version/name")
+    version = canonical_version(ctx["version"])
+    folder.mkdir(parents=True, exist_ok=False)
+    (folder / "assets").mkdir()
+    for path in source.iterdir():
+        if path.name.startswith("."):
+            continue
+        if not path.is_file() or not safe_file("assets/" + path.name):
+            raise ReleaseError("Unexpected WASM package entry")
+        shutil.copyfile(path, folder / "assets" / path.name)
+    result = command(["npm", "pack", "--json", "--ignore-scripts", "--pack-destination", str(folder.resolve())], cwd=source)
+    if result.returncode:
+        raise ReleaseError("npm pack failed")
+    output = json.loads(result.stdout)
+    name = output[0]["filename"]
+    if Path(name).name != name:
+        raise ReleaseError("Invalid npm archive name")
+    (folder / name).rename(folder / "package.tgz")
+    files = {p.relative_to(folder).as_posix(): {"size": p.stat().st_size, "sha256": digest(p).hex()}
+             for p in folder.rglob("*") if p.is_file()}
+    plan = dict(schema=1, **ctx, registry_version=version, files=files,
+                integrity="sha512-" + base64.b64encode(digest(folder / "package.tgz", "sha512")).decode(),
+                changelog=os.environ.get("RELEASE_CHANGELOG", ""))
+    (folder / PLAN).write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+    validate(folder, ctx)
+    note(f"Prepared {ctx['tag']} from {ctx['sha']}; no publication writes performed.")
+
+
+def note(message):
+    print(message)
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as stream:
+            stream.write("- " + message + "\n")
+
+
+def write_once(action, readback, description):
+    # A lost response is resolved by reading state, never by blind repeat writes.
+    try:
+        action()
+    except ReleaseError:
+        pass
+    if not readback():
+        raise ReleaseError(f"{description} was not confirmed; rerun the original run")
+    note(description + " confirmed.")
+
+
+def matching_asset(ctx, release_id, name, info):
+    rows = pages(f"repos/{ctx['repository']}/releases/{release_id}/assets")
+    if any(type(row.get("id")) is not int or row["id"] <= 0
+           or not isinstance(row.get("name"), str) or not row["name"]
+           or row.get("state") not in ("starter", "uploaded")
+           or type(row.get("size")) is not int or row["size"] < 0 for row in rows):
+        raise ReleaseError("Invalid release asset list")
+    found = [a for a in rows if a["name"] == name]
+    if not found:
+        return False
+    if len(found) != 1:
+        raise ReleaseError("Ambiguous release asset")
+    asset = found[0]
+    if type(asset.get("id")) is not int or asset.get("state") != "uploaded" or asset.get("size") != info["size"]:
+        raise ReleaseError(f"Conflicting or incomplete release asset: {name}")
+    checksum = asset.get("digest")
+    if checksum is None:
+        checksum = "sha256:" + hashlib.sha256(gh(f"repos/{ctx['repository']}/releases/assets/{asset['id']}", raw=True)).hexdigest()
+    if checksum != "sha256:" + info["sha256"]:
+        raise ReleaseError(f"Conflicting release asset content: {name}")
+    return True
+
+
+def publish(folder, ctx):
+    plan = validate(folder, ctx)
+    with tempfile.TemporaryDirectory(prefix="release-readback-") as tmp:
+        saved = Path(tmp)
+        if not restore(saved, ctx) or validate(saved, ctx) != plan:
+            raise ReleaseError("Publication bytes must match the immutable package artifact")
+    current = tag_sha(ctx)
+    if current is not None and current != ctx["sha"]:
+        raise ReleaseError("Tag points to a different commit")
+    current_npm = npm_integrity(ctx["package_name"], plan["registry_version"])
+    if current_npm is not None and current_npm != plan["integrity"]:
+        raise ReleaseError("npm version contains different bytes")
+    existing = release(ctx)
+    # Complete all initial reads before creating the first external object.
+    if existing:
+        for name, info in plan["files"].items():
+            if name.startswith("assets/"):
+                matching_asset(ctx, existing["id"], Path(name).name, info)
+    if current is None:
+        write_once(
+            lambda: gh(f"repos/{ctx['repository']}/git/refs", method="POST",
+                       data={"ref": "refs/tags/" + ctx["tag"], "sha": ctx["sha"]}),
+            lambda: tag_sha(ctx) == ctx["sha"], "Saved commit tag",
+        )
+    if existing is None:
+        body = (plan["changelog"] + f"\n\nVersion: {ctx['version']}\nSource: {ctx['sha']}\n"
+                f"Candidate: https://github.com/{ctx['repository']}/actions/runs/{ctx['run_id']}\n").strip()
+        write_once(
+            lambda: gh(f"repos/{ctx['repository']}/releases", method="POST",
+                       data={"tag_name": ctx["tag"], "name": ctx["tag"], "body": body, "draft": True}),
+            lambda: release(ctx) is not None, "Draft GitHub release",
+        )
+        existing = release(ctx)
+    for name, info in plan["files"].items():
+        if not name.startswith("assets/") or matching_asset(ctx, existing["id"], Path(name).name, info):
+            continue
+
+        def upload():
+            result = command(["gh", "release", "upload", ctx["tag"], str((folder / name).resolve()), "--repo", ctx["repository"]])
+            if result.returncode:
+                raise ReleaseError("Asset upload response failed")
+        write_once(upload, lambda: matching_asset(ctx, existing["id"], Path(name).name, info), "Asset " + Path(name).name)
+    prerelease = "-" in ctx["version"].split("+", 1)[0]
+    if current_npm is None:
+        def upload_npm():
+            result = command(["npm", "publish", str((folder / "package.tgz").resolve()), "--registry", REGISTRY,
+                              "--access", "public", "--provenance", "--ignore-scripts", "--tag", "next" if prerelease else "latest"])
+            if result.returncode:
+                raise ReleaseError("npm publication response failed")
+        write_once(upload_npm, lambda: npm_integrity(ctx["package_name"], plan["registry_version"]) == plan["integrity"],
+                   "npm package integrity")
+    else:
+        note("Existing npm package integrity matches; publication preserved.")
+    if existing["draft"]:
+        write_once(
+            lambda: gh(f"repos/{ctx['repository']}/releases/{existing['id']}", method="PATCH",
+                       data={"draft": False, "prerelease": prerelease}),
+            lambda: release(ctx)["draft"] is False, "Final GitHub release",
+        )
+    note(f"Release {ctx['tag']} is complete for saved run {ctx['run_id']}.")
+
+
+def main():
+    action = sys.argv[1]
+    folder = Path(sys.argv[2]).resolve()
+    ctx = context()
+    if action == "restore":
+        restored = restore(folder, ctx)
+        with open(os.environ["GITHUB_OUTPUT"], "a") as stream:
+            stream.write(f"restored={'true' if restored else 'false'}\n")
+    elif action == "prepare":
+        prepare(folder, Path(sys.argv[3]).resolve(), ctx)
+    elif action == "publish":
+        if os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch":
+            raise ReleaseError("Publication requires the existing manual workflow")
+        publish(folder, ctx)
+    else:
+        raise ReleaseError("Unknown release operation")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ReleaseError, ValueError, KeyError, TypeError, OSError, zipfile.BadZipFile, tarfile.TarError) as error:
+        print(f"Release stopped: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/release_wasm.py
+++ b/.github/scripts/release_wasm.py
@@ -30,12 +30,11 @@ def command(args, **kwargs):
     return subprocess.run(args, capture_output=True, **kwargs)
 
 
-def gh(endpoint, *, method="GET", data=None, missing=False, raw=False, paginate=False):
-    args = ["gh", "api", endpoint, "--method", method]
+def gh(endpoint, *, method="GET", data=None, missing=False, raw=False, paginate=False,
+       accept="application/vnd.github+json"):
+    args = ["gh", "api", endpoint, "--method", method, "-H", "Accept: " + accept]
     if paginate:
         args += ["--paginate", "--slurp"]
-    if raw:
-        args += ["-H", "Accept: application/octet-stream"]
     payload = None
     if data is not None:
         args += ["--input", "-"]
@@ -280,7 +279,8 @@ def matching_asset(ctx, release_id, name, info):
         raise ReleaseError(f"Conflicting or incomplete release asset: {name}")
     checksum = asset.get("digest")
     if checksum is None:
-        checksum = "sha256:" + hashlib.sha256(gh(f"repos/{ctx['repository']}/releases/assets/{asset['id']}", raw=True)).hexdigest()
+        checksum = "sha256:" + hashlib.sha256(gh(f"repos/{ctx['repository']}/releases/assets/{asset['id']}", raw=True,
+                                                accept="application/octet-stream")).hexdigest()
     if checksum != "sha256:" + info["sha256"]:
         raise ReleaseError(f"Conflicting release asset content: {name}")
     return True

--- a/.github/scripts/release_wasm.py
+++ b/.github/scripts/release_wasm.py
@@ -58,13 +58,54 @@ def pages(endpoint, key=None):
     result = gh(endpoint + "?per_page=100", paginate=True)
     if not isinstance(result, list) or not result:
         raise ReleaseError("Invalid paginated response")
-    values = []
+    values, total = [], None
     for page in result:
+        if key:
+            if not isinstance(page, dict) or type(page.get("total_count")) is not int or page["total_count"] < 0:
+                raise ReleaseError("Invalid paginated count")
+            if total is not None and total != page["total_count"]:
+                raise ReleaseError("Paginated count changed during reading")
+            total = page["total_count"]
         rows = page.get(key) if key and isinstance(page, dict) else page
-        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        if not isinstance(rows, list) or len(rows) > 100 or not all(isinstance(row, dict) for row in rows):
             raise ReleaseError("Incomplete paginated response")
         values.extend(rows)
+    if key and (len(values) != total or any(type(row.get("id")) is not int or row["id"] <= 0 for row in values)
+                or len({row["id"] for row in values}) != total):
+        raise ReleaseError("Incomplete or duplicate paginated inventory")
     return values
+
+
+def require_unsaved_preparation(ctx):
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    if not re.fullmatch(r"[1-9][0-9]*", attempt):
+        raise ReleaseError("Current run attempt is unmeasured")
+    for previous in range(1, int(attempt)):
+        jobs = pages(f"repos/{ctx['repository']}/actions/runs/{ctx['run_id']}/attempts/{previous}/jobs", "jobs")
+        if any(type(job.get("run_id")) is not int or str(job["run_id"]) != ctx["run_id"]
+               or type(job.get("run_attempt")) is not int or job["run_attempt"] != previous
+               or job.get("head_sha") != ctx["sha"] or job.get("status") != "completed"
+               or not isinstance(job.get("conclusion"), str) or not job["conclusion"]
+               or not isinstance(job.get("name"), str) or not job["name"]
+               or not isinstance(job.get("steps"), list) for job in jobs):
+            raise ReleaseError("Previous preparation history is incomplete")
+        owners = [job for job in jobs if job["name"] == "WASM Release and Publish"]
+        if len(owners) > 1:
+            raise ReleaseError("Previous preparation job is ambiguous")
+        if not owners or owners[0]["conclusion"] == "skipped" and not owners[0]["steps"]:
+            continue
+        steps = owners[0]["steps"]
+        if any(not isinstance(step, dict) or type(step.get("number")) is not int or step["number"] <= 0
+               or not isinstance(step.get("name"), str) or not step["name"] for step in steps) \
+                or len({step["number"] for step in steps}) != len(steps):
+            raise ReleaseError("Previous preparation steps are incomplete")
+        saves = [step for step in steps if step["name"] == "Save the package before any publication writes"]
+        if len(saves) != 1 or not (
+            saves[0].get("status") == "completed" and saves[0].get("conclusion") == "skipped"
+            or saves[0].get("status") == "queued" and "conclusion" in saves[0] and saves[0]["conclusion"] is None
+            and "started_at" in saves[0] and saves[0]["started_at"] is None
+        ):
+            raise ReleaseError("The original package may have been saved; refusing replacement bytes")
 
 
 def context():
@@ -192,6 +233,7 @@ def restore(folder, ctx):
         # Without saved bytes, existing external state must never be adopted.
         if tag_sha(ctx) is not None or release(ctx) is not None or npm_integrity(ctx["package_name"], version) is not None:
             raise ReleaseError("Publication exists but the immutable package artifact is missing")
+        require_unsaved_preparation(ctx)
         return False
     if len(candidates) != 1:
         raise ReleaseError("Ambiguous package artifact")

--- a/.github/scripts/test_release_wasm.py
+++ b/.github/scripts/test_release_wasm.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Exercise native npm packaging and simulated GitHub/npm failures without writes."""
+
+import base64
+import copy
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+import release_wasm as release
+
+
+class Terminated(RuntimeError):
+    pass
+
+
+class Remote:
+    def __init__(self, folder, ctx):
+        self.ctx = ctx
+        self.folder = folder
+        self.plan = json.loads((folder / release.PLAN).read_text())
+        self.tag = None
+        self.release = None
+        self.assets = {}
+        self.integrity = None
+        self.writes = []
+        self.stop = None
+        self.lost = None
+        self.artifact = {"id": 5, "name": release.ARTIFACT, "expired": False}
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            for file in folder.rglob("*"):
+                if file.is_file():
+                    archive.writestr(file.relative_to(folder).as_posix(), file.read_bytes())
+        self.archive = buffer.getvalue()
+
+    def wrote(self, operation):
+        self.writes.append(operation)
+        if self.stop == operation:
+            self.stop = None
+            raise Terminated(operation)
+        if self.lost == operation:
+            self.lost = None
+            raise release.ReleaseError("Response lost after " + operation)
+
+    def gh(self, endpoint, *, method="GET", data=None, **kwargs):
+        if "/artifacts/5/zip" in endpoint:
+            return self.archive
+        if "/artifacts?" in endpoint:
+            return [{"artifacts": [self.artifact] if self.artifact else []}]
+        if "/git/ref/tags/" in endpoint:
+            return {"object": {"type": "commit", "sha": self.tag}} if self.tag else None
+        if endpoint.endswith("/git/refs"):
+            self.tag = data["sha"]
+            self.wrote("tag")
+            return {}
+        if endpoint.endswith("/releases?per_page=100"):
+            return [[copy.deepcopy(self.release)] if self.release else []]
+        if endpoint.endswith("/releases") and method == "POST":
+            self.release = {"id": 7, **data}
+            self.wrote("release")
+            return self.release
+        if "/assets?" in endpoint:
+            return [list(self.assets.values())]
+        if endpoint.endswith("/releases/7") and method == "PATCH":
+            self.release.update(data)
+            self.wrote("final")
+            return self.release
+        raise AssertionError((endpoint, method))
+
+    def command(self, args, **kwargs):
+        if args[:3] == ["gh", "release", "upload"]:
+            path = Path(args[4])
+            self.assets[path.name] = {"id": len(self.assets) + 10, "name": path.name, "state": "uploaded",
+                                     "size": path.stat().st_size, "digest": "sha256:" + release.digest(path).hex()}
+            try:
+                self.wrote("asset:" + path.name)
+            except release.ReleaseError:
+                return subprocess.CompletedProcess(args, 1, b"", b"lost")
+            return subprocess.CompletedProcess(args, 0, b"", b"")
+        if args[:2] == ["npm", "publish"]:
+            self.integrity = self.plan["integrity"]
+            try:
+                self.wrote("npm")
+            except release.ReleaseError:
+                return subprocess.CompletedProcess(args, 1, b"", b"lost")
+            return subprocess.CompletedProcess(args, 0, b"", b"")
+        raise AssertionError("Unexpected process (real network disabled): " + str(args))
+
+
+class ReleaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.tmp.name)
+        cls.source = cls.root / "pkg"
+        cls.source.mkdir()
+        cls.ctx = dict(repository="BitcreditProtocol/Bitcredit-Core", sha="a" * 40, run_id="123",
+                       version="1.2.3", tag="v1.2.3", package_name="@bitcredit/bcr-ebill-wasm")
+        (cls.source / "package.json").write_text(json.dumps({"name": cls.ctx["package_name"], "version": "1.2.3",
+                                                           "files": ["index.js", "index.d.ts", "index_bg.wasm"]}))
+        for name in ("index.js", "index.d.ts", "index_bg.wasm", "LICENSE"):
+            (cls.source / name).write_text("fixture\n")
+        cls.folder = cls.root / "saved"
+        with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": ""}):
+            release.prepare(cls.folder, cls.source, cls.ctx)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def run_publish(self, remote):
+        with patch.object(release, "gh", side_effect=remote.gh), \
+                patch.object(release, "command", side_effect=remote.command), \
+                patch.object(release, "npm_integrity", side_effect=lambda *args: remote.integrity), \
+                patch.object(release, "canonical_version", return_value="1.2.3"), \
+                patch.object(release, "note"):
+            release.publish(self.folder, self.ctx)
+
+    def test_success_and_complete_repeat_preserve_every_write(self):
+        remote = Remote(self.folder, self.ctx)
+        self.run_publish(remote)
+        before = list(remote.writes)
+        self.run_publish(remote)
+        self.assertEqual(remote.writes, before)
+        self.assertFalse(remote.release["draft"])
+        self.assertEqual(remote.integrity, remote.plan["integrity"])
+
+    def test_process_stop_after_each_write_recovers_original_bytes(self):
+        assets = ["asset:" + Path(name).name for name in json.loads((self.folder / release.PLAN).read_text())["files"]
+                  if name.startswith("assets/")]
+        for operation in ["tag", "release", *assets, "npm", "final"]:
+            with self.subTest(operation=operation):
+                remote = Remote(self.folder, self.ctx)
+                remote.stop = operation
+                with self.assertRaises(Terminated):
+                    self.run_publish(remote)
+                self.run_publish(remote)
+                self.assertFalse(remote.release["draft"])
+                self.assertEqual(remote.writes.count(operation), 1)
+
+    def test_lost_responses_are_read_back_before_continuing(self):
+        for operation in ("tag", "release", "asset:LICENSE", "npm", "final"):
+            with self.subTest(operation=operation):
+                remote = Remote(self.folder, self.ctx)
+                remote.lost = operation
+                self.run_publish(remote)
+                self.assertFalse(remote.release["draft"])
+                self.assertEqual(remote.writes.count(operation), 1)
+
+    def test_conflicting_tag_package_or_asset_stops_without_writes(self):
+        for conflict in ("tag", "npm", "asset"):
+            with self.subTest(conflict=conflict):
+                remote = Remote(self.folder, self.ctx)
+                if conflict == "tag":
+                    remote.tag = "b" * 40
+                elif conflict == "npm":
+                    remote.integrity = "sha512-wrong"
+                else:
+                    remote.tag = self.ctx["sha"]
+                    remote.release = {"id": 7, "tag_name": self.ctx["tag"], "draft": True}
+                    remote.assets["LICENSE"] = {"id": 10, "name": "LICENSE", "state": "uploaded", "size": 8,
+                                               "digest": "sha256:" + "b" * 64}
+                with self.assertRaises(release.ReleaseError):
+                    self.run_publish(remote)
+                self.assertEqual(remote.writes, [])
+
+    def test_missing_expired_or_corrupted_artifact_stops(self):
+        for failure in ("missing", "expired", "corrupt"):
+            with self.subTest(failure=failure):
+                remote = Remote(self.folder, self.ctx)
+                remote.tag = self.ctx["sha"]
+                if failure == "missing":
+                    remote.artifact = None
+                elif failure == "expired":
+                    remote.artifact["expired"] = True
+                else:
+                    remote.archive = b"not a zip"
+                with self.assertRaises((release.ReleaseError, zipfile.BadZipFile)):
+                    self.run_publish(remote)
+                self.assertEqual(remote.writes, [])
+
+    def test_incomplete_paginated_rows_stop_before_writes(self):
+        for kind in ("release", "asset", "artifact", "empty-envelope"):
+            with self.subTest(kind=kind):
+                remote = Remote(self.folder, self.ctx)
+                if kind == "asset":
+                    remote.tag = self.ctx["sha"]
+                    remote.release = {"id": 7, "tag_name": self.ctx["tag"], "draft": True}
+                original = remote.gh
+                def damaged(endpoint, **kwargs):
+                    if kind == "release" and endpoint.endswith("/releases?per_page=100"):
+                        return [[{"id": 7, "draft": True}]]
+                    if kind == "asset" and "/assets?" in endpoint:
+                        return [[{"id": 10, "size": 8, "state": "uploaded"}]]
+                    if kind == "artifact" and "/artifacts?" in endpoint:
+                        return [{"artifacts": [{"id": 5, "expired": False}]}]
+                    if kind == "empty-envelope" and "/artifacts?" in endpoint:
+                        return []
+                    return original(endpoint, **kwargs)
+                remote.gh = damaged
+                with self.assertRaises(release.ReleaseError):
+                    self.run_publish(remote)
+                self.assertEqual(remote.writes, [])
+
+    def test_restoration_requires_original_run_and_sha(self):
+        remote = Remote(self.folder, self.ctx)
+        for key, value in (("sha", "b" * 40), ("run_id", "124")):
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as tmp, \
+                    patch.object(release, "gh", side_effect=remote.gh):
+                with self.assertRaises(release.ReleaseError):
+                    release.restore(Path(tmp), {**self.ctx, key: value})
+
+    def test_semver_uses_npm_but_rejects_loose_coercion(self):
+        for version in ("1.2.3", "1.2.3-alpha.1", "1.2.3+build.7", "1.2.3-rc.1+build.7"):
+            with self.subTest(version=version):
+                self.assertEqual(release.canonical_version(version), version.split("+", 1)[0])
+        for version in ("01.2.3", "1.2.3.4", "1.2.3-01", "v1.2.3", "1.2.3+", "1.2.3+a..b", "--prefix=/tmp"):
+            with self.subTest(version=version):
+                with self.assertRaises(release.ReleaseError):
+                    release.canonical_version(version)
+
+    def test_mismatched_package_version_stops_before_pack(self):
+        with self.assertRaises(release.ReleaseError):
+            release.prepare(self.root / "wrong", self.source, {**self.ctx, "version": "2.0.0"})
+
+    def test_http_errors_and_malformed_responses_are_not_absence(self):
+        for status in (403, 429, 500):
+            with self.subTest(status=status), patch.object(release, "command", return_value=
+                    subprocess.CompletedProcess([], 1, b"", f"gh: failure (HTTP {status})".encode())):
+                with self.assertRaises(release.ReleaseError):
+                    release.gh("test", missing=True)
+        with patch.object(release, "command", return_value=subprocess.CompletedProcess([], 1, b"", b"HTTP 404")):
+            self.assertIsNone(release.gh("test", missing=True))
+        with patch.object(release, "command", return_value=subprocess.CompletedProcess([], 0, b"broken", b"")):
+            with self.assertRaises(release.ReleaseError):
+                release.gh("test", missing=True)
+
+    def test_registry_error_and_missing_integrity_stop(self):
+        for result in (
+            subprocess.CompletedProcess([], 1, b'{"error":{"code":"E403"}}', b""),
+            subprocess.CompletedProcess([], 0, b"null", b""),
+            subprocess.CompletedProcess([], 0, b"broken", b""),
+        ):
+            with self.subTest(result=result.stdout), patch.object(release, "command", return_value=result):
+                with self.assertRaises(release.ReleaseError):
+                    release.npm_integrity("test", "1.2.3")
+        with patch.object(release, "command", return_value=subprocess.CompletedProcess([], 1, b'{"error":{"code":"E404"}}', b"")):
+            self.assertIsNone(release.npm_integrity("test", "1.2.3"))
+
+    def test_build_metadata_survives_packaging(self):
+        ctx = {**self.ctx, "version": "1.2.3+build.7", "tag": "v1.2.3+build.7"}
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            for path in self.source.iterdir():
+                (source / path.name).write_bytes(path.read_bytes())
+            package = json.loads((source / "package.json").read_text())
+            package["version"] = ctx["version"]
+            (source / "package.json").write_text(json.dumps(package))
+            folder = Path(tmp) / "saved"
+            release.prepare(folder, source, ctx)
+            plan = release.validate(folder, ctx)
+            self.assertEqual(plan["version"], "1.2.3+build.7")
+            self.assertEqual(plan["registry_version"], "1.2.3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_wasm.py
+++ b/.github/scripts/test_release_wasm.py
@@ -255,6 +255,14 @@ class ReleaseTests(unittest.TestCase):
         with patch.object(release, "command", return_value=subprocess.CompletedProcess([], 1, b'{"error":{"code":"E404"}}', b"")):
             self.assertIsNone(release.npm_integrity("test", "1.2.3"))
 
+    def test_artifact_download_uses_the_actions_api_media_type(self):
+        def transport(args, **kwargs):
+            if "Accept: application/octet-stream" in args:
+                return subprocess.CompletedProcess(args, 1, b"", b"HTTP 415")
+            return subprocess.CompletedProcess(args, 0, b"archive-bytes", b"")
+        with patch.object(release, "command", side_effect=transport):
+            self.assertEqual(release.gh("repos/example/repo/actions/artifacts/5/zip", raw=True), b"archive-bytes")
+
     def test_build_metadata_survives_packaging(self):
         ctx = {**self.ctx, "version": "1.2.3+build.7", "tag": "v1.2.3+build.7"}
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test_release_wasm.py
+++ b/.github/scripts/test_release_wasm.py
@@ -54,7 +54,7 @@ class Remote:
         if "/artifacts/5/zip" in endpoint:
             return self.archive
         if "/artifacts?" in endpoint:
-            return [{"artifacts": [self.artifact] if self.artifact else []}]
+            return [{"total_count": 1 if self.artifact else 0, "artifacts": [self.artifact] if self.artifact else []}]
         if "/git/ref/tags/" in endpoint:
             return {"object": {"type": "commit", "sha": self.tag}} if self.tag else None
         if endpoint.endswith("/git/refs"):
@@ -201,7 +201,7 @@ class ReleaseTests(unittest.TestCase):
                     if kind == "asset" and "/assets?" in endpoint:
                         return [[{"id": 10, "size": 8, "state": "uploaded"}]]
                     if kind == "artifact" and "/artifacts?" in endpoint:
-                        return [{"artifacts": [{"id": 5, "expired": False}]}]
+                        return [{"total_count": 1, "artifacts": [{"id": 5, "expired": False}]}]
                     if kind == "empty-envelope" and "/artifacts?" in endpoint:
                         return []
                     return original(endpoint, **kwargs)
@@ -217,6 +217,63 @@ class ReleaseTests(unittest.TestCase):
                     patch.object(release, "gh", side_effect=remote.gh):
                 with self.assertRaises(release.ReleaseError):
                     release.restore(Path(tmp), {**self.ctx, key: value})
+
+    def restore_absent(self, artifact_pages, history=None, attempt="1"):
+        def read(endpoint, **kwargs):
+            if "/artifacts?" in endpoint:
+                return artifact_pages
+            previous = int(endpoint.split("/attempts/")[1].split("/")[0])
+            value = history[previous]
+            if isinstance(value, Exception):
+                raise value
+            return value
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"GITHUB_RUN_ATTEMPT": attempt}), \
+                patch.object(release, "gh", side_effect=read), patch.object(release, "tag_sha", return_value=None), \
+                patch.object(release, "release", return_value=None), patch.object(release, "npm_integrity", return_value=None), \
+                patch.object(release, "canonical_version", return_value="1.2.3"):
+            destination = Path(tmp) / "restored"
+            result = release.restore(destination, self.ctx)
+            self.assertFalse(destination.exists())
+            return result
+
+    def preparation_history(self, *, conclusion="skipped", attempt=1):
+        return [{"total_count": 1, "jobs": [{"id": 10, "run_id": 123, "run_attempt": attempt,
+            "head_sha": self.ctx["sha"], "name": "WASM Release and Publish", "status": "completed",
+            "conclusion": "failure", "steps": [{"number": 12, "name": "Save the package before any publication writes",
+                                                  "status": "completed", "conclusion": conclusion}]}]}]
+
+    def test_artifact_counts_cannot_turn_incomplete_read_into_preparation(self):
+        row = {"id": 6, "name": "other", "expired": False}
+        for pages in ([{"total_count": 1, "artifacts": []}], [{"artifacts": []}],
+                      [{"total_count": True, "artifacts": [row]}],
+                      [{"total_count": 2, "artifacts": [row, row]}],
+                      [{"total_count": 1, "artifacts": [row]}, {"total_count": 0, "artifacts": []}]):
+            with self.subTest(pages=pages), self.assertRaises(release.ReleaseError):
+                self.restore_absent(pages)
+        self.assertFalse(self.restore_absent([{"total_count": 0, "artifacts": []}]))
+        with patch.object(release, "gh", return_value=[{"total_count": 2, "artifacts": [row]},
+                         {"total_count": 2, "artifacts": [{**row, "id": 7}]}]):
+            self.assertEqual([v["id"] for v in release.pages("fixture", "artifacts")], [6, 7])
+
+    def test_deleted_package_is_not_rebuilt_before_publication(self):
+        empty = [{"total_count": 0, "artifacts": []}]
+        for conclusion in ("success", "failure", "cancelled"):
+            with self.subTest(conclusion=conclusion), self.assertRaisesRegex(release.ReleaseError, "refusing replacement"):
+                self.restore_absent(empty, {1: self.preparation_history(conclusion=conclusion)}, "2")
+        self.assertFalse(self.restore_absent(empty, {1: self.preparation_history()}, "2"))
+        with self.assertRaisesRegex(release.ReleaseError, "refusing replacement"):
+            self.restore_absent(empty, {1: self.preparation_history(conclusion="success"),
+                                       2: self.preparation_history(attempt=2)}, "3")
+
+    def test_unmeasured_prior_preparation_cannot_authorize_rebuild(self):
+        wrong_sha = self.preparation_history()
+        wrong_sha[0]["jobs"][0]["head_sha"] = "b" * 40
+        missing_step = self.preparation_history()
+        missing_step[0]["jobs"][0]["steps"] = []
+        for history in (wrong_sha, missing_step, [{"total_count": 1, "jobs": []}],
+                        release.ReleaseError("history unavailable")):
+            with self.subTest(history=history), self.assertRaises(release.ReleaseError):
+                self.restore_absent([{"total_count": 0, "artifacts": []}], {1: history}, "2")
 
     def test_semver_uses_npm_but_rejects_loose_coercion(self):
         for version in ("1.2.3", "1.2.3-alpha.1", "1.2.3+build.7", "1.2.3-rc.1+build.7"):

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
           private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          permission-contents: read
           owner: BitcreditProtocol
       
       - name: Git auth with app token

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,9 +95,16 @@ jobs:
           cargo install wasm-pack --version 0.14.0
 
       - name: Build WASM version
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
         run: |
           cd crates/bcr-ebill-wasm
-          wasm-pack build --target web
+          wasm-pack build --target web --scope bitcredit --out-name index
+
+      - name: Verify release package without publishing
+        run: |
+          cp LICENSE crates/bcr-ebill-wasm/pkg/
+          python3 .github/scripts/release_wasm.py prepare "$RUNNER_TEMP/wasm-package-check" crates/bcr-ebill-wasm/pkg
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/.github/workflows/test-wasm-release.yml
+++ b/.github/workflows/test-wasm-release.yml
@@ -1,0 +1,30 @@
+name: WASM release regression checks
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/release_wasm.py'
+      - '.github/scripts/test_release_wasm.py'
+      - '.github/workflows/wasm_release.yml'
+      - '.github/workflows/test-wasm-release.yml'
+  push:
+    branches: [master]
+    paths:
+      - '.github/scripts/release_wasm.py'
+      - '.github/scripts/test_release_wasm.py'
+      - '.github/workflows/wasm_release.yml'
+      - '.github/workflows/test-wasm-release.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.12.0
+      - run: python3 .github/scripts/test_release_wasm.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
           private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          permission-contents: read
           owner: BitcreditProtocol
       
       - name: Git auth with app token

--- a/.github/workflows/wasm_release.yml
+++ b/.github/workflows/wasm_release.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: release-wasm
+  cancel-in-progress: false
+
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
@@ -21,10 +25,11 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      actions: read
 
     environment: release-wasm
 
-    # Restrict execution to specific users
+    # Preserve the existing initiator restriction.
     if: contains(fromJson('["mtbitcr", "zupzup", "tompro", "cleot"]'), github.actor)
 
     steps:
@@ -33,92 +38,67 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create Github App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
-          private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
-          owner: BitcreditProtocol
-      
-      - name: Git auth with app token
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-
-      - name: Extract version from Cargo.toml
-        id: get_version
-        run: |
-          VERSION=$(grep -m 1 '^version =' Cargo.toml | cut -d '"' -f2)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Detected version: v$VERSION"
-
-      - name: Ensure tag does not already exist
-        run: |
-          if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
-            echo "Error: Tag v${{ env.VERSION }} already exists!"
-            exit 1
-          fi
-
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.12.0
           registry-url: "https://registry.npmjs.org"
 
+      - name: Restore the original package if it was prepared
+        id: package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/release_wasm.py restore "$RUNNER_TEMP/release-package"
+
+      - name: Create Github App token
+        if: steps.package.outputs.restored != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          owner: BitcreditProtocol
+
+      - name: Git auth with app token
+        if: steps.package.outputs.restored != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
       - name: Install Rust toolchain
+        if: steps.package.outputs.restored != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
 
       - name: Install wasm-pack
-        run: |
-          cargo install wasm-pack --version 0.14.0
+        if: steps.package.outputs.restored != 'true'
+        run: cargo install wasm-pack --version 0.14.0
 
-      - name: Build with wasm-pack
+      - name: Build and prepare immutable WASM package
+        if: steps.package.outputs.restored != 'true'
         env:
           RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+          RELEASE_CHANGELOG: ${{ inputs.changelog }}
         run: |
           cd crates/bcr-ebill-wasm
           wasm-pack build --target web --scope bitcredit --out-name index
-
-      - name: Copy LICENSE into pkg/
-        run: |
+          cd ../..
           cp LICENSE crates/bcr-ebill-wasm/pkg/
+          python3 .github/scripts/release_wasm.py prepare "$RUNNER_TEMP/release-package" crates/bcr-ebill-wasm/pkg
 
-      - name: Create and push git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ env.VERSION }}"
-          git push origin "v${{ env.VERSION }}"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+      - name: Save the package before any publication writes
+        if: steps.package.outputs.restored != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          tag_name: v${{ env.VERSION }}
-          name: v${{ env.VERSION }}
-          body: |
-            ${{ inputs.changelog }}
+          name: release-package
+          path: ${{ runner.temp }}/release-package/
+          retention-days: 90
+          overwrite: false
+          if-no-files-found: error
 
-            **Version:** v${{ env.VERSION }}
-          draft: false
-          prerelease: false
-
-      - name: Upload WASM artifacts to Release
+      - name: Reconcile tag, assets, npm package and final release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          cd crates/bcr-ebill-wasm/pkg
-          for file in *; do
-            if [[ "$file" != ".gitignore" ]]; then
-              gh release upload "v${{ env.VERSION }}" "$file"
-            fi
-          done
-
-      - name: Publish to npm
-        run: |
-          cd crates/bcr-ebill-wasm/pkg
-          npm publish --access public --provenance --tag latest
-
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/release_wasm.py publish "$RUNNER_TEMP/release-package"

--- a/.github/workflows/wasm_release.yml
+++ b/.github/workflows/wasm_release.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
           private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          permission-contents: read
           owner: BitcreditProtocol
 
       - name: Git auth with app token

--- a/README.md
+++ b/README.md
@@ -48,3 +48,29 @@ naming convention. No tag policies are configured.
 Validate WASM builds with the normal `Rust CI` workflow. Do not run the publication
 workflow merely to test environment settings: it creates a release and publishes
 the npm package.
+
+## WASM publication recovery
+
+The workflow prepares the npm tarball and GitHub release assets before creating
+any tag, release or npm version. It saves their SHA-256 checksums, npm integrity,
+source commit, version and original run ID in the immutable `release-package`
+Actions artifact for 90 days. Source and generated package versions must match.
+SemVer build metadata remains in the source tag and package; npm registry version
+identity excludes build metadata.
+
+Use GitHub's **Re-run failed jobs** or **Re-run all jobs** on the original run.
+The workflow restores the saved bytes, verifies existing tags and assets, and
+adds only missing publication results. A lost write response is checked against
+remote state before continuing. Conflicting content or an unavailable artifact
+after publication starts stops recovery; do not move tags or overwrite assets.
+The GitHub release stays draft until its assets and npm integrity are confirmed.
+Stable versions use npm `latest`; prereleases use `next`.
+
+GitHub allows native reruns for 30 days after the original run. Keeping the
+artifact for 90 days does not extend that window. Beyond it, retain the evidence
+and arrange a separate operator recovery; a fresh dispatch cannot adopt an
+existing version without its original saved artifact.
+
+`WASM release regression checks` simulates partial writes, lost responses,
+conflicts and unreadable metadata without publication credentials. Normal
+`Rust CI` also builds and packs the real WASM output without publishing it.

--- a/README.md
+++ b/README.md
@@ -58,11 +58,17 @@ Actions artifact for 90 days. Source and generated package versions must match.
 SemVer build metadata remains in the source tag and package; npm registry version
 identity excludes build metadata.
 
-Use GitHub's **Re-run failed jobs** or **Re-run all jobs** on the original run.
-The workflow restores the saved bytes, verifies existing tags and assets, and
-adds only missing publication results. A lost write response is checked against
-remote state before continuing. Conflicting content or an unavailable artifact
-after publication starts stops recovery; do not move tags or overwrite assets.
+To recover a partial publication, use **Re-run failed jobs** or rerun the
+**WASM Release and Publish** job (`release`) on the original run. This native
+partial rerun retains the original package artifact. Do not use **Re-run all
+jobs**, which removes previous artifacts despite their retention period.
+The existing `release-wasm` environment protection still applies.
+
+The job restores the original package, verifies its saved bytes
+and existing tags and assets, and adds only missing publication results. A lost
+write response is checked against remote state before continuing. Conflicting
+content or an unavailable artifact after publication starts stops recovery; do
+not move tags or overwrite assets.
 The GitHub release stays draft until its assets and npm integrity are confirmed.
 Stable versions use npm `latest`; prereleases use `next`.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ partial rerun retains the original package artifact. Do not use **Re-run all
 jobs**, which removes previous artifacts despite their retention period.
 The existing `release-wasm` environment protection still applies.
 
+If the artifact is absent on a retry, complete native job history must prove
+that package saving never started before a fresh preparation is allowed. A
+missing previously saved package or an incomplete inventory/history stops
+recovery, even when no publication is visible yet.
+
 The job restores the original package, verifies its saved bytes
 and existing tags and assets, and adds only missing publication results. A lost
 write response is checked against remote state before continuing. Conflicting


### PR DESCRIPTION
Preserve the exact WASM npm archive and GitHub assets before the first publication write. Recovery uses the original run's failed/selected publication job, retains matching remote bytes and stops on conflicts, unreadable state or missing original preparation evidence. The GitHub release remains draft until assets and npm integrity are confirmed.

Artifact inventories validate pagination, counts and unique IDs. A missing artifact on retry permits preparation only if complete native history proves no earlier save started. Full-workflow reruns are excluded because they remove earlier artifacts; the native rerun window remains distinct from 90-day retention. Environment/initiator gates, compiler choices and dependency pins are preserved.

All three Git dependency tokens explicitly request Contents read before the later CI App permission change. The branch is synchronized with current master without rewriting history; only approved CI/docs differ from that base.

Validation at `b2f4ef5a85a34ecf816eec81b03ed4bd87bd0c64`: 16 release regressions, actionlint, diff checks and independent review pass. [Native Rust/WASM build and package preparation](https://github.com/BitcreditProtocol/Bitcredit-Core/actions/runs/34833020967/job/103940494079), tests, release regressions and analysis/coverage checks pass. Package preparation is real; partial-publication reconciliation is tested with simulated failures. Regression jobs receive no App secrets or publication rights.

No publication workflow, registry write or App-setting change was performed. Owner merge and the first separately authorized registry authentication/partial-write recovery remain required. Tracked in infrastructure#212/#246.
