### PR TITLE
docs: add AGENTS.md and shorten the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,82 +1,20 @@
-## 📝 Description
+## What
 
-Please provide a brief summary of the changes in this pull request. What issue(s) does this PR address? What problem(s) does it solve?
+<!-- What changes, in a sentence or two. -->
 
-Relates to #(issue-number)
+## Why
 
----
+<!-- The problem this solves. Link the issue if there is one: Closes #123 -->
 
-## ✅ Checklist
+## How it was verified
 
-Please ensure the following tasks are completed before requesting a review:
-
-- [ ] My code adheres to the coding guidelines of this project.
-- [ ] I have run `cargo fmt`.
-- [ ] I have run `cargo clippy`.
-- [ ] I have added or updated tests (if applicable).
-- [ ] All CI/CD steps were successful.
-- [ ] I have updated the documentation (if applicable).
-- [ ] I have checked that there are no console errors or warnings.
-- [ ] I have verified that the application builds without errors.
-- [ ] I've described the changes made to the API. (modification, addition, deletion).
+<!-- What you ran, and what it showed. "CI is green" counts; so does a manual
+     check, if you say what you checked. -->
 
 ---
 
-## 🚀 Changes Made
-
-- **New Features:**
-  - [Describe any new features added.]
-
-- **Bug Fixes:**
-  - [List the bugs fixed.]
-
-- **Refactoring:**
-  - [Highlight refactored code, if any.]
-
-- **Other Changes:**
-  - [Describe additional changes not covered above.]
-
----
-
-## 💡 How to Test
-
-Please provide clear instructions on how reviewers can test your changes:
-
-1. [Step 1]
-2. [Step 2]
-3. [Step 3]
-
----
-
-## 🤝 Related Issues
-
-List any related issues, pull requests, or discussions:
-
-- #123
-- #456
-
----
-
-## 🔗 Additional Context (optional)
-
-Add any other context or information that might be useful for reviewers:
-
-[Additional notes or links]
-
----
-
-## 📄 Relevant Documentation (optional)
-
-Provide links to relevant documentation that reviewers may need:
-
-- [Link to related documentation]
-
----
-
-## 📋 Review Guidelines
-
-Please focus on the following while reviewing:
-
-- [ ] Does the code follow the repository's contribution guidelines?
-- [ ] Are there any potential bugs or performance issues?
-- [ ] Are there any typos or grammatical errors in the code or comments?
+- [ ] `just check` passes locally (fmt, clippy and deny are advisory in CI, so this is the real gate)
+- [ ] Tests added or updated, or not applicable and said so above
+- [ ] Public API or wire-format changes are described above and noted in CHANGELOG.md
+- [ ] Reviewed my own diff before requesting review
+- [ ] No secrets, tokens or credentials in the diff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# AGENTS.md
+
+Agent-specific context for Bitcredit-Core. What the project is lives in [README.md](README.md);
+general contributor guidance is inherited from the BitcreditProtocol organisation (this repo's
+`CONTRIBUTING.md` was removed in #983). Everything here is a default: the developer's
+instructions win, and if a rule fights the task, say so and get sign-off before breaking it.
+
+## Project Map
+
+Dependencies run `bcr-ebill-core` → `bcr-ebill-persistence` → `bcr-ebill-api` →
+`bcr-ebill-transport` → `bcr-ebill-wasm`; only the last ships, as the npm package
+`@bitcredit/bcr-ebill-wasm`. There is no server: keys and all state live in the browser
+(SurrealDB over IndexedDB), and Nostr relays, Esplora and mints are external services the
+client talks to. The native target exists so `cargo check/test/clippy` run on a host — no
+crate defines a binary.
+
+## Quality Gates
+
+Full gate before every PR; the workspace suite is one command:
+
+    just check   # wasm dev build, fmt --check, cargo check, cargo test --all,
+                 # clippy --all-targets --all-features -D warnings, cargo deny check
+    just wasm    # wasm-pack dev build alone — the fast wasm32 compile check
+
+Needs `wasm-pack` and `cargo-deny` on PATH ([docs/wasm.md](docs/wasm.md) covers wasm-pack).
+CI does not use `just`: `Rust CI` marks fmt, clippy and deny `continue-on-error` and
+`Test coverage` runs `cargo test --workspace`, so a green CI does not prove clippy or fmt
+passed — `just check` is where they are enforced, and the PR checklist asks for both.
+
+- Tests run natively only; `#[cfg(target_arch = "wasm32")]` branches are compile-checked by
+  the wasm build and never executed (there is no `wasm-bindgen-test`).
+- Keep tests hermetic: in-memory SurrealDB (`kv-mem`), `mockall`, `mockito` and the
+  in-process `nostr-relay-builder` relay are the fixtures; CI has no live relay, Esplora or mint.
+- NEVER trigger the `WASM Release` workflow to test anything: it tags, creates a GitHub
+  release and publishes to npm, none of which is undoable. Validate wasm builds with
+  `Rust CI` instead (README, "WASM publication approval").
+
+## Key Patterns
+
+- **Compile for wasm32 and native.** wasm32 is single-threaded: services use
+  `ServiceTraitBounds` (`bcr-ebill-core/src/application/mod.rs`; `Send + Sync` natively, empty
+  on wasm32) instead of bare bounds, `tokio_with_wasm::alias as tokio` for timers and spawning,
+  and Cargo `[target.'cfg(...)']` tables for platform deps. A bare `tokio::time` call compiles
+  natively and fails only at `just wasm`. Build wasm from the crate — its `.cargo/config.toml`
+  sets the wasm32 target and the `getrandom_backend="wasm_js"` cfg; `pkg/` is wasm-pack
+  output, untracked and never hand-edited.
+- **`protocol/` types are the wire format.** Blocks are borsh-serialised, hashed and
+  Schnorr-signed, so a field change alters hashes other clients already verify. Chains are
+  append-only (`Blockchain::try_add_block`, no removal) and every inbound block is re-validated
+  locally: relays are transport, not consensus (CHANGELOG 0.5.1-1 still calls chain reordering
+  a pre-mainnet placeholder). Prefer changes old clients can still read, as 0.5.13 did.
+- **Bill, mint and payment states are separate machines.** `BillState` in `application/bill`,
+  `MintRequestStatus` in `protocol/mint` and Esplora payment checks
+  (`bcr-ebill-api/src/external/bitcoin.rs`) are computed independently. A valid signature
+  proves who signed, not that a bill is paid or a mint solvent; `Accepted`/`MintingEnabled`
+  mean the mint agreed, and `MintOffer.proofs` is separately optional.
+- **The JS boundary is a public API.** Types in `crates/bcr-ebill-wasm/src/data/` derive
+  `Tsify` and become the npm package's TypeScript surface used by the web frontend; shape
+  changes there are breaking API changes.
+- **Dependencies float.** `Cargo.lock` is gitignored, so CI resolves fresh within `Cargo.toml`
+  ranges — don't commit one. `bcr-common` is pinned by git `rev` in the root `Cargo.toml` and
+  bumped there (deny.toml allows git sources only from the BitcreditProtocol org).
+
+## Common Gotchas
+
+1. **Keep `[profile.dev] opt-level = 1`** (root `Cargo.toml`); its comment records that
+   opt-level 0 hits a SurrealDB index-out-of-bounds bug.
+2. **Amounts cross to JS as strings.** `Sum` serialises as a string to avoid JavaScript
+   precision loss (CHANGELOG 0.5.1-1); don't expose sats as numbers.
+3. **Wait for `MintingEnabled` before minting**; an offer that is merely `Accepted` fails
+   (hotfix 0.5.0-2).
+
+This list grows from real incidents only — add one whenever an agent or human loses time
+here; it is the cheapest productivity investment in the repo.
+
+## Glossary
+
+Names that look alike belong to separate machines (Key Patterns); never join them.
+
+- **`BillAcceptState::Accepted`** — an `Accept` block proves the drawee assented, not that anyone paid.
+- **`BillPaymentState::Paid`** — Esplora confirmed the funds; every lesser state is unpaid.
+- **`QuoteStatusReply::Accepted`** / **`MintRequestStatus::Accepted`** — the mint (remote) or
+  this client (stored) recorded offer assent; minting is not yet allowed.
+- **`MintingEnabled`** — the mint permits issuance; `MintOffer.proofs` may still be absent.
+- **signed** — a verified block authenticates its signer, nothing about business state.
+
+## Plans and work artifacts
+
+- Plans, research notes and scratch files stay outside the worktree or in the gitignored
+  `docs/plans/`; working state is not product documentation.
+- The merged PR plus its CHANGELOG bullet is the implementation record. Do not add a second
+  checklist or PR summary to the repo; it drifts from the code.
+
+## Working Agreements
+
+Organisation-wide rules (branch protection, reviews, labels, Dependabot) live in the
+[contributing guide](https://github.com/BitcreditProtocol/.github/blob/master/CONTRIBUTING.md).
+This section is the per-task delta.
+
+- Open pull requests against `master`. Branch from it too: basing work on another branch
+  conflicts in exactly the files other people are changing.
+- Never open, mark ready or merge a PR, and never push a tag, unless the developer
+  explicitly asks. Each is visible to the whole team, and a tag also starts a release.
+- Commit small and often. Each commit is self-contained, passes the gate above and is
+  reviewable on its own; the subject says why, not just what. Reviewers only catch
+  mistakes in changes they can hold in their head.
+- Titles: conventional-commit style in plain language, e.g. `fix(api): recourse blocks
+  reach the drawee again`. Mark breaking changes with the `breaking` label, not a `!` in
+  the title; release notes are built from labels (see
+  [`.github/release.yml`](.github/release.yml)), so also label `bug`, `enhancement`,
+  `documentation` or `dependencies`.
+- Body: the problem in a sentence or two, then how it was fixed, then how it was verified.
+  The [PR template](.github/PULL_REQUEST_TEMPLATE.md) asks exactly that. End with the
+  model and harness that did the work.
+- Evidence: the test that failed before and passes now, or for a wire or public API
+  change, the consumer that was rebuilt against it. Upload evidence to the PR on GitHub;
+  never commit PR-only screenshots or assets.
+- One concern per PR. If the description needs an "also", split it.
+- Babysitting a PR: poll checks and comments newer than the last push; verify each bot
+  finding against the source, fix the real ones, dismiss false positives with a written
+  reason. No status check is required to merge, so a red check may predate your change:
+  confirm that before blaming it, and say so in the PR. Stay quiet when nothing is new;
+  stop when checks are green on the latest commit.
+- Every PR adds a bullet to the top section of [CHANGELOG.md](CHANGELOG.md), tagging
+  breakage inline like existing entries (`breaking DB change`, `breaking API change`,
+  `breaking bill chain change`). The version is bumped once per cycle in the root
+  `[workspace.package]` (`init X.Y.Z` commits), never per PR; scheme in
+  [docs/versioning.md](docs/versioning.md).
+- Workflows pin actions by commit SHA with a version comment (#982); keep that form.
+  Releases follow [docs/wasm_releasing.md](docs/wasm_releasing.md) plus the README
+  approval rules (`master` and `hotfix/*` only).
+
+## See Also
+
+- [docs/index.md](docs/index.md) — documentation hub
+- [docs/concepts.md](docs/concepts.md) — bill actions and states by role; read before touching bill logic
+- [docs/wasm.md](docs/wasm.md), [docs/wasm_configuration.md](docs/wasm_configuration.md) — building, the JS playground (`just serve`), runtime `Config`
+- [docs/testing.md](docs/testing.md) — which layer gets which kind of test
+- [.github/copilot-instructions.md](.github/copilot-instructions.md) — Copilot adapter with a longer architecture tour; check it for drift when gates change here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What
Adds `AGENTS.md` (with `CLAUDE.md` symlinked to it) as the guide for coding agents: quality gates as CI actually runs them, the wasm/native and wire-format invariants, a glossary of the state names that collide, and the PR and commit rules. Shortens the PR template to the organisation's What/Why/verified form, keeping the five checks that still carry information (local gate, tests, API and CHANGELOG, self-review, no secrets).

## Why
Agents (and people) have been opening large PRs with long, hard-to-review descriptions. This states the small-commit, one-concern, plain-language rules in the place agents load on every session, and the 82-line checklist template pulled in the other direction.

## How it was verified
Static: every path, `just` recipe and link in the file resolves in this checkout; `just check` is the gate the file names and CI still runs unchanged. No code touched.

Written with Claude Fable 5.1 in Claude Code; glossary and artifact sections drafted by Codex CLI and reviewed against source.

---

- [x] Reviewed my own diff before requesting review
- [x] No secrets, tokens or credentials in the diff
