### PR TITLE
Upgrade bcr-common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ bcr-ebill-core = { path = "./crates/bcr-ebill-core" }
 bcr-ebill-api = { path = "./crates/bcr-ebill-api" }
 bcr-ebill-persistence = { path = "./crates/bcr-ebill-persistence" }
 bcr-ebill-transport = { path = "./crates/bcr-ebill-transport" }
-bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "f073baec12fc136aa7f2f1cb351a73740fb4825a" }
+bcr-common = { git = "https://github.com/BitcreditProtocol/bcr-common", rev = "d6a1388d7e6b9c425e8c727c0e6a1b64790752b7" }
 surrealdb = { version = "2.3", default-features = false }
 strum = { version = "0.28", features = ["derive"] }
 url = { version = "2.5" }

--- a/crates/bcr-ebill-transport/Cargo.toml
+++ b/crates/bcr-ebill-transport/Cargo.toml
@@ -31,7 +31,7 @@ futures.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
-nostr-relay-builder = "0.44"
+nostr-relay-builder = "0.44" # superseeded by nostr-sdk 0.45, but that has a race-condition bug, so staying on this one for now
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json"] }


### PR DESCRIPTION
Just use latest bcr-common

I tried to use nostr-sdk for the MockRelay, but that's buggy and introduces races, so staying on the deprecated `nostr-relay-builder` for the time being, since it's just for tests anway