### PR TITLE
Add dev-mode override to nostr state for bills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.15-hotfix1
+
+* Add dev-mode endpoint `dev_mode_override_bill_chain_from_nostr` that syncs a local bill, overriding it with the state on Nostr
+    * This is helpful if e.g. a bug prevented a local block from propagating, or chains diverged between clients - if all sides do this, they have the same state
+* Add dev-mode endpoint `dev_mode_reset_bill_mint_quote_state` that resets a bill's local mint quote state
+
 # 0.5.15
 
 * Use latest bcr-common with new bitcr Token format including the btc network

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.15"
+version = "0.5.15-hotfix1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/BitcreditProtocol/Bitcredit-Core"

--- a/crates/bcr-ebill-api/src/service/bill_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/mod.rs
@@ -244,6 +244,9 @@ pub trait BillServiceApi: ServiceTraitBounds {
         current_identity_node_id: &NodeId,
     ) -> Result<Vec<BillBlockPlaintextWrapper>>;
 
+    /// If dev mode is on, reset the bill's local mint quote state
+    async fn dev_mode_reset_bill_mint_quote_state(&self, bill_id: &BillId) -> Result<()>;
+
     /// Shares a bill with the configured court and the given court node id
     async fn share_bill_with_court(
         &self,

--- a/crates/bcr-ebill-api/src/service/bill_service/service.rs
+++ b/crates/bcr-ebill-api/src/service/bill_service/service.rs
@@ -1888,6 +1888,21 @@ impl BillServiceApi for BillService {
         Ok(plaintext_chain)
     }
 
+    async fn dev_mode_reset_bill_mint_quote_state(&self, bill_id: &BillId) -> Result<()> {
+        // if dev mode is off - we return an error
+        if !get_config().dev_mode_config.on {
+            error!("Called dev mode operation with dev mode disabled - please enable!");
+            return Err(Error::Validation(ValidationError::InvalidOperation));
+        }
+
+        validate_bill_id_network(bill_id)?;
+
+        self.mint_store.dev_mode_reset_for_bill(bill_id).await?;
+        self.store.invalidate_bill_in_cache(bill_id).await?;
+
+        Ok(())
+    }
+
     async fn share_bill_with_court(
         &self,
         bill_id: &BillId,

--- a/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/block_transport.rs
@@ -1,4 +1,5 @@
 use super::Result;
+use crate::service::transport_service::ResyncMode;
 use async_trait::async_trait;
 use bcr_common::core::{BillId, NodeId};
 use bcr_ebill_core::{
@@ -26,7 +27,12 @@ pub trait BlockTransportServiceApi: ServiceTraitBounds {
     async fn send_bill_chain_events(&self, events: BillChainEvent) -> Result<()>;
     /// Resync bill chain. If `from_nostr` is true, fetches missing blocks from Nostr first.
     /// If false, only invalidates the local cache.
-    async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
+    async fn resync_bill_chain(
+        &self,
+        bill_id: &BillId,
+        from_nostr: bool,
+        mode: ResyncMode,
+    ) -> Result<()>;
     /// Resync company chain
     async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
     /// Resync identity chain

--- a/crates/bcr-ebill-api/src/service/transport_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/transport_service/mod.rs
@@ -160,6 +160,15 @@ impl NostrContactData {
     }
 }
 
+/// The resync mode
+/// Normal prefers the longest chain and the local chain
+/// NostrAuthoritative strictly prefers the remote chain, overriding the local chain
+#[derive(Clone, Debug)]
+pub enum ResyncMode {
+    Normal,
+    NostrAuthoritative,
+}
+
 /// Our custom data on nostr Metadata messages
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BcrMetadata {

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -133,6 +133,7 @@ pub mod tests {
                 discounted_sum: Sum,
             ) -> Result<()>;
             async fn get_offer(&self, mint_request_id: &Uuid) -> Result<Option<MintOffer>>;
+            async fn dev_mode_reset_for_bill(&self, bill_id: &BillId) -> Result<()>;
         }
     }
 

--- a/crates/bcr-ebill-persistence/src/db/mint.rs
+++ b/crates/bcr-ebill-persistence/src/db/mint.rs
@@ -74,6 +74,31 @@ impl MintStoreApi for SurrealMintStore {
         }
     }
 
+    async fn dev_mode_reset_for_bill(&self, bill_id: &BillId) -> Result<()> {
+        let mut bindings = Bindings::default();
+        bindings.add("requests_table", Self::REQUESTS_TABLE)?;
+        bindings.add("offers_table", Self::OFFERS_TABLE)?;
+        bindings.add(DB_BILL_ID, bill_id.to_owned())?;
+
+        // Offers only know the mint_request_id, so remove offers belonging
+        // to requests for this bill first.
+        self.db
+            .query_check(
+                "DELETE FROM type::table($offers_table) WHERE mint_request_id IN (SELECT VALUE mint_request_id FROM type::table($requests_table) WHERE bill_id = $bill_id)",
+                bindings.clone(),
+            )
+            .await?;
+
+        self.db
+            .query_check(
+                "DELETE FROM type::table($requests_table) WHERE bill_id = $bill_id",
+                bindings,
+            )
+            .await?;
+
+        Ok(())
+    }
+
     async fn get_all_active_requests(&self) -> Result<Vec<MintRequest>> {
         let mut bindings = Bindings::default();
         bindings.add(DB_TABLE, Self::REQUESTS_TABLE)?;
@@ -686,5 +711,36 @@ mod tests {
             .unwrap();
         let offer = offer_store.get_offer(&id).await.unwrap();
         assert!(offer.as_ref().unwrap().proofs_spent);
+    }
+
+    #[tokio::test]
+    async fn test_dev_mode_reset_for_bill_deletes_requests_and_offers() {
+        let store = get_requests_store().await;
+        let id = get_uuid_v4();
+        let bill_id = bill_id_test();
+
+        store
+            .add_request(
+                &node_id_test(),
+                &bill_id,
+                &node_id_test_other(),
+                &id,
+                test_ts(),
+            )
+            .await
+            .unwrap();
+
+        store
+            .add_offer(&id, "keyset_id", test_ts(), Sum::new_sat(1500).unwrap())
+            .await
+            .unwrap();
+
+        assert!(store.get_request(&id).await.unwrap().is_some());
+        assert!(store.get_offer(&id).await.unwrap().is_some());
+
+        store.dev_mode_reset_for_bill(&bill_id).await.unwrap();
+
+        assert!(store.get_request(&id).await.unwrap().is_none());
+        assert!(store.get_offer(&id).await.unwrap().is_none());
     }
 }

--- a/crates/bcr-ebill-persistence/src/mint.rs
+++ b/crates/bcr-ebill-persistence/src/mint.rs
@@ -68,4 +68,6 @@ pub trait MintStoreApi: ServiceTraitBounds {
     ) -> Result<()>;
     /// Gets an offer by the mint request id
     async fn get_offer(&self, mint_request_id: &Uuid) -> Result<Option<MintOffer>>;
+    /// Resets the mint quote state for the given bill - DEV MODE ONLY
+    async fn dev_mode_reset_for_bill(&self, bill_id: &BillId) -> Result<()>;
 }

--- a/crates/bcr-ebill-transport/src/block_transport.rs
+++ b/crates/bcr-ebill-transport/src/block_transport.rs
@@ -7,8 +7,9 @@ use crate::handler::{
 use crate::nostr_transport::NostrTransportService;
 use async_trait::async_trait;
 use bcr_common::core::{BillId, NodeId};
-use bcr_ebill_api::service::transport_service::BlockTransportServiceApi;
-use bcr_ebill_core::application::ServiceTraitBounds;
+use bcr_ebill_api::get_config;
+use bcr_ebill_api::service::transport_service::{BlockTransportServiceApi, ResyncMode};
+use bcr_ebill_core::application::{ServiceTraitBounds, ValidationError};
 use bcr_ebill_core::protocol::Sha256Hash;
 use bcr_ebill_core::protocol::blockchain::BlockchainType;
 use bcr_ebill_core::protocol::blockchain::bill::BillBlock;
@@ -290,9 +291,20 @@ impl BlockTransportServiceApi for BlockTransportService {
 
     /// Resync bill chain. If `from_nostr` is true, fetches missing blocks from Nostr first.
     /// If false, only invalidates the local cache.
-    async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()> {
+    async fn resync_bill_chain(
+        &self,
+        bill_id: &BillId,
+        from_nostr: bool,
+        mode: ResyncMode,
+    ) -> Result<()> {
+        // if dev mode is off - we return an error
+        if matches!(mode, ResyncMode::NostrAuthoritative) && !get_config().dev_mode_config.on {
+            error!("Called dev mode operation with dev mode disabled - please enable!");
+            return Err(Error::Validation(ValidationError::InvalidOperation));
+        }
+
         self.bill_chain_event_processor
-            .resync_chain(bill_id, from_nostr)
+            .resync_chain(bill_id, from_nostr, mode)
             .await?;
         Ok(())
     }

--- a/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
+++ b/crates/bcr-ebill-transport/src/handler/bill_chain_event_processor.rs
@@ -1,11 +1,13 @@
 use crate::handler::public_chain_helpers::{
-    BlockData, EventContainer, is_fork_block, resolve_event_chains, resolve_fork,
+    BlockData, EventContainer, find_first_difference, is_fork_block, resolve_event_chains,
+    resolve_fork,
 };
 use crate::{Error, Result};
 use async_trait::async_trait;
 use bcr_common::core::BillId;
 use bcr_ebill_api::external::mint::MintClientApi;
 use bcr_ebill_api::get_config;
+use bcr_ebill_api::service::transport_service::ResyncMode;
 use bcr_ebill_api::service::transport_service::transport_client::TransportClientApi;
 use bcr_ebill_core::application::ServiceTraitBounds;
 use bcr_ebill_core::protocol::Validate;
@@ -103,7 +105,12 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
         .await
     }
 
-    async fn resync_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()> {
+    async fn resync_chain(
+        &self,
+        bill_id: &BillId,
+        from_nostr: bool,
+        mode: ResyncMode,
+    ) -> Result<()> {
         if !from_nostr {
             debug!("invalidating cache for {bill_id} without Nostr refetch");
             return self.invalidate_cache_for_bill(bill_id).await;
@@ -114,7 +121,7 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
             self.bill_store.get_keys(bill_id).await,
         ) {
             (Ok(mut existing_chain), Ok(bill_keys)) => {
-                debug!("starting bill chain resync for {bill_id}");
+                debug!("starting bill chain resync for {bill_id} with mode {mode:?}");
                 let bcr_keys = BcrKeys::from_private_key(&bill_keys.get_private_key());
                 // Pre-fetch validation data needed for all chain candidates
                 let is_paid = self.bill_store.is_paid(bill_id).await.map_err(|e| {
@@ -149,14 +156,34 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                             continue;
                         }
 
-                        let (is_preferred, fork_point) =
-                            resolve_fork(existing_chain.blocks(), &blocks);
+                        let fork_point = match mode {
+                            ResyncMode::Normal => {
+                                let (is_preferred, fork_point) =
+                                    resolve_fork(existing_chain.blocks(), &blocks);
 
-                        if !is_preferred {
-                            continue;
+                                if !is_preferred {
+                                    continue;
+                                }
+
+                                fork_point
+                            }
+                            // In this mode, we want to find the point where the local chain diverges from the Nostr chain
+                            ResyncMode::NostrAuthoritative => {
+                                find_first_difference(existing_chain.blocks(), &blocks)
+                            }
+                        };
+
+                        if matches!(mode, ResyncMode::NostrAuthoritative)
+                            && fork_point == Some(BlockId::first())
+                        {
+                            return Err(Error::Blockchain(
+                                    "Nostr-authoritative resync cannot replace a differing genesis block".to_string(),
+                            ));
                         }
 
+                        // chain to validate before we persist
                         let mut test_chain = existing_chain.clone();
+
                         if let Some(fork_id) = &fork_point {
                             test_chain.truncate_from(*fork_id);
                         }
@@ -175,7 +202,7 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                             Ok(()) => {
                                 if let Some(fork_id) = fork_point {
                                     info!(
-                                        "Fork resolution for bill {bill_id}: replacing blocks from height {fork_id} with preferred remote chain"
+                                        "Fork resolution with mode {mode:?} and bill {bill_id}: replacing blocks from height {fork_id} with preferred remote chain"
                                     );
                                     if let Err(e) = self
                                         .bill_blockchain_store
@@ -227,6 +254,9 @@ impl BillChainEventProcessorApi for BillChainEventProcessor {
                                         );
                                     }
                                 }
+
+                                // invalidate cache in any case for re-sync
+                                self.invalidate_cache_for_bill(bill_id).await?;
 
                                 debug!("resynced bill {bill_id} with {} remote events", data.len());
                                 return Ok(());
@@ -344,7 +374,7 @@ impl BillChainEventProcessor {
                             "Split chain detected for bill {bill_id} at height {} - resyncing",
                             block.id
                         );
-                        self.resync_chain(bill_id, true).await?;
+                        self.resync_chain(bill_id, true, ResyncMode::Normal).await?;
                         return Ok(());
                     }
                 }
@@ -379,7 +409,7 @@ impl BillChainEventProcessor {
                             "Received invalid block {} for bill {bill_id} - missing blocks - try to resync",
                             block.id
                         );
-                        self.resync_chain(bill_id, true).await?;
+                        self.resync_chain(bill_id, true, ResyncMode::Normal).await?;
                         break;
                     } else {
                         error!("Error adding block for bill {bill_id}: {e}");
@@ -2021,7 +2051,7 @@ mod tests {
 
         // This should process the valid chain and exit
         handler
-            .resync_chain(&bill_id, true)
+            .resync_chain(&bill_id, true, ResyncMode::Normal)
             .await
             .expect("resync should succeed");
     }
@@ -2162,7 +2192,7 @@ mod tests {
         );
 
         handler
-            .resync_chain(&bill_id, true)
+            .resync_chain(&bill_id, true, ResyncMode::Normal)
             .await
             .expect("resync should succeed with fork resolution");
     }
@@ -2277,9 +2307,455 @@ mod tests {
             bitcoin::Network::Testnet,
         );
 
-        let result = handler.resync_chain(&bill_id, true).await;
+        let result = handler
+            .resync_chain(&bill_id, true, ResyncMode::Normal)
+            .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_resync_chain_nostr_authoritative_removes_local_only_block() {
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let bcr_keys = BcrKeys::from_private_key(&private_key_test());
+        let bill_id = BillId::new(bcr_keys.pub_key(), bitcoin::Network::Testnet);
+        let bill = get_test_bitcredit_bill(&bill_id, &payer, &payee, None, None);
+
+        let genesis_chain = get_genesis_chain(Some(bill.clone()));
+
+        // Local chain has a block that was not published to Nostr
+        let ts = genesis_chain.get_latest_block().timestamp + 1000;
+        let local_only_block = BillBlock::create_block_for_request_to_accept(
+            bill_id.clone(),
+            genesis_chain.get_latest_block(),
+            &BillRequestToAcceptBlockData {
+                requester: BillParticipantBlockData::Ident(payer.clone().into()),
+                signatory: None,
+                signing_timestamp: ts,
+                signing_address: Some(empty_address()),
+                signer_identity_proof: Some(signed_identity_proof_test().into()),
+                acceptance_deadline_timestamp: ts + 2 * ACCEPT_DEADLINE_SECONDS,
+            },
+            &bcr_keys,
+            None,
+            &bcr_keys,
+            ts,
+        )
+        .unwrap();
+
+        let mut local_chain = genesis_chain.clone();
+        assert!(local_chain.try_add_block(local_only_block.clone()));
+
+        let event0 = generate_test_event(
+            &bcr_keys,
+            None,
+            None,
+            as_event_payload(&bill_id, genesis_chain.get_latest_block()),
+            &bill_id,
+        );
+        let nostr_events = vec![event0];
+
+        let (mut bill_chain_store, mut bill_store, contact, mut transport, mut chain_event_store) =
+            create_mocks();
+
+        bill_store
+            .expect_get_keys()
+            .returning(move |_| Ok(bcr_keys.clone()));
+
+        bill_store.expect_is_paid().returning(|_| Ok(false));
+
+        bill_store
+            .expect_invalidate_bill_in_cache()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let local_chain_clone = local_chain.clone();
+        bill_chain_store
+            .expect_get_chain()
+            .with(eq(bill_id.clone()))
+            .returning(move |_| Ok(local_chain_clone.clone()));
+
+        transport
+            .expect_resolve_public_chain()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .returning(move |_, _| Ok(nostr_events.clone()))
+            .once();
+
+        // local-only block is removed
+        bill_chain_store
+            .expect_remove_blocks_from_height()
+            .with(eq(bill_id.clone()), eq(local_only_block.id))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        bill_chain_store.expect_add_block().times(0);
+
+        chain_event_store
+            .expect_remove_chain_events()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let handler = BillChainEventProcessor::new(
+            Arc::new(bill_chain_store),
+            Arc::new(bill_store),
+            Arc::new(MockFileReferenceStore::new()),
+            Arc::new(contact),
+            Arc::new(chain_event_store),
+            Arc::new(transport),
+            Arc::new(MockMintClient::new()),
+            bitcoin::Network::Testnet,
+        );
+
+        handler
+            .resync_chain(&bill_id, true, ResyncMode::NostrAuthoritative)
+            .await
+            .expect("Nostr-authoritative resync should remove local-only blocks");
+    }
+
+    #[tokio::test]
+    async fn test_resync_chain_nostr_authoritative_rebuilds_chain_events_with_identical_blocks() {
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let bcr_keys = BcrKeys::from_private_key(&private_key_test());
+        let bill_id = BillId::new(bcr_keys.pub_key(), bitcoin::Network::Testnet);
+        let bill = get_test_bitcredit_bill(&bill_id, &payer, &payee, None, None);
+
+        let local_chain = get_genesis_chain(Some(bill.clone()));
+
+        let event0 = generate_test_event(
+            &bcr_keys,
+            None,
+            None,
+            as_event_payload(&bill_id, local_chain.get_latest_block()),
+            &bill_id,
+        );
+        let nostr_events = vec![event0];
+
+        let (mut bill_chain_store, mut bill_store, contact, mut transport, mut chain_event_store) =
+            create_mocks();
+
+        bill_store
+            .expect_get_keys()
+            .returning(move |_| Ok(bcr_keys.clone()));
+
+        bill_store.expect_is_paid().returning(|_| Ok(false));
+
+        bill_store
+            .expect_invalidate_bill_in_cache()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let local_chain_clone = local_chain.clone();
+        bill_chain_store
+            .expect_get_chain()
+            .with(eq(bill_id.clone()))
+            .returning(move |_| Ok(local_chain_clone.clone()));
+
+        transport
+            .expect_resolve_public_chain()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .returning(move |_, _| Ok(nostr_events.clone()))
+            .once();
+
+        bill_chain_store.expect_remove_blocks_from_height().times(0);
+
+        bill_chain_store.expect_add_block().times(0);
+
+        // Chain events ARE refreshed, even if the chain doesn't change
+        chain_event_store
+            .expect_remove_chain_events()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let handler = BillChainEventProcessor::new(
+            Arc::new(bill_chain_store),
+            Arc::new(bill_store),
+            Arc::new(MockFileReferenceStore::new()),
+            Arc::new(contact),
+            Arc::new(chain_event_store),
+            Arc::new(transport),
+            Arc::new(MockMintClient::new()),
+            bitcoin::Network::Testnet,
+        );
+
+        handler
+            .resync_chain(&bill_id, true, ResyncMode::NostrAuthoritative)
+            .await
+            .expect("Nostr-authoritative resync should rebuild chain events");
+    }
+
+    #[tokio::test]
+    async fn test_resync_chain_nostr_authoritative_adds_remote_blocks() {
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let bcr_keys = BcrKeys::from_private_key(&private_key_test());
+        let bill_id = BillId::new(bcr_keys.pub_key(), bitcoin::Network::Testnet);
+        let bill = get_test_bitcredit_bill(&bill_id, &payer, &payee, None, None);
+
+        let local_chain = get_genesis_chain(Some(bill.clone()));
+
+        let ts = local_chain.get_latest_block().timestamp + 1000;
+        let remote_block = BillBlock::create_block_for_request_to_accept(
+            bill_id.clone(),
+            local_chain.get_latest_block(),
+            &BillRequestToAcceptBlockData {
+                requester: BillParticipantBlockData::Ident(payer.clone().into()),
+                signatory: None,
+                signing_timestamp: ts,
+                signing_address: Some(empty_address()),
+                signer_identity_proof: Some(signed_identity_proof_test().into()),
+                acceptance_deadline_timestamp: ts + 2 * ACCEPT_DEADLINE_SECONDS,
+            },
+            &bcr_keys,
+            None,
+            &bcr_keys,
+            ts,
+        )
+        .unwrap();
+
+        let event0 = generate_test_event(
+            &bcr_keys,
+            None,
+            None,
+            as_event_payload(&bill_id, local_chain.get_latest_block()),
+            &bill_id,
+        );
+
+        let event1 = generate_test_event(
+            &bcr_keys,
+            Some(event0.clone()),
+            Some(event0.clone()),
+            as_event_payload(&bill_id, &remote_block),
+            &bill_id,
+        );
+
+        let nostr_events = vec![event0, event1];
+
+        let (
+            mut bill_chain_store,
+            mut bill_store,
+            mut contact,
+            mut transport,
+            mut chain_event_store,
+        ) = create_mocks();
+
+        bill_store
+            .expect_get_keys()
+            .returning(move |_| Ok(bcr_keys.clone()));
+
+        bill_store.expect_is_paid().returning(|_| Ok(false));
+
+        bill_store
+            .expect_invalidate_bill_in_cache()
+            .returning(|_| Ok(()));
+
+        let local_chain_clone = local_chain.clone();
+        bill_chain_store
+            .expect_get_chain()
+            .with(eq(bill_id.clone()))
+            .returning(move |_| Ok(local_chain_clone.clone()));
+
+        transport
+            .expect_resolve_public_chain()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .returning(move |_, _| Ok(nostr_events.clone()))
+            .once();
+
+        // nothing removed, because first blocks are identical
+        bill_chain_store.expect_remove_blocks_from_height().times(0);
+
+        // new blocks are added
+        bill_chain_store
+            .expect_add_block()
+            .with(eq(bill_id.clone()), eq(remote_block.clone()))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        contact.expect_ensure_nostr_contact().returning(|_| ());
+
+        chain_event_store
+            .expect_remove_chain_events()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // new chain events are added
+        chain_event_store
+            .expect_add_chain_event()
+            .times(2)
+            .returning(|_| Ok(()));
+
+        let handler = BillChainEventProcessor::new(
+            Arc::new(bill_chain_store),
+            Arc::new(bill_store),
+            Arc::new(MockFileReferenceStore::new()),
+            Arc::new(contact),
+            Arc::new(chain_event_store),
+            Arc::new(transport),
+            Arc::new(MockMintClient::new()),
+            bitcoin::Network::Testnet,
+        );
+
+        handler
+            .resync_chain(&bill_id, true, ResyncMode::NostrAuthoritative)
+            .await
+            .expect("Nostr-authoritative resync should append missing remote blocks");
+    }
+
+    #[tokio::test]
+    async fn test_resync_chain_nostr_authoritative_replaces_non_preferred_remote_fork() {
+        let payer = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let payee = BillIdentParticipant::new(get_baseline_identity().identity).unwrap();
+        let bcr_keys = BcrKeys::from_private_key(&private_key_test());
+        let bill_id = BillId::new(bcr_keys.pub_key(), bitcoin::Network::Testnet);
+        let bill = get_test_bitcredit_bill(&bill_id, &payer, &payee, None, None);
+
+        let genesis_chain = get_genesis_chain(Some(bill.clone()));
+        let ts = genesis_chain.get_latest_block().timestamp + 1000;
+
+        // Local block has the earlier timestamp and would therefore normally win
+        let local_block = BillBlock::create_block_for_request_to_accept(
+            bill_id.clone(),
+            genesis_chain.get_latest_block(),
+            &BillRequestToAcceptBlockData {
+                requester: BillParticipantBlockData::Ident(payer.clone().into()),
+                signatory: None,
+                signing_timestamp: ts,
+                signing_address: Some(empty_address()),
+                signer_identity_proof: Some(signed_identity_proof_test().into()),
+                acceptance_deadline_timestamp: ts + 2 * ACCEPT_DEADLINE_SECONDS,
+            },
+            &bcr_keys,
+            None,
+            &bcr_keys,
+            ts + 1000,
+        )
+        .unwrap();
+
+        let mut local_chain = genesis_chain.clone();
+        assert!(local_chain.try_add_block(local_block.clone()));
+
+        // Remote fork has a later timestamp, so Normal mode would reject it
+        let remote_block = BillBlock::create_block_for_request_to_accept(
+            bill_id.clone(),
+            genesis_chain.get_latest_block(),
+            &BillRequestToAcceptBlockData {
+                requester: BillParticipantBlockData::Ident(payer.clone().into()),
+                signatory: None,
+                signing_timestamp: ts,
+                signing_address: Some(empty_address()),
+                signer_identity_proof: Some(signed_identity_proof_test().into()),
+                acceptance_deadline_timestamp: ts + 2 * ACCEPT_DEADLINE_SECONDS,
+            },
+            &bcr_keys,
+            None,
+            &bcr_keys,
+            ts + 2000,
+        )
+        .unwrap();
+
+        let event0 = generate_test_event(
+            &bcr_keys,
+            None,
+            None,
+            as_event_payload(&bill_id, genesis_chain.get_latest_block()),
+            &bill_id,
+        );
+
+        let event_remote = generate_test_event(
+            &bcr_keys,
+            Some(event0.clone()),
+            Some(event0.clone()),
+            as_event_payload(&bill_id, &remote_block),
+            &bill_id,
+        );
+
+        let nostr_events = vec![event0, event_remote];
+
+        let (
+            mut bill_chain_store,
+            mut bill_store,
+            mut contact,
+            mut transport,
+            mut chain_event_store,
+        ) = create_mocks();
+
+        bill_store
+            .expect_get_keys()
+            .returning(move |_| Ok(bcr_keys.clone()));
+
+        bill_store.expect_is_paid().returning(|_| Ok(false));
+
+        bill_store
+            .expect_invalidate_bill_in_cache()
+            .returning(|_| Ok(()));
+
+        let local_chain_clone = local_chain.clone();
+        bill_chain_store
+            .expect_get_chain()
+            .with(eq(bill_id.clone()))
+            .returning(move |_| Ok(local_chain_clone.clone()));
+
+        transport
+            .expect_resolve_public_chain()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .returning(move |_, _| Ok(nostr_events.clone()))
+            .once();
+
+        // replace local blocks from fork height
+        bill_chain_store
+            .expect_remove_blocks_from_height()
+            .with(eq(bill_id.clone()), eq(local_block.id))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        bill_chain_store
+            .expect_add_block()
+            .with(eq(bill_id.clone()), eq(remote_block.clone()))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        contact.expect_ensure_nostr_contact().returning(|_| ());
+
+        chain_event_store
+            .expect_remove_chain_events()
+            .with(eq(bill_id.to_string()), eq(BlockchainType::Bill))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        chain_event_store
+            .expect_add_chain_event()
+            .times(2)
+            .returning(|_| Ok(()));
+
+        let handler = BillChainEventProcessor::new(
+            Arc::new(bill_chain_store),
+            Arc::new(bill_store),
+            Arc::new(MockFileReferenceStore::new()),
+            Arc::new(contact),
+            Arc::new(chain_event_store),
+            Arc::new(transport),
+            Arc::new(MockMintClient::new()),
+            bitcoin::Network::Testnet,
+        );
+
+        handler
+            .resync_chain(&bill_id, true, ResyncMode::NostrAuthoritative)
+            .await
+            .expect("Nostr-authoritative resync should replace local fork");
     }
 
     #[tokio::test]

--- a/crates/bcr-ebill-transport/src/handler/mod.rs
+++ b/crates/bcr-ebill-transport/src/handler/mod.rs
@@ -1,6 +1,7 @@
 use crate::{Result, handler::public_chain_helpers::EventContainer};
 use async_trait::async_trait;
 use bcr_common::core::{BillId, NodeId};
+use bcr_ebill_api::service::transport_service::ResyncMode;
 use bcr_ebill_core::protocol::crypto::BcrKeys;
 use bcr_ebill_core::{
     application::ServiceTraitBounds,
@@ -102,7 +103,12 @@ pub trait BillChainEventProcessorApi: ServiceTraitBounds {
     /// Tries to resync the chain for the given bill id. If `from_nostr` is true, this will try to
     /// find the bill keys and then try to find the chain data from Nostr. Will add all potentially
     /// missing blocks to the chain. If `from_nostr` is false, only invalidates the local cache.
-    async fn resync_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
+    async fn resync_chain(
+        &self,
+        bill_id: &BillId,
+        from_nostr: bool,
+        mode: ResyncMode,
+    ) -> Result<()>;
 
     /// Invalidates the cached bill data for the given bill id.
     async fn invalidate_cache_for_bill(&self, bill_id: &BillId) -> Result<()>;

--- a/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
+++ b/crates/bcr-ebill-transport/src/handler/public_chain_helpers.rs
@@ -97,6 +97,22 @@ pub fn resolve_fork<B: Block>(local: &[B], remote: &[B]) -> (bool, Option<BlockI
     (true, None)
 }
 
+/// Finds the first difference between two chains and returns the block height of the differing block
+pub fn find_first_difference(local: &[BillBlock], remote: &[BillBlock]) -> Option<BlockId> {
+    for (local_block, remote_block) in local.iter().zip(remote.iter()) {
+        if local_block.id != remote_block.id || local_block.hash != remote_block.hash {
+            return Some(local_block.id);
+        }
+    }
+
+    // Local chain has more blocks than Nostr, so difference starts at the latest shared block
+    if local.len() > remote.len() {
+        return Some(local[remote.len()].id);
+    }
+
+    None
+}
+
 /// Determines if the remote block can be considered a fork point in the chain:
 /// - same id
 /// - different hash
@@ -753,5 +769,111 @@ mod tests {
         let (is_preferred, fork_point) = resolve_fork(&local, &remote);
         assert!(is_preferred);
         assert_eq!(fork_point, None);
+    }
+
+    #[test]
+    fn test_find_first_difference_identical_chains() {
+        let local = make_test_chain_with_timestamps(&[1000, 1500, 2000]);
+        let remote = local.clone();
+
+        let result = find_first_difference(&local, &remote);
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_first_difference_remote_longer() {
+        let local = make_test_chain_with_timestamps(&[1000, 1500, 2000]);
+        let mut remote = local.clone();
+
+        let block4 = make_test_block(
+            BlockId::next_from_previous_block_id(&remote[2].id()),
+            remote[2].hash.clone(),
+            Timestamp::new(2500).unwrap(),
+        );
+        let block5 = make_test_block(
+            BlockId::next_from_previous_block_id(&block4.id()),
+            block4.hash.clone(),
+            Timestamp::new(3000).unwrap(),
+        );
+
+        remote.push(block4);
+        remote.push(block5);
+
+        let result = find_first_difference(&local, &remote);
+
+        // take blocks from remote, but nothing needs to change
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_first_difference_local_longer() {
+        let remote = make_test_chain_with_timestamps(&[1000, 1500, 2000]);
+        let mut local = remote.clone();
+
+        let block4 = make_test_block(
+            BlockId::next_from_previous_block_id(&local[2].id()),
+            local[2].hash.clone(),
+            Timestamp::new(2500).unwrap(),
+        );
+        let block5 = make_test_block(
+            BlockId::next_from_previous_block_id(&block4.id()),
+            block4.hash.clone(),
+            Timestamp::new(3000).unwrap(),
+        );
+
+        local.push(block4);
+        local.push(block5);
+
+        let result = find_first_difference(&local, &remote);
+
+        // extra local block 4 needs to be removed, so start at the difference at 3
+        assert_eq!(result, Some(local[3].id()));
+    }
+
+    #[test]
+    fn test_find_first_difference_fork() {
+        let shared = make_test_chain_with_timestamps(&[1000, 1500]);
+
+        let mut local = shared.clone();
+        let mut remote = shared;
+
+        let local_block3 = make_test_block(
+            BlockId::next_from_previous_block_id(&local[1].id()),
+            local[1].hash.clone(),
+            Timestamp::new(2000).unwrap(),
+        );
+        let local_block4 = make_test_block(
+            BlockId::next_from_previous_block_id(&local_block3.id()),
+            local_block3.hash.clone(),
+            Timestamp::new(2500).unwrap(),
+        );
+
+        let remote_block3 = make_test_block(
+            BlockId::next_from_previous_block_id(&remote[1].id()),
+            remote[1].hash.clone(),
+            Timestamp::new(2100).unwrap(),
+        );
+        let remote_block4 = make_test_block(
+            BlockId::next_from_previous_block_id(&remote_block3.id()),
+            remote_block3.hash.clone(),
+            Timestamp::new(2600).unwrap(),
+        );
+        let remote_block5 = make_test_block(
+            BlockId::next_from_previous_block_id(&remote_block4.id()),
+            remote_block4.hash.clone(),
+            Timestamp::new(3000).unwrap(),
+        );
+
+        local.push(local_block3);
+        local.push(local_block4);
+
+        remote.push(remote_block3);
+        remote.push(remote_block4);
+        remote.push(remote_block5);
+
+        let result = find_first_difference(&local, &remote);
+
+        assert_eq!(result, Some(local[2].id()));
     }
 }

--- a/crates/bcr-ebill-transport/src/test_utils.rs
+++ b/crates/bcr-ebill-transport/src/test_utils.rs
@@ -510,7 +510,7 @@ mockall::mock! {
         async fn send_identity_chain_events(&self, events: IdentityChainEvent) -> Result<()>;
         async fn send_company_chain_events(&self, events: CompanyChainEvent) -> Result<()>;
         async fn send_bill_chain_events(&self, events: BillChainEvent) -> Result<()>;
-        async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool) -> Result<()>;
+        async fn resync_bill_chain(&self, bill_id: &BillId, from_nostr: bool, mode: bcr_ebill_api::service::transport_service::ResyncMode) -> Result<()>;
         async fn resync_company_chain(&self, company_id: &NodeId) -> Result<()>;
         async fn resync_identity_chain(&self) -> Result<()>;
         async fn validate_bill_blocks_exist_on_nostr_chain(

--- a/crates/bcr-ebill-wasm/index.html
+++ b/crates/bcr-ebill-wasm/index.html
@@ -211,6 +211,7 @@
             <button type="button" id="request_to_mint">Request to Mint</button>
             <button type="button" id="get_mint_state">Get Mint State</button>
             <button type="button" id="check_mint_state">Check Mint State</button>
+            <button type="button" id="dev_mode_reset_mint_state">Reset Mint State (Dev Mode)</button>
             <br />
              Mint Request Id: <input type="text" id="mint_req_id"/>
             <button type="button" id="cancel_req_to_mint">Cancel Mint Request</button>
@@ -246,6 +247,7 @@
             <button type="button" id="bitcoin_keys">Get BTC Keys</button>
             <button type="button" id="sync_bill_chain">Sync Bill Chain</button>
             <button type="button" id="sync_bill_chain_from_nostr">Sync Bill Chain From Nostr</button>
+            <button type="button" id="override_bill_chain_from_nostr">Override Bill Chain From Nostr</button>
             <div>Execution Time: <span id="bill_execution_time"></div>
             <div>Results: <span id="bill_results"></div>
             <img id="bill_attached_file"/>

--- a/crates/bcr-ebill-wasm/main.js
+++ b/crates/bcr-ebill-wasm/main.js
@@ -74,6 +74,7 @@ document.getElementById("reject_recourse").addEventListener("click", rejectRecou
 document.getElementById("request_to_mint").addEventListener("click", requestToMint);
 document.getElementById("get_mint_state").addEventListener("click", getMintState);
 document.getElementById("check_mint_state").addEventListener("click", checkMintState);
+document.getElementById("dev_mode_reset_mint_state").addEventListener("click", devModeResetMintState);
 document.getElementById("cancel_req_to_mint").addEventListener("click", cancelRegToMint);
 document.getElementById("accept_mint_offer").addEventListener("click", acceptMintOffer);
 document.getElementById("reject_mint_offer").addEventListener("click", rejectMintOffer);
@@ -84,6 +85,7 @@ document.getElementById("clear_bill_cache").addEventListener("click", clearBillC
 document.getElementById("bitcoin_keys").addEventListener("click", getBitcoinKeys);
 document.getElementById("sync_bill_chain").addEventListener("click", syncBillChain);
 document.getElementById("sync_bill_chain_from_nostr").addEventListener("click", syncBillChainFromNostr);
+document.getElementById("override_bill_chain_from_nostr").addEventListener("click", overrideBillChainFromNostr);
 document.getElementById("dev_mode_get_bill_chain").addEventListener("click", devModeGetBillChain);
 document.getElementById("share_bill_with_court").addEventListener("click", shareBillWithCourt);
 document.getElementById("mempool_link").addEventListener("click", mempoolLink);
@@ -771,6 +773,14 @@ async function checkMintState() {
   await measured();
 }
 
+async function devModeResetMintState() {
+  let bill_id = document.getElementById("endorse_bill_id").value;
+  let measured = measure(async () => {
+    return success_or_fail(await window.billApi.dev_mode_reset_bill_mint_quote_state({ bill_id }));
+  });
+  await measured();
+}
+
 async function cancelRegToMint() {
   let mint_request_id = document.getElementById("mint_req_id").value;
   let measured = measure(async () => {
@@ -894,6 +904,15 @@ async function syncBillChainFromNostr() {
   console.log("syncBillChain from Nostr", bill_id);
   let measured = measure(async () => {
     return success_or_fail(await window.billApi.sync_bill_chain({ bill_id: bill_id, from_nostr: true }));
+  });
+  await measured();
+}
+
+async function overrideBillChainFromNostr() {
+  let bill_id = document.getElementById("bill_id").value;
+  console.log("overrideBillChain from Nostr", bill_id);
+  let measured = measure(async () => {
+    return success_or_fail(await window.billApi.dev_mode_override_bill_chain_from_nostr({ bill_id: bill_id }));
   });
   await measured();
 }

--- a/crates/bcr-ebill-wasm/src/api/bill.rs
+++ b/crates/bcr-ebill-wasm/src/api/bill.rs
@@ -7,6 +7,7 @@ use bcr_ebill_api::service::{
     Error,
     bill_service::Error as BillServiceError,
     file_upload_service::{UploadFileHandler, detect_content_type_for_bytes},
+    transport_service::ResyncMode,
 };
 use bcr_ebill_core::{
     application::{
@@ -37,15 +38,15 @@ use crate::{
         Base64FileResponse, BinaryFileResponse, UploadFile, UploadFileResponse,
         bill::{
             AcceptBitcreditBillPayload, BillCheckSweepBTCFundsPayload, BillCombinedBitcoinKeyWeb,
-            BillHistoryResponse, BillIdResponse, BillSweepBTCEstimateWeb, BillSweepBTCFundsPayload,
-            BillSweepBTCFundsResultWeb, BillsResponse, BillsSearchFilterPayload,
-            BitcreditBillPayload, BitcreditBillWeb, EndorseBitcreditBillPayload,
-            EndorsementsResponse, LightBillsResponse, OfferToSellBitcreditBillPayload,
-            PastEndorseesResponse, PastPaymentsResponse, RejectActionBillPayload,
-            RequestRecourseForAcceptancePayload, RequestRecourseForPaymentPayload,
-            RequestToAcceptBitcreditBillPayload, RequestToMintBitcreditBillPayload,
-            RequestToPayAsMintBitcreditBillPayload, RequestToPayBitcreditBillPayload,
-            ResyncBillPayload, ShareBillWithCourtPayload,
+            BillHistoryResponse, BillIdResponse, BillResetMintQuoteState, BillSweepBTCEstimateWeb,
+            BillSweepBTCFundsPayload, BillSweepBTCFundsResultWeb, BillsResponse,
+            BillsSearchFilterPayload, BitcreditBillPayload, BitcreditBillWeb,
+            EndorseBitcreditBillPayload, EndorsementsResponse, LightBillsResponse,
+            OfferToSellBitcreditBillPayload, OverrideBillFromNostrPayload, PastEndorseesResponse,
+            PastPaymentsResponse, RejectActionBillPayload, RequestRecourseForAcceptancePayload,
+            RequestRecourseForPaymentPayload, RequestToAcceptBitcreditBillPayload,
+            RequestToMintBitcreditBillPayload, RequestToPayAsMintBitcreditBillPayload,
+            RequestToPayBitcreditBillPayload, ResyncBillPayload, ShareBillWithCourtPayload,
         },
         mint::MintRequestStateResponse,
         parse_deadline_string,
@@ -1077,7 +1078,48 @@ impl Bill {
             get_ctx()
                 .transport_service
                 .block_transport()
-                .resync_bill_chain(&payload.bill_id, payload.from_nostr.unwrap_or(false))
+                .resync_bill_chain(
+                    &payload.bill_id,
+                    payload.from_nostr.unwrap_or(false),
+                    ResyncMode::Normal,
+                )
+                .await?;
+            Ok(())
+        }
+        .await;
+        TSResult::res_to_js(res)
+    }
+
+    /// Given a bill id, override the bill chain with the state from nostr
+    #[wasm_bindgen(unchecked_return_type = "TSResult<void>")]
+    pub async fn dev_mode_override_bill_chain_from_nostr(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "OverrideBillFromNostrPayload")] payload: JsValue,
+    ) -> JsValue {
+        let res: Result<()> = async {
+            let payload: OverrideBillFromNostrPayload = serde_wasm_bindgen::from_value(payload)?;
+            get_ctx()
+                .transport_service
+                .block_transport()
+                .resync_bill_chain(&payload.bill_id, true, ResyncMode::NostrAuthoritative)
+                .await?;
+            Ok(())
+        }
+        .await;
+        TSResult::res_to_js(res)
+    }
+
+    /// Given a bill id, reset the local mint quote state for this bill
+    #[wasm_bindgen(unchecked_return_type = "TSResult<void>")]
+    pub async fn dev_mode_reset_bill_mint_quote_state(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "BillResetMintQuoteState")] payload: JsValue,
+    ) -> JsValue {
+        let res: Result<()> = async {
+            let payload: BillResetMintQuoteState = serde_wasm_bindgen::from_value(payload)?;
+            get_ctx()
+                .bill_service
+                .dev_mode_reset_bill_mint_quote_state(&payload.bill_id)
                 .await?;
             Ok(())
         }

--- a/crates/bcr-ebill-wasm/src/data/bill.rs
+++ b/crates/bcr-ebill-wasm/src/data/bill.rs
@@ -255,6 +255,20 @@ pub struct ResyncBillPayload {
     pub from_nostr: Option<bool>,
 }
 
+#[derive(Tsify, Debug, Clone, Deserialize)]
+#[tsify(from_wasm_abi)]
+pub struct OverrideBillFromNostrPayload {
+    #[tsify(type = "string")]
+    pub bill_id: BillId,
+}
+
+#[derive(Tsify, Debug, Clone, Deserialize)]
+#[tsify(from_wasm_abi)]
+pub struct BillResetMintQuoteState {
+    #[tsify(type = "string")]
+    pub bill_id: BillId,
+}
+
 impl From<BillCombinedBitcoinKey> for BillCombinedBitcoinKeyWeb {
     fn from(val: BillCombinedBitcoinKey) -> Self {
         BillCombinedBitcoinKeyWeb {


### PR DESCRIPTION
* Add a dev-mode endpoint `dev_mode_override_bill_chain_from_nostr` that syncs a local bill, overriding it with the state on Nostr
    * This is helpful if e.g. a bug prevented a local block from propagating, or chains diverged between clients - if all sides do this, they have the same state
* Add dev-mode endpoint `dev_mode_reset_bill_mint_quote_state` that resets a bill's local mint quote state

Relates to #1006 